### PR TITLE
Various Bugfixes: OnReactionOccured event proc, Klee E, Zhongli

### DIFF
--- a/internal/characters/klee/klee.go
+++ b/internal/characters/klee/klee.go
@@ -207,7 +207,8 @@ func (c *char) ChargeAttack(p map[string]int) (int, int) {
 	return f, a
 }
 
-//p is the number of mines that hit, up to ??
+// Has two parameters, "bounce" determines the number of bounces that hit
+// "mine" determines the number of mines that hit the enemy
 func (c *char) Skill(p map[string]int) (int, int) {
 	f, a := c.ActionFrames(core.ActionSkill, p)
 
@@ -231,6 +232,11 @@ func (c *char) Skill(p map[string]int) (int, int) {
 
 	for i := 0; i < bounce; i++ {
 		x := d.Clone()
+
+		// 3rd bounce is 2B
+		if i == 2 {
+			x.Durability = 50
+		}
 		c.AddTask(func() {
 			c.Core.Combat.ApplyDamage(&x)
 			c.addSpark()
@@ -248,7 +254,7 @@ func (c *char) Skill(p map[string]int) (int, int) {
 
 	//8 mines.. no idea how many normally hits
 	d = c.Snapshot(
-		"Jumpy Dumpty",
+		"Jumpy Dumpty Mine Hit",
 		core.AttackTagElementalArt,
 		core.ICDTagKleeFireDamage,
 		core.ICDGroupDefault,

--- a/internal/characters/zhongli/abil.go
+++ b/internal/characters/zhongli/abil.go
@@ -62,7 +62,7 @@ func (c *char) Skill(p map[string]int) (int, int) {
 	if p["hold"] == 1 {
 		c.skillHold(f, max, true)
 		cd = 720
-	} else if p["hold_nosteele"] == 1 {
+	} else if p["hold_nostele"] == 1 {
 		c.skillHold(f, max, false)
 		cd = 720
 	} else {
@@ -75,10 +75,12 @@ func (c *char) Skill(p map[string]int) (int, int) {
 }
 
 func (c *char) skillPress(f, max int) {
-	c.newSteele(f, 1860, max)
+	c.AddTask(func() {
+		c.newStele(1860, max)
+	}, "zhongli-create-stele", f)
 }
 
-func (c *char) skillHold(f, max int, createSteele bool) {
+func (c *char) skillHold(f, max int, createStele bool) {
 	//hold does dmg
 	d := c.Snapshot(
 		"Stone Stele (Hold)",
@@ -95,13 +97,17 @@ func (c *char) skillHold(f, max int, createSteele bool) {
 
 	c.QueueDmg(&d, f-1)
 
-	//create a steele if none exists and desired by player
-	if (c.steeleCount == 0) && createSteele {
-		c.newSteele(f, 1860, max) //31 seconds
+	//create a stele if none exists and desired by player
+	if (c.steleCount == 0) && createStele {
+		c.AddTask(func() {
+			c.newStele(1860, max) //31 seconds
+		}, "zhongli-create-stele", f)
 	}
 
-	//make a shield
-	c.addJadeShield()
+	//make a shield - enemy debuff arrows appear 3-5 frames after the damage number shows up in game
+	c.AddTask(func() {
+		c.addJadeShield()
+	}, "zhongli-create-shield", f+3)
 }
 
 func (c *char) Burst(p map[string]int) (int, int) {

--- a/internal/characters/zhongli/construct.go
+++ b/internal/characters/zhongli/construct.go
@@ -17,8 +17,8 @@ func (s *stoneStele) Type() core.GeoConstructType {
 }
 
 func (s *stoneStele) OnDestruct() {
-	if s.c.steeleCount > 0 {
-		s.c.steeleCount--
+	if s.c.steleCount > 0 {
+		s.c.steleCount--
 	}
 }
 

--- a/internal/characters/zhongli/stele.go
+++ b/internal/characters/zhongli/stele.go
@@ -4,20 +4,22 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core"
 )
 
-func (c *char) newSteele(f, dur, max int) {
+func (c *char) newStele(dur int, max int) {
 	//deal damage when created
-	// d := c.Snapshot(
-	// 	"Stone Stele (Initial)",
-	// 	core.AttackTagElementalArt,
-	// 	core.ICDTagElementalArt,
-	// 	core.ICDGroupDefault,
-	// 	core.StrikeTypeBlunt,
-	// 	core.Geo,
-	// 	50,
-	// 	skill[c.TalentLvlSkill()],
-	// )
-	// d.FlatDmg = 0.019 * c.HPMax
-	// d.Targets = core.TargetAll
+	d := c.Snapshot(
+		"Stone Stele (Initial)",
+		core.AttackTagElementalArt,
+		core.ICDTagElementalArt,
+		core.ICDGroupDefault,
+		core.StrikeTypeBlunt,
+		core.Geo,
+		50,
+		skill[c.TalentLvlSkill()],
+	)
+	d.FlatDmg = 0.019 * c.HPMax
+	d.Targets = core.TargetAll
+	// Damage proc is near instant upon creation
+	c.QueueDmg(&d, 0)
 
 	//create a construct
 	con := &stoneStele{
@@ -28,9 +30,9 @@ func (c *char) newSteele(f, dur, max int) {
 
 	num := c.Core.Constructs.CountByType(core.GeoConstructZhongliSkill)
 
-	c.Core.Constructs.New(con, num == c.maxSteele)
+	c.Core.Constructs.New(con, num == c.maxStele)
 
-	c.steeleCount = c.Core.Constructs.CountByType(core.GeoConstructZhongliSkill)
+	c.steleCount = c.Core.Constructs.CountByType(core.GeoConstructZhongliSkill)
 
 	c.Core.Log.Debugw(
 		"Stele added",
@@ -38,7 +40,7 @@ func (c *char) newSteele(f, dur, max int) {
 		"event", core.LogCharacterEvent,
 		"char", c.Index,
 		"orig_count", num,
-		"cur_count", c.steeleCount,
+		"cur_count", c.steleCount,
 		"max_hit", max,
 		"next_tick", c.Core.F+120,
 	)

--- a/internal/characters/zhongli/zhongli.go
+++ b/internal/characters/zhongli/zhongli.go
@@ -7,9 +7,9 @@ import (
 
 type char struct {
 	*character.Tmpl
-	maxSteele   int
-	steeleCount int
-	energyICD   int
+	maxStele   int
+	steleCount int
+	energyICD  int
 }
 
 func init() {
@@ -30,9 +30,9 @@ func NewChar(s *core.Core, p core.CharacterProfile) (core.Character, error) {
 	c.SkillCon = 3
 	c.NormalHitNum = 6
 
-	c.maxSteele = 1
+	c.maxStele = 1
 	if c.Base.Cons >= 1 {
-		c.maxSteele = 2
+		c.maxStele = 2
 	}
 
 	c.a2()

--- a/pkg/monster/cryo.go
+++ b/pkg/monster/cryo.go
@@ -12,6 +12,8 @@ func (a *AuraCyro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 	if ds.Durability == 0 {
 		return a, false
 	}
+
+	reactionTriggered := true
 	switch ds.Element {
 	case core.Anemo:
 		ds.ReactionType = core.SwirlCryo
@@ -45,6 +47,7 @@ func (a *AuraCyro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 		//refresh
 		a.Refresh(ds.Durability)
 		ds.Durability = 0
+		reactionTriggered = false
 	case core.Electro:
 		//superconduct
 		ds.ReactionType = core.Superconduct
@@ -54,7 +57,7 @@ func (a *AuraCyro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 		return a, false
 	}
 	if a.CurrentDurability < 0 {
-		return nil, true
+		return nil, reactionTriggered
 	}
-	return a, true
+	return a, reactionTriggered
 }

--- a/pkg/monster/electro.go
+++ b/pkg/monster/electro.go
@@ -10,6 +10,8 @@ func (a *AuraElectro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 	if ds.Durability == 0 {
 		return a, false
 	}
+
+	reactionTriggered := true
 	switch ds.Element {
 	case core.Anemo:
 		ds.ReactionType = core.SwirlElectro
@@ -48,13 +50,14 @@ func (a *AuraElectro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 		//refresh
 		a.Refresh(ds.Durability)
 		ds.Durability = 0
+		reactionTriggered = false
 	default:
 		return a, false
 	}
 	if a.CurrentDurability < 0 {
-		return nil, true
+		return nil, reactionTriggered
 	}
-	return a, true
+	return a, reactionTriggered
 }
 
 /**

--- a/pkg/monster/hydro.go
+++ b/pkg/monster/hydro.go
@@ -12,6 +12,8 @@ func (a *AuraHydro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 	if ds.Durability == 0 {
 		return a, false
 	}
+
+	reactionTriggered := true
 	switch ds.Element {
 	case core.Anemo:
 		//this one doesn't do aoe damage for some reason
@@ -37,6 +39,7 @@ func (a *AuraHydro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 		//refresh
 		a.Refresh(ds.Durability)
 		ds.Durability = 0
+		reactionTriggered = false
 	case core.Cryo:
 		//first reduce hydro durability by incoming cryo; capped at existing
 		red := a.Reduce(ds, 1)
@@ -58,7 +61,7 @@ func (a *AuraHydro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 		return a, false
 	}
 	if a.CurrentDurability < 0 {
-		return nil, true
+		return nil, reactionTriggered
 	}
-	return a, true
+	return a, reactionTriggered
 }

--- a/pkg/monster/pyro.go
+++ b/pkg/monster/pyro.go
@@ -13,6 +13,7 @@ func (a *AuraPyro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 		return a, false
 	}
 
+	reactionTriggered := true
 	switch ds.Element {
 	case core.Anemo:
 		ds.ReactionType = core.SwirlPyro
@@ -31,6 +32,7 @@ func (a *AuraPyro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 		//refresh
 		a.Refresh(ds.Durability)
 		ds.Durability = 0
+		reactionTriggered = false
 	case core.Hydro:
 		//vaporize + reduce
 		ds.ReactionType = core.Vaporize
@@ -53,7 +55,7 @@ func (a *AuraPyro) React(ds *core.Snapshot, t *Target) (Aura, bool) {
 		return a, false
 	}
 	if a.CurrentDurability < 0 {
-		return nil, true
+		return nil, reactionTriggered
 	}
-	return a, true
+	return a, reactionTriggered
 }


### PR DESCRIPTION
Fixes:
- OnReactionOccured event was firing when aura was being refreshed
- Klee 3rd bounce was not 2B durability (fixes #39)
- Changed all instances of "Steele" to "Stele" in Zhongli code
- Fixed Zhongli stele spawn not procing damage (fixes #56)
- Fixed incorrect Zhongli stele and shield spawn frames