### PR TITLE
Fixes / Kokomi's A4/Skill/Burst & Prototype Amber

### DIFF
--- a/internal/characters/kokomi/abil.go
+++ b/internal/characters/kokomi/abil.go
@@ -138,8 +138,10 @@ func (c *char) createSkillSnapshot() *core.AttackEvent {
 // Helper function that handles damage, healing, and particle components of every tick of her E
 func (c *char) skillTick(d *core.AttackEvent) {
 
+	hpplus := 1 + c.Stat(core.Heal)
+
 	c.Core.Combat.QueueAttackEvent(d, 0)
-	c.Core.Health.HealActive(c.Index, skillHealPct[c.TalentLvlSkill()]*c.HPMax+skillHealFlat[c.TalentLvlSkill()])
+	c.Core.Health.HealActive(c.Index, (skillHealPct[c.TalentLvlSkill()]*c.HPMax+skillHealFlat[c.TalentLvlSkill()])*hpplus)
 
 	// Particles are 0~1 (1:2) on every damage instance
 	if c.Core.Rand.Float64() < .6667 {
@@ -154,7 +156,7 @@ func (c *char) skillTick(d *core.AttackEvent) {
 	if c.Base.Cons >= 2 {
 		active := c.Core.Chars[c.Core.ActiveChar]
 		if active.HP()/active.MaxHP() <= .5 {
-			c.Core.Health.HealActive(c.Index, 0.045*c.HPMax)
+			c.Core.Health.HealActive(c.Index, 0.045*c.HPMax*hpplus)
 		}
 	}
 }
@@ -246,7 +248,7 @@ func (c *char) burstDmgBonus(a core.AttackTag) float64 {
 	if c.Core.Status.Duration("kokomiburst") == 0 {
 		return 0
 	}
-	a4Bonus := c.Stats[core.Heal] * 0.15
+	a4Bonus := c.Stat(core.Heal) * 0.15
 	switch a {
 	case core.AttackTagNormal:
 		return (burstBonusNormal[c.TalentLvlBurst()] + a4Bonus) * c.HPMax

--- a/internal/characters/kokomi/kokomi.go
+++ b/internal/characters/kokomi/kokomi.go
@@ -73,7 +73,8 @@ func (c *char) burstActiveHook() {
 			return false
 		}
 
-		c.Core.Health.HealAll(c.Index, burstHealPct[c.TalentLvlBurst()]*c.HPMax+burstHealFlat[c.TalentLvlBurst()])
+		hpplus := 1 + c.Stat(core.Heal)
+		c.Core.Health.HealAll(c.Index, (burstHealPct[c.TalentLvlBurst()]*c.HPMax+burstHealFlat[c.TalentLvlBurst()])*hpplus)
 
 		// C2 handling
 		// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
@@ -83,7 +84,7 @@ func (c *char) burstActiveHook() {
 				if char.HP()/char.MaxHP() > .5 {
 					continue
 				}
-				c.Core.Health.HealIndex(c.Index, i, 0.006*c.HPMax)
+				c.Core.Health.HealIndex(c.Index, i, 0.006*c.HPMax*hpplus)
 			}
 		}
 

--- a/internal/weapons/catalyst/prototype/prototype.go
+++ b/internal/weapons/catalyst/prototype/prototype.go
@@ -26,7 +26,7 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 
 			char.AddTask(func() {
 				char.AddEnergy(e)
-				c.Health.HealAllPercent(char.CharIndex(), e/100.0)
+				c.Health.HealAllPercent(char.CharIndex(), e/100.0*(1+char.Stat(core.Heal)))
 			}, "recharge", i)
 		}
 


### PR DESCRIPTION
- Fix bonus from Kokomi's A4;
- Fix heal bonus from Kokomi's skill/burst;
- Fix heal bonus from passive of Prototype Amber;