### PR TITLE
Bugfixes - Pale Flame, Bennett Burst and A4, Gorou C6, Energy Log

### DIFF
--- a/internal/artifacts/paleflame/paleflame.go
+++ b/internal/artifacts/paleflame/paleflame.go
@@ -16,7 +16,7 @@ func New(c core.Character, s *core.Core, count int, params map[string]int) {
 		m := make([]float64, core.EndStatType)
 		m[core.PhyP] = 0.25
 		c.AddMod(core.CharStatMod{
-			Key: "maiden-2pc",
+			Key: "pf-2pc",
 			Amount: func() ([]float64, bool) {
 				return m, true
 			},

--- a/internal/characters/bennett/bennett.go
+++ b/internal/characters/bennett/bennett.go
@@ -129,7 +129,7 @@ func (c *char) Skill(p map[string]int) (int, int) {
 	}
 
 	//A4
-	if c.Core.Status.Duration("btburst") > 0 {
+	if c.ModIsActive("bennett-field") {
 		cd = cd / 2
 	}
 
@@ -222,10 +222,11 @@ func (c *char) skillHoldLong() {
 
 func (c *char) Burst(p map[string]int) (int, int) {
 
+	burstStartFrame := 31
 	f, a := c.ActionFrames(core.ActionBurst, p)
 
 	//add field effect timer
-	c.Core.Status.AddStatus("btburst", 720)
+	c.Core.Status.AddStatus("btburst", 720+burstStartFrame)
 	//hook for buffs; active right away after cast
 
 	ai := core.AttackInfo{
@@ -251,8 +252,9 @@ func (c *char) Burst(p map[string]int) (int, int) {
 	c.applyBennettField(stats)()
 
 	//add 12 ticks starting at t = 1 to t= 12
-	//TODO confirm if starts at t=1 or after animation
-	for i := 0; i <= 720; i += 60 {
+	// Buff appears to start ticking right before hit
+	// https://discord.com/channels/845087716541595668/869210750596554772/936507730779308032
+	for i := burstStartFrame; i <= 720+burstStartFrame; i += 60 {
 		c.AddTask(c.applyBennettField(stats), "bennett-field", i)
 	}
 

--- a/internal/characters/gorou/cons.go
+++ b/internal/characters/gorou/cons.go
@@ -59,10 +59,13 @@ func (c *char) c2() {
 
 func (c *char) c6() {
 	for _, char := range c.Core.Chars {
-		char.AddMod(core.CharStatMod{
+		char.AddPreDamageMod(core.PreDamageMod{
 			Key:    c6key,
 			Expiry: c.Core.F + 720, //12s
-			Amount: func() ([]float64, bool) {
+			Amount: func(ae *core.AttackEvent, t core.Target) ([]float64, bool) {
+				if ae.Info.Element != core.Geo {
+					return nil, false
+				}
 				return c.c6buff, true
 			},
 		})

--- a/pkg/character/energy.go
+++ b/pkg/character/energy.go
@@ -92,5 +92,6 @@ func (c *Tmpl) ReceiveParticle(p core.Particle, isActive bool, partyCount int) {
 		"pre_recovery", pre,
 		"amt", amt,
 		"post_recovery", c.Energy,
+		"max_energy", c.MaxEnergy(),
 	)
 }


### PR DESCRIPTION
- Fixes pale flame 2 pc set typo
- Fixes Bennett burst frame timing and A4 activation method
- Fixes Gorou C6 incorrectly snapshotting
- Add max energy in energy log