### PR TITLE
Bugfixes - Shenhe, Crystallize, Keqing E and Q, Substat Optimizer, Log Improvements

### DIFF
--- a/internal/characters/keqing/abil.go
+++ b/internal/characters/keqing/abil.go
@@ -71,6 +71,13 @@ func (c *char) ChargeAttack(p map[string]int) (int, int) {
 		c.Tags["e"] = 0
 		// c.CD[def.SkillCD] = c.eStartFrame + 100
 		c.SetCD(core.ActionSkill, c.eStartFrame+450-c.Core.F)
+
+		// TODO: Particle timing?
+		if c.Core.Rand.Float64() < .5 {
+			c.QueueParticle("keqing", 2, core.Electro, 100)
+		} else {
+			c.QueueParticle("keqing", 3, core.Electro, 100)
+		}
 	}
 
 	if c.Base.Cons == 6 {
@@ -171,6 +178,13 @@ func (c *char) skillNext(p map[string]int) (int, int) {
 		}
 	}
 
+	// TODO: Particle timing?
+	if c.Core.Rand.Float64() < .5 {
+		c.QueueParticle("keqing", 2, core.Electro, 100)
+	} else {
+		c.QueueParticle("keqing", 3, core.Electro, 100)
+	}
+
 	//place on cooldown
 	c.Tags["e"] = 0
 	c.SetCD(core.ActionSkill, c.eStartFrame+450-c.Core.F)
