### PR TITLE
Bugfixes: Albedo E, Hu Tao E, Sara E/C2 ICD, XL C2, Prototype Amber

### DIFF
--- a/internal/characters/albedo/albedo.go
+++ b/internal/characters/albedo/albedo.go
@@ -165,6 +165,7 @@ func (c *char) Skill(p map[string]int) (int, int) {
 		25,
 		skill[c.TalentLvlSkill()],
 	)
+	d.Targets = core.TargetAll
 
 	c.QueueDmg(&d, f)
 
@@ -178,6 +179,7 @@ func (c *char) Skill(p map[string]int) (int, int) {
 		25,
 		skillTick[c.TalentLvlSkill()],
 	)
+	d.Targets = core.TargetAll
 	c.skillSnapshot.UseDef = true
 
 	//create a construct

--- a/internal/characters/hutao/hutao.go
+++ b/internal/characters/hutao/hutao.go
@@ -283,7 +283,7 @@ func (c *char) bbtickfunc(src int) func() {
 func (c *char) Skill(p map[string]int) (int, int) {
 	//increase based on hp at cast time
 	//drains hp
-	c.Core.Status.AddStatus("paramita", 520+20) //to account for animation
+	c.Core.Status.AddStatus("paramita", 540+20) //to account for animation
 	c.Core.Log.Debugw("Paramita acivated", "frame", c.Core.F, "event", core.LogCharacterEvent, "expiry", c.Core.F+540+20)
 	//figure out atk buff
 	c.ppBonus = ppatk[c.TalentLvlSkill()] * c.HPMax
@@ -347,6 +347,7 @@ func (c *char) Burst(p map[string]int) (int, int) {
 	//[2:29 PM] Isu: yes, what Aluminum said. PP can't expire during the burst animation, but any other buff can
 	if f > c.Core.Status.Duration("paramita") && c.Core.Status.Duration("paramita") > 0 {
 		c.Core.Status.AddStatus("paramita", f) //extend this to barely cover the burst
+		c.Core.Log.Debugw("Paramita status extension for burst", "frame", c.Core.F, "event", core.LogCharacterEvent, "new_duration", c.Core.Status.Duration("paramita"))
 	}
 
 	if c.Core.Status.Duration("paramita") > 0 && c.Base.Cons >= 2 {

--- a/internal/characters/sara/abil.go
+++ b/internal/characters/sara/abil.go
@@ -73,7 +73,7 @@ func (c *char) Aimed(p map[string]int) (int, int) {
 		d := c.Snapshot(
 			"Tengu Juurai: Ambush",
 			core.AttackTagElementalArt,
-			core.ICDTagElementalArt,
+			core.ICDTagNone,
 			core.ICDGroupDefault,
 			core.StrikeTypePierce,
 			core.Electro,
@@ -114,7 +114,7 @@ func (c *char) Skill(p map[string]int) (int, int) {
 		d := c.Snapshot(
 			"Tengu Juurai: Ambush C2",
 			core.AttackTagElementalArt,
-			core.ICDTagElementalArt,
+			core.ICDTagNone,
 			core.ICDGroupDefault,
 			core.StrikeTypePierce,
 			core.Electro,

--- a/internal/characters/xiangling/xiangling.go
+++ b/internal/characters/xiangling/xiangling.go
@@ -117,10 +117,21 @@ func (c *char) Attack(p map[string]int) (int, int) {
 
 	//if n = 5, add explosion for c2
 	if c.Base.Cons >= 2 && c.NormalCounter == 4 {
-		d1 := d.Clone()
-		d1.Element = core.Pyro
-		d1.Mult = 0.75
-		c.QueueDmg(&d1, 120)
+		// According to TCL, does not snapshot and has no ability type scaling tags
+		// TODO: Does not mention ICD or pyro aura strength?
+		c.QueueDmgDynamic(func() *core.Snapshot {
+			d1 := c.Snapshot(
+				"Oil Meets Fire (C2)",
+				core.AttackTagNone,
+				core.ICDTagNormalAttack,
+				core.ICDGroupDefault,
+				core.StrikeTypeDefault,
+				core.Pyro,
+				25,
+				0.75,
+			)
+			return &d1
+		}, 120)
 	}
 	//add a 75 frame attackcounter reset
 	c.AdvanceNormalIndex()

--- a/internal/weapons/catalyst/prototype/prototype.go
+++ b/internal/weapons/catalyst/prototype/prototype.go
@@ -21,9 +21,7 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) {
 
 		for i := 120; i <= 360; i += 120 {
 			char.AddTask(func() {
-				for _, char := range c.Chars {
-					char.AddEnergy(e)
-				}
+				char.AddEnergy(e)
 				c.Health.HealAllPercent(e / 100.0)
 			}, "recharge", i)
 		}


### PR DESCRIPTION
Fixes:
- Albedo E did not target all enemies
- Hu Tao E duration was wrong
- Sara E/C2 had incorrect ICD
- XL C2 was not handled correctly
- Prototype Amber energy recovery was applying to all characters rather than
weapon holder