### PR TITLE
Logging improvements

### DIFF
--- a/internal/characters/barbara/abil.go
+++ b/internal/characters/barbara/abil.go
@@ -118,7 +118,11 @@ func (c *char) Skill(p map[string]int) (int, int) {
 	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1, false, core.TargettableEnemy), 5, 5)
 	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1, false, core.TargettableEnemy), 5, 35) // need to confirm timing of this
 
-	stats := c.SnapshotStats("Let the Show Begin♪ (Heal)", core.AttackTagNone)
+	aiHeal := core.AttackInfo{
+		Abil:      "Let the Show Begin♪ (Heal)",
+		AttackTag: core.AttackTagNone,
+	}
+	stats := c.SnapshotStats(&aiHeal)
 	hpplus := stats[core.Heal]
 	heal := (skillhp[c.TalentLvlBurst()] + skillhpp[c.TalentLvlBurst()]*c.MaxHP()) * (1 + hpplus)
 	//apply right away
@@ -182,7 +186,11 @@ func (c *char) Burst(p map[string]int) (int, int) {
 	f, a := c.ActionFrames(core.ActionBurst, p)
 	//hook for buffs; active right away after cast
 
-	stats := c.SnapshotStats("Shining Miracle♪ (Heal)", core.AttackTagNone)
+	ai := core.AttackInfo{
+		Abil:      "Shining Miracle♪ (Heal)",
+		AttackTag: core.AttackTagNone,
+	}
+	stats := c.SnapshotStats(&ai)
 
 	hpplus := stats[core.Heal]
 	heal := (bursthp[c.TalentLvlBurst()] + bursthpp[c.TalentLvlBurst()]*c.MaxHP()) * (1 + hpplus)

--- a/internal/characters/bennett/bennett.go
+++ b/internal/characters/bennett/bennett.go
@@ -242,7 +242,11 @@ func (c *char) Burst(p map[string]int) (int, int) {
 	//TODO: review bennett AOE size
 	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(5, false, core.TargettableEnemy), 33, 33)
 
-	stats := c.SnapshotStats("Fantastic Voyage (Heal)", core.AttackTagNone)
+	aiHeal := core.AttackInfo{
+		Abil:      "Fantastic Voyage (Heal)",
+		AttackTag: core.AttackTagNone,
+	}
+	stats := c.SnapshotStats(&aiHeal)
 
 	//apply right away
 	c.applyBennettField(stats)()

--- a/internal/characters/gorou/abil.go
+++ b/internal/characters/gorou/abil.go
@@ -122,7 +122,11 @@ func (c *char) Skill(p map[string]int) (int, int) {
 
 		if c.Base.Cons >= 4 && c.geoCharCount > 1 {
 			//TODO: not sure if this actually snapshots stats
-			stats := c.SnapshotStats("Inuzaka All-Round Defense C4", core.AttackTagNone)
+			ai := core.AttackInfo{
+				Abil:      "Inuzaka All-Round Defense C4",
+				AttackTag: core.AttackTagNone,
+			}
+			stats := c.SnapshotStats(&ai)
 			c.Core.Tasks.Add(c.gorouSkillHealField(c.Core.F, stats[:]), 90)
 		}
 	}

--- a/internal/characters/shenhe/abil.go
+++ b/internal/characters/shenhe/abil.go
@@ -256,7 +256,11 @@ func (c *char) quillDamageMod() {
 		}
 
 		if c.quillcount[atk.Info.ActorIndex] > 0 {
-			stats := c.SnapshotStats("Quills", core.AttackTagNone)
+			ai := core.AttackInfo{
+				Abil:      "Quills",
+				AttackTag: core.AttackTagNone,
+			}
+			stats := c.SnapshotStats(&ai)
 			amt := skillpp[c.TalentLvlSkill()] * ((c.Base.Atk+c.Weapon.Atk)*(1+stats[core.ATKP]) + stats[core.ATK])
 			if consumeStack { //c6
 				c.quillcount[atk.Info.ActorIndex]--

--- a/internal/characters/yunjin/abil.go
+++ b/internal/characters/yunjin/abil.go
@@ -209,7 +209,11 @@ func (c *char) burstProc() {
 			finalBurstBuff += 0.025 * float64(c.partyElementalTypes)
 		}
 
-		stats := c.SnapshotStats("Yunjin Burst Buff", core.AttackTagNone)
+		ai := core.AttackInfo{
+			Abil:      "Yunjin Burst Buff",
+			AttackTag: core.AttackTagNone,
+		}
+		stats := c.SnapshotStats(&ai)
 		dmgAdded := (c.Base.Def*(1+stats[core.DEFP]) + stats[core.DEF]) * finalBurstBuff
 		ae.Info.FlatDmg += dmgAdded
 

--- a/internal/weapons/claymore/redhorn/redhorn.go
+++ b/internal/weapons/claymore/redhorn/redhorn.go
@@ -37,7 +37,7 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 		baseDmgAdd := (atk.Snapshot.BaseDef*(1+atk.Snapshot.Stats[core.DEFP]) + atk.Snapshot.Stats[core.DEF]) * nacaBoost
 		atk.Info.FlatDmg += baseDmgAdd
 
-		c.Log.Debugw("Redhorn proc dmg add", "frame", c.F, "event", core.LogCalc, "char", char.CharIndex(), "base_added_dmg", baseDmgAdd)
+		c.Log.Debugw("Redhorn proc dmg add", "frame", c.F, "event", core.LogPreDamageMod, "char", char.CharIndex(), "base_added_dmg", baseDmgAdd)
 
 		return false
 	}, "")

--- a/internal/weapons/sword/cinnabar/cinnnabar.go
+++ b/internal/weapons/sword/cinnabar/cinnnabar.go
@@ -27,9 +27,10 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 		if effectDurationExpiry < c.F && c.F <= effectICDExpiry {
 			return false
 		}
-		atk.Info.FlatDmg += (atk.Snapshot.BaseDef*(1+atk.Snapshot.Stats[core.DEFP]) + atk.Snapshot.Stats[core.DEF]) * defPer
+		damageAdd := (atk.Snapshot.BaseDef*(1+atk.Snapshot.Stats[core.DEFP]) + atk.Snapshot.Stats[core.DEF]) * defPer
+		atk.Info.FlatDmg += damageAdd
 
-		c.Log.Debugw("Cinnabar Spindle proc dmg add", "frame", c.F, "event", core.LogCalc, "char", char.CharIndex(), "lastproc", effectLastProc, "effect_ends_at", effectDurationExpiry, "effect_icd_ends_at", effectICDExpiry)
+		c.Log.Debugw("Cinnabar Spindle proc dmg add", "frame", c.F, "event", core.LogPreDamageMod, "char", char.CharIndex(), "damage_added", damageAdd, "lastproc", effectLastProc, "effect_ends_at", effectDurationExpiry, "effect_icd_ends_at", effectICDExpiry)
 
 		// TODO: Assumes that the ICD starts after the last duration ends
 		effectICDExpiry = c.F + 6 + 90

--- a/pkg/core/action.go
+++ b/pkg/core/action.go
@@ -315,16 +315,16 @@ func (a *ActionCtrl) execNoSwap(n *CmdNoSwap) (int, bool, error) {
 func (a *ActionCtrl) execAction(n *ActionItem) (int, bool, error) {
 	c := a.core.Chars[a.core.ActiveChar]
 	f := 0
-	a.core.Log.Debugw(
-		"attempting to execute "+n.Typ.String(),
-		"frame", a.core.F,
-		"event", LogActionEvent,
-		"char", a.core.ActiveChar,
-		"action", n.Typ.String(),
-		"target", n.Target,
-		"swap_cd_pre", a.core.SwapCD,
-		"stam_pre", a.core.Stam,
-	)
+	// a.core.Log.Debugw(
+	// 	"attempting to execute "+n.Typ.String(),
+	// 	"frame", a.core.F,
+	// 	"event", LogActionEvent,
+	// 	"char", a.core.ActiveChar,
+	// 	"action", n.Typ.String(),
+	// 	"target", n.Target,
+	// 	"swap_cd_pre", a.core.SwapCD,
+	// 	"stam_pre", a.core.Stam,
+	// )
 
 	//do one last ready check
 	if !c.ActionReady(n.Typ, n.Param) {
@@ -371,7 +371,7 @@ func (a *ActionCtrl) execAction(n *ActionItem) (int, bool, error) {
 			break
 		}
 		if a.core.SwapCD > 0 {
-			a.core.Log.Warnw("swap on cd", "cd", a.core.SwapCD, "frame", a.core.F, "event", LogActionEvent)
+			a.core.Log.Warnw("could not execute swap - on cd", "cd", a.core.SwapCD, "frame", a.core.F, "event", LogActionEvent, "char", c.CharIndex())
 			return 0, false, nil
 		}
 		f = a.core.Swap(n.Target)

--- a/pkg/core/attackevent.go
+++ b/pkg/core/attackevent.go
@@ -1,5 +1,9 @@
 package core
 
+import (
+	"go.uber.org/zap"
+)
+
 type AttackEvent struct {
 	Info    AttackInfo
 	Pattern AttackPattern
@@ -54,6 +58,8 @@ type AttackInfo struct {
 	//special flag for sim generated attack
 	SourceIsSim bool
 	DoNotLog    bool
+
+	ModsLog []zap.Field
 }
 
 type Snapshot struct {

--- a/pkg/core/target/attack.go
+++ b/pkg/core/target/attack.go
@@ -95,8 +95,8 @@ func (t *Tmpl) calcDmg(atk *core.AttackEvent) (float64, bool) {
 	if atk.Snapshot.Stats[core.CR] > 1 {
 		atk.Snapshot.Stats[core.CR] = 1
 	}
-	res := t.Resist(atk.Info.Element, atk.Info.ActorIndex)
-	defadj := t.DefAdj(atk.Info.ActorIndex)
+	res := t.Resist(&atk.Info)
+	defadj := t.DefAdj(&atk.Info)
 
 	if defadj > 0.9 {
 		defadj = 0.9
@@ -203,24 +203,26 @@ func (t *Tmpl) calcDmg(atk *core.AttackEvent) (float64, bool) {
 	return damage, isCrit
 }
 
-func (t *Tmpl) Resist(ele core.EleType, char int) float64 {
+func (t *Tmpl) Resist(ai *core.AttackInfo) float64 {
 	// log.Debugw("\t\t res calc", "res", e.res, "mods", e.mod)
 	var logDetails []zap.Field
 	var sb strings.Builder
+	var detailsMods map[string][]string
 
 	if t.Core.Flags.LogDebug {
 		logDetails = make([]zap.Field, 0, 4+5*len(t.ResMod))
 		logDetails = append(logDetails,
 			zap.Int("frame", t.Core.F),
 			zap.Any("event", core.LogPreDamageMod),
-			zap.Int("char", char),
+			zap.Int("char", ai.ActorIndex),
 			zap.Int("target", t.TargetIndex),
 		)
+		detailsMods = make(map[string][]string)
 	}
 
-	r := t.Res[ele]
+	r := t.Res[ai.Element]
 	for _, v := range t.ResMod {
-		if v.Expiry > t.Core.F && v.Ele == ele {
+		if v.Expiry > t.Core.F && v.Ele == ai.Element {
 			if t.Core.Flags.LogDebug {
 				modStatus := make([]string, 0)
 
@@ -232,6 +234,7 @@ func (t *Tmpl) Resist(ele core.EleType, char int) float64 {
 					"amount: "+strconv.FormatFloat(v.Value, 'f', -1, 64),
 				)
 				logDetails = append(logDetails, zap.Any(sb.String(), modStatus))
+				detailsMods[sb.String()] = modStatus
 				sb.Reset()
 			}
 			r += v.Value
@@ -240,24 +243,29 @@ func (t *Tmpl) Resist(ele core.EleType, char int) float64 {
 
 	// No need to output if resist was not modified
 	if t.Core.Flags.LogDebug && len(logDetails) > 4 {
-		t.Core.Log.Desugar().Debug("resist modified", logDetails...)
+		// Disable as it is in the damage log
+		// t.Core.Log.Desugar().Debug("resist modified", logDetails...)
+		ai.ModsLog = append(ai.ModsLog,
+			zap.Any("resist_mods", detailsMods))
 	}
 
 	return r
 }
 
-func (t *Tmpl) DefAdj(char int) float64 {
+func (t *Tmpl) DefAdj(ai *core.AttackInfo) float64 {
 	var logDetails []zap.Field
 	var sb strings.Builder
+	var detailsMods map[string][]string
 
 	if t.Core.Flags.LogDebug {
 		logDetails = make([]zap.Field, 0, 4+5*len(t.ResMod))
 		logDetails = append(logDetails,
 			zap.Int("frame", t.Core.F),
 			zap.Any("event", core.LogPreDamageMod),
-			zap.Int("char", char),
+			zap.Int("char", ai.ActorIndex),
 			zap.Int("target", t.TargetIndex),
 		)
+		detailsMods = make(map[string][]string)
 	}
 
 	var r float64
@@ -273,15 +281,19 @@ func (t *Tmpl) DefAdj(char int) float64 {
 					"amount: "+strconv.FormatFloat(v.Value, 'f', -1, 64),
 				)
 				logDetails = append(logDetails, zap.Any(sb.String(), modStatus))
+				detailsMods[sb.String()] = modStatus
 				sb.Reset()
 			}
 			r += v.Value
 		}
 	}
 
-	// No need to output if resist was not modified
+	// No need to output if def was not modified
 	if t.Core.Flags.LogDebug && len(logDetails) > 4 {
-		t.Core.Log.Desugar().Debug("resist modified", logDetails...)
+		// Disable as it is in the damage log
+		// t.Core.Log.Desugar().Debug("def modified", logDetails...)
+		ai.ModsLog = append(ai.ModsLog,
+			zap.Any("def_mods", detailsMods))
 	}
 
 	return r


### PR DESCRIPTION
Streamlines the log display so things are more readable primarily by condensing the various snapshot debug logs into the damage log, making the debug view much faster to parse as you don't need to go scrolling around for the frame on which skills were snapshot to see their mods, and also exposes resist mods without needing to go into the Calc log.

I did not make changes related to flat damage logging (e.g., Yun Jin), so those still live in "Pre Damage Mods". As a result, I've disabled the old pre-damage mods view since those on the same frame as the damage log anyway, but the old "Snapshot_Mods" view still exist even though it's now mostly duplicative with the new damage log view in case it's useful.

Before:
![image](https://user-images.githubusercontent.com/84653157/148959677-6c09e625-a2bf-4770-909c-19227f3f86b7.png)

After:
![image](https://user-images.githubusercontent.com/84653157/148959786-3608da34-77a8-4943-9474-865f2709b2d7.png)

New damage log view:
![image](https://user-images.githubusercontent.com/84653157/148959841-5eca3d01-ff2e-44f6-9683-c44dd4a34379.png)
