### PR TITLE
add ended status tracking for mods

### DIFF
--- a/internal/tmpl/character/mods.go
+++ b/internal/tmpl/character/mods.go
@@ -1,0 +1,110 @@
+package character
+
+import "github.com/genshinsim/gcsim/pkg/core"
+
+func (c *Tmpl) AddPreDamageMod(mod core.PreDamageMod) {
+	ind := -1
+	for i, v := range c.PreDamageMods {
+		if v.Key == mod.Key {
+			ind = i
+		}
+	}
+	if ind > -1 {
+		ref := c.Core.Log.NewEvent("mod refreshed", core.LogStatusEvent, c.Index, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
+		//pull out existing event and update the ended
+		mod.Evt = c.PreDamageMods[ind].Evt
+		if mod.Expiry != -1 {
+			mod.Evt.SetEnded(mod.Expiry)
+			ref.SetEnded(mod.Expiry)
+		}
+		c.PreDamageMods[ind] = mod
+
+	} else {
+		//create new event
+		mod.Evt = c.Core.Log.NewEvent("mod added", core.LogStatusEvent, c.Index, "overwrite", false, "key", mod.Key, "expiry", mod.Expiry)
+		if mod.Expiry != -1 {
+			mod.Evt.SetEnded(mod.Expiry)
+		}
+		c.PreDamageMods = append(c.PreDamageMods, mod)
+	}
+
+	// Add task to check for mod expiry in debug instances
+	// if c.Core.Flags.LogDebug && mod.Expiry > -1 {
+	// 	c.AddTask(func() {
+	// 		if c.PreDamageModIsActive(mod.Key) {
+	// 			return
+	// 		}
+	// 		c.Core.Log.NewEvent("mod expired", core.LogStatusEvent, c.Index, "overwrite", false, "key", mod.Key, "expiry", mod.Expiry)
+	// 	}, "check-mod-expiry", mod.Expiry+1-c.Core.F)
+	// }
+}
+
+func (c *Tmpl) AddMod(mod core.CharStatMod) {
+	ind := -1
+	for i, v := range c.Mods {
+		if v.Key == mod.Key {
+			ind = i
+		}
+	}
+	if ind > -1 {
+		ref := c.Core.Log.NewEvent("mod refreshed", core.LogStatusEvent, c.Index, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
+		//pull out existing event and update the ended
+		mod.Evt = c.Mods[ind].Evt
+		if mod.Expiry != -1 {
+			mod.Evt.SetEnded(mod.Expiry)
+			ref.SetEnded(mod.Expiry)
+		}
+		c.Mods[ind] = mod
+	} else {
+		mod.Evt = c.Core.Log.NewEvent("mod added", core.LogStatusEvent, c.Index, "overwrite", false, "key", mod.Key, "expiry", mod.Expiry)
+		if mod.Expiry != -1 {
+			mod.Evt.SetEnded(mod.Expiry)
+		}
+		c.Mods = append(c.Mods, mod)
+	}
+
+	// Add task to check for mod expiry in debug instances
+	// if c.Core.Flags.LogDebug && mod.Expiry > -1 {
+	// 	c.AddTask(func() {
+	// 		if c.ModIsActive(mod.Key) {
+	// 			return
+	// 		}
+	// 		c.Core.Log.NewEvent("mod expired", core.LogStatusEvent, c.Index, "overwrite", false, "key", mod.Key, "expiry", mod.Expiry)
+	// 	}, "check-mod-expiry", mod.Expiry+1-c.Core.F)
+	// }
+}
+
+func (t *Tmpl) AddReactBonusMod(mod core.ReactionBonusMod) {
+	ind := -1
+	for i, v := range t.ReactMod {
+		if v.Key == mod.Key {
+			ind = i
+		}
+	}
+	if ind != -1 {
+		ref := t.Core.Log.NewEvent("mod refreshed", core.LogStatusEvent, t.Index, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
+		mod.Evt = t.ReactMod[ind].Evt
+		if mod.Expiry != -1 {
+			mod.Evt.SetEnded(mod.Expiry)
+			ref.SetEnded(mod.Expiry)
+		}
+		t.ReactMod[ind] = mod
+
+		return
+	}
+	mod.Evt = t.Core.Log.NewEvent("mod added", core.LogStatusEvent, t.Index, "key", mod.Key, "expiry", mod.Expiry)
+	if mod.Expiry != -1 {
+		mod.Evt.SetEnded(mod.Expiry)
+	}
+	t.ReactMod = append(t.ReactMod, mod)
+
+	// Add task to check for mod expiry in debug instances
+	// if t.Core.Flags.LogDebug && mod.Expiry > -1 {
+	// 	t.AddTask(func() {
+	// 		if t.ReactBonusModIsActive(mod.Key) {
+	// 			return
+	// 		}
+	// 		t.Core.Log.NewEvent("mod expired", core.LogStatusEvent, t.Index, "key", mod.Key, "expiry", mod.Expiry)
+	// 	}, "check-mod-expiry", mod.Expiry+1-t.Core.F)
+	// }
+}

--- a/internal/tmpl/character/tmpl.go
+++ b/internal/tmpl/character/tmpl.go
@@ -116,58 +116,6 @@ func (c *Tmpl) AddWeaponInfuse(inf core.WeaponInfusion) {
 	c.Infusion = inf
 }
 
-func (c *Tmpl) AddPreDamageMod(mod core.PreDamageMod) {
-	ind := -1
-	for i, v := range c.PreDamageMods {
-		if v.Key == mod.Key {
-			ind = i
-		}
-	}
-	if ind > -1 {
-		c.Core.Log.NewEvent("mod refreshed", core.LogStatusEvent, c.Index, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
-		c.PreDamageMods[ind] = mod
-	} else {
-		c.PreDamageMods = append(c.PreDamageMods, mod)
-		c.Core.Log.NewEvent("mod added", core.LogStatusEvent, c.Index, "overwrite", false, "key", mod.Key, "expiry", mod.Expiry)
-	}
-
-	// Add task to check for mod expiry in debug instances
-	if c.Core.Flags.LogDebug && mod.Expiry > -1 {
-		c.AddTask(func() {
-			if c.PreDamageModIsActive(mod.Key) {
-				return
-			}
-			c.Core.Log.NewEvent("mod expired", core.LogStatusEvent, c.Index, "overwrite", false, "key", mod.Key, "expiry", mod.Expiry)
-		}, "check-mod-expiry", mod.Expiry+1-c.Core.F)
-	}
-}
-
-func (c *Tmpl) AddMod(mod core.CharStatMod) {
-	ind := -1
-	for i, v := range c.Mods {
-		if v.Key == mod.Key {
-			ind = i
-		}
-	}
-	if ind > -1 {
-		c.Core.Log.NewEvent("mod refreshed", core.LogStatusEvent, c.Index, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
-		c.Mods[ind] = mod
-	} else {
-		c.Mods = append(c.Mods, mod)
-		c.Core.Log.NewEvent("mod added", core.LogStatusEvent, c.Index, "overwrite", false, "key", mod.Key, "expiry", mod.Expiry)
-	}
-
-	// Add task to check for mod expiry in debug instances
-	if c.Core.Flags.LogDebug && mod.Expiry > -1 {
-		c.AddTask(func() {
-			if c.ModIsActive(mod.Key) {
-				return
-			}
-			c.Core.Log.NewEvent("mod expired", core.LogStatusEvent, c.Index, "overwrite", false, "key", mod.Key, "expiry", mod.Expiry)
-		}, "check-mod-expiry", mod.Expiry+1-c.Core.F)
-	}
-}
-
 func (c *Tmpl) ModIsActive(key string) bool {
 	ind := -1
 	for i, v := range c.Mods {
@@ -223,32 +171,6 @@ func (c *Tmpl) ReactBonusModIsActive(key string) bool {
 		return false
 	}
 	return true
-}
-
-func (t *Tmpl) AddReactBonusMod(mod core.ReactionBonusMod) {
-	ind := -1
-	for i, v := range t.ReactMod {
-		if v.Key == mod.Key {
-			ind = i
-		}
-	}
-	if ind != -1 {
-		t.ReactMod[ind] = mod
-		t.Core.Log.NewEvent("mod refreshed", core.LogStatusEvent, t.Index, "overwrite", true, "key", mod.Key, "expiry", mod.Expiry)
-		return
-	}
-	t.ReactMod = append(t.ReactMod, mod)
-	t.Core.Log.NewEvent("mod added", core.LogStatusEvent, t.Index, "key", mod.Key, "expiry", mod.Expiry)
-
-	// Add task to check for mod expiry in debug instances
-	if t.Core.Flags.LogDebug && mod.Expiry > -1 {
-		t.AddTask(func() {
-			if t.ReactBonusModIsActive(mod.Key) {
-				return
-			}
-			t.Core.Log.NewEvent("mod expired", core.LogStatusEvent, t.Index, "key", mod.Key, "expiry", mod.Expiry)
-		}, "check-mod-expiry", mod.Expiry+1-t.Core.F)
-	}
 }
 
 func (c *Tmpl) Tag(key string) int {

--- a/internal/tmpl/status/status.go
+++ b/internal/tmpl/status/status.go
@@ -43,7 +43,7 @@ func (s *StatusCtrl) AddStatus(key string, dur int) {
 		//log an entry for refreshing
 		//TODO: this line may not be needed
 		if s.core.Flags.LogDebug {
-			s.core.Log.NewEvent("status refreshed: ", core.LogStatusEvent, -1, "key", key, "expiry", s.core.F+dur)
+			s.core.Log.NewEvent("status refreshed: ", core.LogStatusEvent, -1, "key", key, "expiry", s.core.F+dur).SetEnded(s.core.F + dur)
 		}
 		return
 	}
@@ -70,7 +70,7 @@ func (s *StatusCtrl) ExtendStatus(key string, dur int) {
 
 	//TODO: this line may not be needed
 	if s.core.Flags.LogDebug {
-		s.core.Log.NewEvent("status refreshed: ", core.LogStatusEvent, -1, "key", key, "expiry", a.expiry)
+		s.core.Log.NewEvent("status refreshed: ", core.LogStatusEvent, -1, "key", key, "expiry", a.expiry).SetEnded(a.expiry)
 	}
 }
 

--- a/internal/tmpl/target/mods.go
+++ b/internal/tmpl/target/mods.go
@@ -18,23 +18,32 @@ func (t *Tmpl) AddDefMod(key string, val float64, dur int) {
 		}
 	}
 	if ind != -1 {
-		t.Core.Log.NewEvent("enemy mod refreshed", core.LogStatusEvent, -1, "count", len(t.DefMod), "val", val, "target", t.TargetIndex, "key", m.Key, "expiry", m.Expiry)
+		m.Evt = t.DefMod[ind].Evt
+		ref := t.Core.Log.NewEvent("enemy mod refreshed", core.LogStatusEvent, -1, "count", len(t.DefMod), "val", val, "target", t.TargetIndex, "key", m.Key, "expiry", m.Expiry)
+		if m.Expiry != -1 {
+			m.Evt.SetEnded(m.Expiry)
+			ref.SetEnded(m.Expiry)
+		}
 		t.DefMod[ind] = m
 		return
 	}
+	m.Evt = t.Core.Log.NewEvent("enemy mod added", core.LogStatusEvent, -1, "count", len(t.DefMod), "val", val, "target", t.TargetIndex, "key", m.Key, "expiry", m.Expiry)
+	if m.Expiry != -1 {
+		m.Evt.SetEnded(m.Expiry)
+	}
 	t.DefMod = append(t.DefMod, m)
-	t.Core.Log.NewEvent("enemy mod added", core.LogStatusEvent, -1, "count", len(t.DefMod), "val", val, "target", t.TargetIndex, "key", m.Key, "expiry", m.Expiry)
+
 	// e.mod[key] = val
 
 	// Add task to check for mod expiry in debug instances
-	if t.Core.Flags.LogDebug && m.Expiry > 0 {
-		t.AddTask(func() {
-			if t.HasDefMod(m.Key) {
-				return
-			}
-			t.Core.Log.NewEvent("enemy mod expired", core.LogStatusEvent, -1, "count", len(t.DefMod), "val", val, "target", t.TargetIndex, "key", m.Key, "expiry", m.Expiry)
-		}, "check-m-expiry", m.Expiry+1-t.Core.F)
-	}
+	// if t.Core.Flags.LogDebug && m.Expiry > 0 {
+	// 	t.AddTask(func() {
+	// 		if t.HasDefMod(m.Key) {
+	// 			return
+	// 		}
+	// 		t.Core.Log.NewEvent("enemy mod expired", core.LogStatusEvent, -1, "count", len(t.DefMod), "val", val, "target", t.TargetIndex, "key", m.Key, "expiry", m.Expiry)
+	// 	}, "check-m-expiry", m.Expiry+1-t.Core.F)
+	// }
 }
 
 func (t *Tmpl) HasDefMod(key string) bool {
@@ -58,23 +67,31 @@ func (t *Tmpl) AddResMod(key string, val core.ResistMod) {
 		}
 	}
 	if ind != -1 {
-		t.Core.Log.NewEvent("enemy mod refreshed", core.LogStatusEvent, -1, "count", len(t.ResMod), "val", val, "target", t.TargetIndex, "key", val.Key, "expiry", val.Expiry)
+		ref := t.Core.Log.NewEvent("enemy mod refreshed", core.LogStatusEvent, -1, "count", len(t.ResMod), "val", val, "target", t.TargetIndex, "key", val.Key, "expiry", val.Expiry)
+		val.Evt = t.ResMod[ind].Evt
+		if val.Expiry != -1 {
+			val.Evt.SetEnded(val.Expiry)
+			ref.SetEnded(val.Expiry)
+		}
 		t.ResMod[ind] = val
 		return
 	}
+	val.Evt = t.Core.Log.NewEvent("enemy mod added", core.LogStatusEvent, -1, "count", len(t.ResMod), "val", val, "target", t.TargetIndex, "key", val.Key, "expiry", val.Expiry)
+	if val.Expiry != -1 {
+		val.Evt.SetEnded(val.Expiry)
+	}
 	t.ResMod = append(t.ResMod, val)
-	t.Core.Log.NewEvent("enemy mod added", core.LogStatusEvent, -1, "count", len(t.ResMod), "val", val, "target", t.TargetIndex, "key", val.Key, "expiry", val.Expiry)
 	// e.mod[key] = val
 
 	// Add task to check for mod expiry in debug instances
-	if t.Core.Flags.LogDebug && val.Expiry > -1 {
-		t.AddTask(func() {
-			if t.HasResMod(val.Key) {
-				return
-			}
-			t.Core.Log.NewEvent("enemy mod expired", core.LogStatusEvent, -1, "count", len(t.ResMod), "val", val, "target", t.TargetIndex, "key", val.Key, "expiry", val.Expiry)
-		}, "check-m-expiry", val.Expiry+1-t.Core.F)
-	}
+	// if t.Core.Flags.LogDebug && val.Expiry > -1 {
+	// 	t.AddTask(func() {
+	// 		if t.HasResMod(val.Key) {
+	// 			return
+	// 		}
+	// 		t.Core.Log.NewEvent("enemy mod expired", core.LogStatusEvent, -1, "count", len(t.ResMod), "val", val, "target", t.TargetIndex, "key", val.Key, "expiry", val.Expiry)
+	// 	}, "check-m-expiry", val.Expiry+1-t.Core.F)
+	// }
 }
 
 func (t *Tmpl) RemoveResMod(key string) {

--- a/pkg/core/character.go
+++ b/pkg/core/character.go
@@ -92,14 +92,14 @@ type CharStatMod struct {
 	Amount        func() ([]float64, bool) // Returns an array containing the stats boost and whether mod applies
 	ConditionTags []AttackTag
 	Expiry        int
-	Evt           LogEvent
+	Evt           LogEvent `json:"-"`
 }
 
 type PreDamageMod struct {
 	Key    string
 	Amount func(atk *AttackEvent, t Target) ([]float64, bool) // Returns an array containing the stats boost and whether mod applies
 	Expiry int
-	Evt    LogEvent
+	Evt    LogEvent `json:"-"`
 }
 
 type WeaponInfusion struct {
@@ -107,7 +107,7 @@ type WeaponInfusion struct {
 	Ele    EleType
 	Tags   []AttackTag
 	Expiry int
-	Evt    LogEvent
+	Evt    LogEvent `json:"-"`
 }
 
 type CDAdjust struct {
@@ -126,5 +126,5 @@ type ReactionBonusMod struct {
 	Key    string
 	Amount func(AttackInfo) (float64, bool)
 	Expiry int
-	Evt    LogEvent
+	Evt    LogEvent `json:"-"`
 }

--- a/pkg/core/character.go
+++ b/pkg/core/character.go
@@ -92,12 +92,14 @@ type CharStatMod struct {
 	Amount        func() ([]float64, bool) // Returns an array containing the stats boost and whether mod applies
 	ConditionTags []AttackTag
 	Expiry        int
+	Evt           LogEvent
 }
 
 type PreDamageMod struct {
 	Key    string
 	Amount func(atk *AttackEvent, t Target) ([]float64, bool) // Returns an array containing the stats boost and whether mod applies
 	Expiry int
+	Evt    LogEvent
 }
 
 type WeaponInfusion struct {
@@ -105,6 +107,7 @@ type WeaponInfusion struct {
 	Ele    EleType
 	Tags   []AttackTag
 	Expiry int
+	Evt    LogEvent
 }
 
 type CDAdjust struct {
@@ -123,4 +126,5 @@ type ReactionBonusMod struct {
 	Key    string
 	Amount func(AttackInfo) (float64, bool)
 	Expiry int
+	Evt    LogEvent
 }

--- a/pkg/core/target.go
+++ b/pkg/core/target.go
@@ -79,14 +79,14 @@ type ResistMod struct {
 	Value    float64
 	Duration int
 	Expiry   int
-	Evt      LogEvent
+	Evt      LogEvent `json:"-"`
 }
 
 type DefMod struct {
 	Key    string
 	Value  float64
 	Expiry int
-	Evt    LogEvent
+	Evt    LogEvent `json:"-"`
 }
 
 // func (c *Core) ReindexTargets() {

--- a/pkg/core/target.go
+++ b/pkg/core/target.go
@@ -79,12 +79,14 @@ type ResistMod struct {
 	Value    float64
 	Duration int
 	Expiry   int
+	Evt      LogEvent
 }
 
 type DefMod struct {
 	Key    string
 	Value  float64
 	Expiry int
+	Evt    LogEvent
 }
 
 // func (c *Core) ReindexTargets() {


### PR DESCRIPTION
this should let you click on mods for charstat, predamagemod, enemy res and def mod and see the duration

only issue is that refresh only shows the duration of that refresh but if you want to see the entire time that the buff is active you gotta find the original added...