### PR TITLE
Add Option to Place Zhongli Hold E Away From Enemy

### DIFF
--- a/internal/characters/zhongli/abil.go
+++ b/internal/characters/zhongli/abil.go
@@ -60,7 +60,10 @@ func (c *char) Skill(p map[string]int) (int, int) {
 
 	//press does no dmg
 	if p["hold"] == 1 {
-		c.skillHold(f, max)
+		c.skillHold(f, max, true)
+		cd = 720
+	} else if p["hold_nosteele"] == 1 {
+		c.skillHold(f, max, false)
 		cd = 720
 	} else {
 		c.skillPress(f, max)
@@ -75,7 +78,7 @@ func (c *char) skillPress(f, max int) {
 	c.newSteele(f, 1860, max)
 }
 
-func (c *char) skillHold(f, max int) {
+func (c *char) skillHold(f, max int, createSteele bool) {
 	//hold does dmg
 	d := c.Snapshot(
 		"Stone Stele (Hold)",
@@ -92,8 +95,8 @@ func (c *char) skillHold(f, max int) {
 
 	c.QueueDmg(&d, f-1)
 
-	//create a steele if none exists
-	if c.steeleCount == 0 {
+	//create a steele if none exists and desired by player
+	if (c.steeleCount == 0) && createSteele {
 		c.newSteele(f, 1860, max) //31 seconds
 	}
 


### PR DESCRIPTION
In practical combat you usually don't have his pillar attacking enemies all that often and it can also mess up reaction based comps like Ganyu.