### PR TITLE
Swap Delay and Action Delay

### DIFF
--- a/pkg/core/action.go
+++ b/pkg/core/action.go
@@ -393,6 +393,11 @@ func (a *ActionCtrl) execAction(n *ActionItem) (int, bool, error) {
 	return f, true, nil
 }
 
+// Each "abil" function returns two frames:
+// First int is the total animation frame, or the number of frames the ability should last.
+// Second int is the first frame after using an ability that the sim can start looking to queue the next action.
+// Supports user config overriding the total animation frames (second number)
+// TODO: Second int is basically completely unimplemented
 func (a *ActionCtrl) execActionItem(
 	n *ActionItem,
 	pre, post EventType,
@@ -403,6 +408,10 @@ func (a *ActionCtrl) execActionItem(
 	a.core.Events.Emit(pre)
 	f, l := abil(n.Param)
 	a.core.SetState(state, l)
+
+	if n.Param["delay"] > 0 {
+		f = f + n.Param["delay"]
+	}
 	if reset {
 		a.core.ResetAllNormalCounter()
 	}

--- a/pkg/core/cfg.go
+++ b/pkg/core/cfg.go
@@ -10,9 +10,16 @@ type Config struct {
 	}
 	Rotation []ActionBlock
 
+	Settings DefaultSetting
+
 	Hurt      HurtEvent
 	Energy    EnergyEvent
 	FixedRand bool //if this is true then use the same seed
+}
+
+type DefaultSetting struct {
+	SwapDelay int
+	FrameType string // Placeholder for when we want to implement perfect vs. "human" frames
 }
 
 type RunOpt struct {

--- a/pkg/parse/items.go
+++ b/pkg/parse/items.go
@@ -77,6 +77,7 @@ const (
 	itemEnergy     // energy
 	itemActive     // active
 	itemTarget     // target
+	itemDefaults   // defaults
 	// these are options related keywords
 	itemDebug      // debug
 	itemIterations // iteration
@@ -129,6 +130,9 @@ const (
 	// these are related to target setting
 
 	itemResist
+
+	// Related to defaults
+	itemSwapDelay
 
 	// stat types after the rest
 

--- a/pkg/parse/keys.go
+++ b/pkg/parse/keys.go
@@ -15,6 +15,7 @@ var key = map[string]ItemType{
 	"energy":      itemEnergy,
 	"active":      itemActive,
 	"options":     itemOptions,
+	"defaults":    itemDefaults,
 	//options
 	"debug":     itemDebug,
 	"iteration": itemIterations,
@@ -58,6 +59,8 @@ var key = map[string]ItemType{
 	"ele":      itemEle,
 	// target related
 	"resist": itemResist,
+	// defaults related
+	"swap_delay": itemSwapDelay,
 }
 
 var statKeys = map[string]core.StatType{

--- a/pkg/parse/parseDefaults.go
+++ b/pkg/parse/parseDefaults.go
@@ -1,0 +1,27 @@
+package parse
+
+import "errors"
+
+func parseDefaults(p *Parser) (parseFn, error) {
+	var err error
+
+	// Should handle something like the below:
+	// defaults swapdelay=8 framedefaults="human";
+	for n := p.next(); n.typ != itemEOF; n = p.next() {
+
+		switch n.typ {
+		case itemSwapDelay:
+			n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
+			if err == nil {
+				p.cfg.Settings.SwapDelay, err = itemNumberToInt(n)
+			}
+		case itemTerminateLine:
+			return parseRows, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, errors.New("unexpected end of line while parsing defaults")
+}

--- a/pkg/parse/parseRows.go
+++ b/pkg/parse/parseRows.go
@@ -65,6 +65,8 @@ func parseRows(p *Parser) (parseFn, error) {
 		return parseChar, nil
 	case itemOptions:
 		return parseOptions, nil
+	case itemDefaults:
+		return parseDefaults, nil
 	case itemChain:
 		return parseChain, nil
 	case itemWaitFor:

--- a/run.go
+++ b/run.go
@@ -61,6 +61,8 @@ func (s *Simulation) Run() (Stats, error) {
 	return s.stats, nil
 }
 
+// Advances simulation frame, handling any events and queueing up the next action
+// Primary method that interacts with queueing system, including queue delays
 func (s *Simulation) AdvanceFrame() error {
 	var done bool
 	var err error
@@ -130,6 +132,10 @@ func (s *Simulation) AdvanceFrame() error {
 		}
 
 		if done {
+			if s.queue[0].(*core.ActionItem).Typ == core.ActionSwap {
+				s.skip = s.cfg.Settings.SwapDelay
+			}
+
 			if s.opts.LogDetails && isAction {
 				s.stats.AbilUsageCountByChar[s.C.ActiveChar][act.Typ.String()]++
 			}


### PR DESCRIPTION
- Add "defaults" keyword to config, with ability to set "swap_delay"
- Add "delay" parameter to allow for custom delays after actions

Works in configs like this, which adds a global 8 frame swap delay, and a 60 frame delay to Hu Tao CA on top of the standard animation frames.
```
defaults swap_delay=8;

hutao attack:2,charge[delay=60],dash
      +if=.status.paramita>60
      && .stam.hutao>180;
```