@@ -196,7 +210,7 @@ func (c *char) Burst(p map[string]int) (int, int) {
 
 	//initial
 	ai := core.AttackInfo{
-		Abil:       "Starward Sword (Initial)",
+		Abil:       "Starward Sword (Cast)",
 		ActorIndex: c.Index,
 		AttackTag:  core.AttackTagElementalBurst,
 		ICDTag:     core.ICDTagElementalBurst,
@@ -209,7 +223,7 @@ func (c *char) Burst(p map[string]int) (int, int) {
 	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(5, false, core.TargettableEnemy), 70, 70)
 	//8 hits
 
-	ai.Abil = "Starward Sword (Tick)"
+	ai.Abil = "Starward Sword (Consecutive Slash)"
 	ai.Mult = burstDot[c.TalentLvlBurst()]
 	for i := 70; i < 170; i += 13 {
 		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(5, false, core.TargettableEnemy), i, i)
@@ -217,7 +231,7 @@ func (c *char) Burst(p map[string]int) (int, int) {
 
 	//final
 
-	ai.Abil = "Starward Sword (Tick)"
+	ai.Abil = "Starward Sword (Last Attack)"
 	ai.Mult = burstFinal[c.TalentLvlBurst()]
 	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(5, false, core.TargettableEnemy), 211, 211)
 

--- a/internal/reactable/crystallize.go
+++ b/internal/reactable/crystallize.go
@@ -37,7 +37,7 @@ func (r *Reactable) tryCrystallizeWithEle(a *core.AttackEvent, ele core.EleType,
 		Abil:       string(rt),
 	}
 	snap := char.Snapshot(&ai)
-	shd := NewCrystallizeShield(core.Electro, r.core.F, snap.CharLvl, snap.Stats[core.EM], r.core.F+900)
+	shd := NewCrystallizeShield(ele, r.core.F, snap.CharLvl, snap.Stats[core.EM], r.core.F+900)
 	r.core.Shields.Add(shd)
 	//reduce
 	r.reduce(ele, a.Info.Durability, 0.5)

--- a/internal/substatoptimizer/substatoptimizer.go
+++ b/internal/substatoptimizer/substatoptimizer.go
@@ -75,6 +75,9 @@ func RunSubstatOptim(simopt simulator.Options, verbose bool, additionalOptions s
 	mainstatValues[core.HPP] = 0.466
 	mainstatValues[core.DEFP] = 0.583
 
+	// Each optimizer run should not be saving anything out for the GZIP
+	simopt.GZIPResult = false
+
 	// Start logger
 	zapcfg := zap.NewDevelopmentConfig()
 	zapcfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)

--- a/internal/tmpl/character/energy.go
+++ b/internal/tmpl/character/energy.go
@@ -43,7 +43,12 @@ func (c *Tmpl) AddEnergy(src string, e float64) {
 	}
 
 	c.Core.Events.Emit(core.OnEnergyChange, c, preEnergy, e, src)
-	c.Core.Log.NewEvent("adding energy", core.LogEnergyEvent, c.Index, "rec'd", e, "next energy", c.Energy, "char", c.Index, "src", src)
+	c.Core.Log.NewEvent("adding energy", core.LogEnergyEvent, c.Index,
+		"rec'd", e,
+		"post_recovery", c.Energy,
+		"source", src,
+		"max_energy", c.EnergyMax,
+	)
 }
 
 func (c *Tmpl) ReceiveParticle(p core.Particle, isActive bool, partyCount int) {

--- a/internal/tmpl/status/status.go
+++ b/internal/tmpl/status/status.go
@@ -43,13 +43,13 @@ func (s *StatusCtrl) AddStatus(key string, dur int) {
 		//log an entry for refreshing
 		//TODO: this line may not be needed
 		if s.core.Flags.LogDebug {
-			s.core.Log.NewEvent("status refreshed: "+key, core.LogStatusEvent, -1, "key", key, "expiry", s.core.F+dur)
+			s.core.Log.NewEvent("status refreshed: ", core.LogStatusEvent, -1, "key", key, "expiry", s.core.F+dur)
 		}
 		return
 	}
 
 	//otherwise create a new event
-	a.evt = s.core.Log.NewEvent("status added: "+key, core.LogStatusEvent, -1, "key", key, "expiry", s.core.F+dur)
+	a.evt = s.core.Log.NewEvent("status added: ", core.LogStatusEvent, -1, "key", key, "expiry", s.core.F+dur)
 	a.expiry = s.core.F + dur
 
 	s.status[key] = a
@@ -69,7 +69,7 @@ func (s *StatusCtrl) ExtendStatus(key string, dur int) {
 
 	//TODO: this line may not be needed
 	if s.core.Flags.LogDebug {
-		s.core.Log.NewEvent("status extended: "+key, core.LogStatusEvent, -1, "key", key, "expiry", a.expiry)
+		s.core.Log.NewEvent("status refreshed: ", core.LogStatusEvent, -1, "key", key, "expiry", a.expiry)
 	}
 }
 
@@ -80,7 +80,7 @@ func (s *StatusCtrl) DeleteStatus(key string) {
 		a.evt.SetEnded(s.core.F)
 		//TODO: this line may not be needed
 		if s.core.Flags.LogDebug {
-			s.core.Log.NewEvent("status deleted: "+key, core.LogStatusEvent, -1, "key", key)
+			s.core.Log.NewEvent("status deleted: ", core.LogStatusEvent, -1, "key", key)
 		}
 	}
 	delete(s.status, key)

--- a/pkg/simulation/energy.go
+++ b/pkg/simulation/energy.go
@@ -55,8 +55,8 @@ func (s *Simulation) randomOnHitEnergy() {
 		}
 		//add energy
 		char.AddEnergy("na-ca-on-hit", 1)
-		s.C.Log.NewEvent("random energy on normal", core.LogEnergyEvent, -1, "char", atk.Info.ActorIndex, "chance", current[w])
-		// s.C.Log.Debugw("random energy on normal", "frame", s.C.F, core.LogEnergyEvent, "char", atk.Info.ActorIndex, "chance", current[w])
+		// Add this log in sim if necessary to see as AddEnergy already generates a log
+		s.C.Log.NewEvent("random energy on normal", core.LogSimEvent, char.CharIndex(), "char", atk.Info.ActorIndex, "chance", current[w])
 		//set icd
 		icd = s.C.F + 12
 		current[w] = 0


### PR DESCRIPTION
Fixes #272 and #273 - Shenhe particle timing and burst
  - Burst ticks were incorrectly coded
  - C2 was not implemented correctly
  - Burst res shred duration was wrong

Fixes #235 - Generated crystallize shields were always electro
Fixes #284 and #285 - Add particles to Keqing E; fix Keqing Q name
Fixes #286 - Substat optimizer should ignore gzip setting
Fixes #288 - Updates log for energy add, random normals, and status


