### PR TITLE
Fixes: Yoimiya A4, Shield Names, Zhongli Shield Type, Array Checks

### DIFF
--- a/internal/characters/beidou/abil.go
+++ b/internal/characters/beidou/abil.go
@@ -57,6 +57,7 @@ func (c *char) Skill(p map[string]int) (int, int) {
 		c.Core.Shields.Add(&shield.Tmpl{
 			Src:        c.Core.F,
 			ShieldType: core.ShieldBeidouThunderShield,
+			Name:       "Beidou Skill",
 			HP:         shieldPer[c.TalentLvlSkill()]*c.HPMax + shieldBase[c.TalentLvlSkill()],
 			Ele:        core.Electro,
 			Expires:    c.Core.F + 900, //15 sec
@@ -110,6 +111,7 @@ func (c *char) Burst(p map[string]int) (int, int) {
 		c.Core.Shields.Add(&shield.Tmpl{
 			Src:        c.Core.F,
 			ShieldType: core.ShieldBeidouThunderShield,
+			Name:       "Beidou C1",
 			HP:         .16 * c.HPMax,
 			Ele:        core.Electro,
 			Expires:    c.Core.F + 900, //15 sec

--- a/internal/characters/diona/abil.go
+++ b/internal/characters/diona/abil.go
@@ -110,6 +110,7 @@ func (c *char) Skill(p map[string]int) (int, int) {
 		c.Core.Shields.Add(&shield.Tmpl{
 			Src:        c.Core.F,
 			ShieldType: core.ShieldDionaSkill,
+			Name:       "Diona Skill",
 			HP:         shd,
 			Ele:        core.Cryo,
 			Expires:    c.Core.F + pawDur[c.TalentLvlSkill()], //15 sec

--- a/internal/characters/kaeya/cons.go
+++ b/internal/characters/kaeya/cons.go
@@ -33,6 +33,7 @@ func (c *char) c4() {
 			c.Core.Shields.Add(&shield.Tmpl{
 				Src:        c.Core.F,
 				ShieldType: core.ShieldKaeyaC4,
+				Name:       "Kaeya C4",
 				HP:         .3 * c.HPMax,
 				Ele:        core.Cryo,
 				Expires:    c.Core.F + 1200,

--- a/internal/characters/noelle/abil.go
+++ b/internal/characters/noelle/abil.go
@@ -88,6 +88,7 @@ func (c *char) newShield(base float64, t core.ShieldType, dur int) *noelleShield
 	n.Tmpl = &shield.Tmpl{}
 	n.Tmpl.Src = c.Core.F
 	n.Tmpl.ShieldType = t
+	n.Tmpl.Name = "Noelle Skill"
 	n.Tmpl.HP = base
 	n.Tmpl.Expires = c.Core.F + dur
 	n.c = c

--- a/internal/characters/noelle/noelle.go
+++ b/internal/characters/noelle/noelle.go
@@ -74,6 +74,7 @@ func (c *char) a2() {
 		c.Core.Shields.Add(&shield.Tmpl{
 			Src:        c.Core.F,
 			ShieldType: core.ShieldNoelleA2,
+			Name:       "Noelle A2",
 			HP:         4 * x,
 			Ele:        core.Cryo,
 			Expires:    c.Core.F + 1200, //20 sec

--- a/internal/characters/yanfei/abil.go
+++ b/internal/characters/yanfei/abil.go
@@ -205,6 +205,7 @@ func (c *char) c4() {
 		c.Core.Shields.Add(&shield.Tmpl{
 			Src:        c.Core.F,
 			ShieldType: core.ShieldYanfeiC4,
+			Name:       "Yanfei C4",
 			HP:         c.HPMax * .45,
 			Ele:        core.Pyro,
 			Expires:    c.Core.F + 15*60,

--- a/internal/characters/yoimiya/abil.go
+++ b/internal/characters/yoimiya/abil.go
@@ -117,24 +117,20 @@ func (c *char) Burst(p map[string]int) (int, int) {
 	}
 	c.AddTask(func() {
 		c.Core.Status.AddStatus("aurous", duration)
-		//attack buff if stacks
-		if c.Core.Status.Duration("yoimiyaa2") > 0 {
-			val := make([]float64, core.EndStatType)
-			val[core.ATKP] = 0.1 + float64(c.a2stack)*0.01
-			for i, char := range c.Core.Chars {
-				if i == c.Index {
-					continue
-				}
-				char.AddMod(core.CharStatMod{
-					Key:    "yoimiya-a4",
-					Expiry: c.Core.F + 900, //15s
-					Amount: func() ([]float64, bool) {
-						return val, true
-					},
-				})
+		val := make([]float64, core.EndStatType)
+		//attack buff
+		val[core.ATKP] = 0.1 + float64(c.a2stack)*0.01
+		for i, char := range c.Core.Chars {
+			if i == c.Index {
+				continue
 			}
-		} else {
-			c.a2stack = 0
+			char.AddMod(core.CharStatMod{
+				Key:    "yoimiya-a4",
+				Expiry: c.Core.F + 900, //15s
+				Amount: func() ([]float64, bool) {
+					return val, true
+				},
+			})
 		}
 	}, "start-blaze", f)
 

--- a/internal/characters/zhongli/shield.go
+++ b/internal/characters/zhongli/shield.go
@@ -53,7 +53,9 @@ func (c *char) newShield(base float64, dur int) *shd {
 	n.Tmpl = &shield.Tmpl{}
 	n.Tmpl.Src = c.Core.F
 	n.Tmpl.ShieldType = core.ShieldZhongliJadeShield
+	n.Tmpl.Ele = core.Geo
 	n.Tmpl.HP = base
+	n.Tmpl.Name = "Zhongli Skill"
 	n.Tmpl.Expires = c.Core.F + dur
 	n.c = c
 	return n

--- a/internal/weapons/claymore/bell/bell.go
+++ b/internal/weapons/claymore/bell/bell.go
@@ -31,6 +31,7 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 		c.Shields.Add(&shield.Tmpl{
 			Src:        c.F,
 			ShieldType: core.ShieldBell,
+			Name:       "Bell",
 			HP:         hp * char.MaxHP(),
 			Ele:        core.NoElement,
 			Expires:    c.F + 600, //10 sec

--- a/pkg/character/actions.go
+++ b/pkg/character/actions.go
@@ -70,17 +70,17 @@ func (c *Tmpl) ActionInterruptableDelay(next core.ActionType) int {
 }
 
 func (c *Tmpl) AddCDAdjustFunc(rd core.CDAdjust) {
-	ind := len(c.CDReductionFuncs)
+	ind := -1
 	for i, v := range c.CDReductionFuncs {
 		//if expired already, set to nil and ignore
 		if v.Key == rd.Key {
 			ind = i
 		}
 	}
-	if ind == len(c.CDReductionFuncs) {
-		c.CDReductionFuncs = append(c.CDReductionFuncs, rd)
-	} else {
+	if ind > -1 {
 		c.CDReductionFuncs[ind] = rd
+	} else {
+		c.CDReductionFuncs = append(c.CDReductionFuncs, rd)
 	}
 }
 

--- a/pkg/character/tmpl.go
+++ b/pkg/character/tmpl.go
@@ -112,14 +112,14 @@ func (c *Tmpl) AddWeaponInfuse(inf core.WeaponInfusion) {
 }
 
 func (c *Tmpl) AddPreDamageMod(mod core.PreDamageMod) {
-	ind := len(c.PreDamageMods)
+	ind := -1
 	for i, v := range c.PreDamageMods {
 		if v.Key == mod.Key {
 			ind = i
 		}
 	}
-	if ind != 0 && ind != len(c.PreDamageMods) {
-		c.Core.Log.Debugw("char pre damage mod added", "frame", c.Core.F, "event", core.LogCharacterEvent, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
+	if ind > -1 {
+		c.Core.Log.Debugw("char pre damage mod replaced", "frame", c.Core.F, "event", core.LogCharacterEvent, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
 		c.PreDamageMods[ind] = mod
 	} else {
 		c.PreDamageMods = append(c.PreDamageMods, mod)
@@ -129,14 +129,14 @@ func (c *Tmpl) AddPreDamageMod(mod core.PreDamageMod) {
 }
 
 func (c *Tmpl) AddMod(mod core.CharStatMod) {
-	ind := len(c.Mods)
+	ind := -1
 	for i, v := range c.Mods {
 		if v.Key == mod.Key {
 			ind = i
 		}
 	}
-	if ind != 0 && ind != len(c.Mods) {
-		c.Core.Log.Debugw("char mod added", "frame", c.Core.F, "char", c.Index, "event", core.LogCharacterEvent, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
+	if ind > -1 {
+		c.Core.Log.Debugw("char mod replaced", "frame", c.Core.F, "char", c.Index, "event", core.LogCharacterEvent, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
 		c.Mods[ind] = mod
 	} else {
 		c.Mods = append(c.Mods, mod)

--- a/pkg/core/construct.go
+++ b/pkg/core/construct.go
@@ -47,7 +47,7 @@ func NewConstructCtrl(c *Core) *ConstructCtrl {
 func (s *ConstructCtrl) New(c Construct, refresh bool) {
 
 	//if refresh, we nil out the old one if any
-	ind := len(s.constructs)
+	ind := -1
 	if refresh {
 		for i, v := range s.constructs {
 			if v.Type() == c.Type() {
@@ -55,7 +55,7 @@ func (s *ConstructCtrl) New(c Construct, refresh bool) {
 			}
 		}
 	}
-	if ind != len(s.constructs) {
+	if ind > -1 {
 		s.core.Log.Debugw("construct replaced", "event", LogConstructEvent, "frame", s.core.F, "key", s.constructs[ind].Key(), "prev type", s.constructs[ind].Type(), "next type", c.Type())
 		s.constructs[ind].OnDestruct()
 		s.constructs[ind] = c
@@ -85,14 +85,14 @@ func (s *ConstructCtrl) New(c Construct, refresh bool) {
 
 func (s *ConstructCtrl) NewNoLimitCons(c Construct, refresh bool) {
 	if refresh {
-		ind := len(s.consNoLimit)
+		ind := -1
 		for i, v := range s.consNoLimit {
 			//if expired already, set to nil and ignore
 			if v.Key() == c.Key() {
 				ind = i
 			}
 		}
-		if ind != 0 && ind != len(s.consNoLimit) {
+		if ind > -1 {
 			//destroy the existing by setting expiry
 			s.consNoLimit[ind].OnDestruct()
 			s.core.Log.Debugw("destroyed", "event", LogConstructEvent, "frame", s.core.F, "key", s.consNoLimit[ind].Key(), "type", s.consNoLimit[ind].Type())

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -95,13 +95,13 @@ func (h *EventCtrl) Subscribe(e EventType, f EventHook, key string) {
 	a := h.events[e]
 
 	//check if override first
-	ind := len(a)
+	ind := -1
 	for i, v := range a {
 		if v.key == key {
 			ind = i
 		}
 	}
-	if ind != 0 && ind != len(a) {
+	if ind > -1 {
 		h.c.Log.Debugw("hook added", "frame", h.c.F, "event", LogHookEvent, "overwrite", true, "key", key, "type", e)
 		a[ind] = ehook{
 			f:   f,

--- a/pkg/core/shield.go
+++ b/pkg/core/shield.go
@@ -72,14 +72,14 @@ func (s *ShieldCtrl) AddBonus(f func() float64) {
 
 func (s *ShieldCtrl) Add(shd Shield) {
 	//we always assume over write of the same type
-	ind := len(s.shields)
+	ind := -1
 	for i, v := range s.shields {
 		if v.Type() == shd.Type() {
 			ind = i
 		}
 	}
-	if ind != 0 && ind != len(s.shields) {
-		s.core.Log.Debugw("shield added", "frame", s.core.F, "event", LogShieldEvent, "frame", s.core.F, "overwrite", true, "name", shd.Desc(), "hp", shd.CurrentHP(), "ele", shd.Element(), "expiry", shd.Expiry())
+	if ind > -1 {
+		s.core.Log.Debugw("shield overridden", "frame", s.core.F, "event", LogShieldEvent, "frame", s.core.F, "overwrite", true, "name", shd.Desc(), "hp", shd.CurrentHP(), "ele", shd.Element(), "expiry", shd.Expiry())
 		s.shields[ind].OnOverwrite()
 		s.shields[ind] = shd
 	} else {

--- a/pkg/core/stam.go
+++ b/pkg/core/stam.go
@@ -12,16 +12,16 @@ func (c *Core) AddStamMod(f func(a ActionType) (float64, bool), key string) {
 			ind = i
 		}
 	}
-	if ind == -1 {
+	if ind > -1 {
+		c.Log.Debugw("char stam mod replaced", "frame", c.F, "event", LogCharacterEvent, "overwrite", true, "key", key)
+		c.stamModifier[ind].f = f
+		c.stamModifier[ind].key = key
+	} else {
 		c.Log.Debugw("char stam mod added", "frame", c.F, "event", LogCharacterEvent, "overwrite", false, "key", key)
 		c.stamModifier = append(c.stamModifier, stamMod{
 			f:   f,
 			key: key,
 		})
-	} else {
-		c.Log.Debugw("char stam mod added", "frame", c.F, "event", LogCharacterEvent, "overwrite", true, "key", key)
-		c.stamModifier[ind].f = f
-		c.stamModifier[ind].key = key
 	}
 }
 

--- a/pkg/core/target/mods.go
+++ b/pkg/core/target/mods.go
@@ -47,13 +47,13 @@ func (t *Tmpl) AddResMod(key string, val core.ResistMod) {
 		}
 	}
 	if ind != -1 {
-		t.Core.Log.Debugw("mod overwritten", "frame", t.Core.F, "event", core.LogEnemyEvent, "count", len(t.ResMod), "old", t.ResMod[ind], "next", val)
+		t.Core.Log.Debugw("mod overwritten", "frame", t.Core.F, "event", core.LogEnemyEvent, "target", t.TargetIndex, "count", len(t.ResMod), "old", t.ResMod[ind], "next", val)
 		// LogEnemyEvent
 		t.ResMod[ind] = val
 		return
 	}
 	t.ResMod = append(t.ResMod, val)
-	t.Core.Log.Debugw("new mod", "frame", t.Core.F, "event", core.LogEnemyEvent, "count", len(t.ResMod), "next", val)
+	t.Core.Log.Debugw("new mod", "frame", t.Core.F, "event", core.LogEnemyEvent, "target", t.TargetIndex, "count", len(t.ResMod), "next", val)
 	// e.mod[key] = val
 }
 

--- a/pkg/reactable/crystallize.go
+++ b/pkg/reactable/crystallize.go
@@ -69,6 +69,7 @@ func NewCrystallizeShield(typ core.EleType, src int, lvl int, em float64, expiry
 
 	s.Tmpl.Ele = typ
 	s.Tmpl.ShieldType = core.ShieldCrystallize
+	s.Tmpl.Name = "Crystallize " + typ.String()
 	s.Tmpl.Src = src
 	s.Tmpl.HP = shieldBaseHP[lvl]
 	s.Tmpl.Expires = expiry


### PR DESCRIPTION
- Yoimiya A4 did not activate properly
- Shield names all added
- Zhongli Shield Type fixed to Geo
- Unified array checking interface where we need to replace existing entries
- Fixes issues like Zhongli E shield not refreshing properly (Closes #150)