### PR TITLE
custom global delay, frames framework, kazuha frame update

### DIFF
--- a/cmd/gcsim/.gitignore
+++ b/cmd/gcsim/.gitignore
@@ -3,3 +3,4 @@
 *.gz
 gcsim
 gcsim.exe
+config.txt

--- a/internal/characters/kazuha/abil.go
+++ b/internal/characters/kazuha/abil.go
@@ -6,6 +6,14 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core"
 )
 
+var hitmarks = [][]int{
+	{12},         //n1
+	{11},         //n2
+	{16, 25},     //n3
+	{15},         //n4
+	{15, 23, 31}, //n5
+}
+
 func (c *char) Attack(p map[string]int) (int, int) {
 
 	f, a := c.ActionFrames(core.ActionAttack, p)
@@ -23,7 +31,7 @@ func (c *char) Attack(p map[string]int) (int, int) {
 
 	for i, mult := range attack[c.NormalCounter] {
 		ai.Mult = mult[c.TalentLvlAttack()]
-		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.3, false, core.TargettableEnemy), f-2+i, f-2+i)
+		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.3, false, core.TargettableEnemy), hitmarks[c.NormalCounter][i], hitmarks[c.NormalCounter][i])
 	}
 
 	c.AdvanceNormalIndex()
@@ -48,7 +56,7 @@ func (c *char) ChargeAttack(p map[string]int) (int, int) {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1, false, core.TargettableEnemy), f-len(charge)+i, f-len(charge)+i)
+		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1, false, core.TargettableEnemy), 20+i, 20+i)
 	}
 
 	return f, a
@@ -74,7 +82,7 @@ func (c *char) HighPlungeAttack(p map[string]int) (int, int) {
 			Mult:           plunge[c.TalentLvlAttack()],
 			IgnoreInfusion: true,
 		}
-		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.3, false, core.TargettableEnemy), f-10, f-10)
+		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.3, false, core.TargettableEnemy), f, f)
 	}
 
 	//aoe dmg
@@ -91,7 +99,7 @@ func (c *char) HighPlungeAttack(p map[string]int) (int, int) {
 		IgnoreInfusion: true,
 	}
 
-	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1.5, false, core.TargettableEnemy), f-8, f-8)
+	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1.5, false, core.TargettableEnemy), f, f)
 
 	// a2 if applies
 	if c.a2Ele != core.NoElement {
@@ -137,7 +145,7 @@ func (c *char) skillPress(p map[string]int) (int, int) {
 		Durability: 25,
 		Mult:       skill[c.TalentLvlSkill()],
 	}
-	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1.5, false, core.TargettableEnemy), 0, 13)
+	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1.5, false, core.TargettableEnemy), 0, f)
 
 	c.QueueParticle("kazuha", 3, core.Anemo, 100)
 
@@ -169,7 +177,7 @@ func (c *char) skillHold(p map[string]int) (int, int) {
 		Mult:       skillHold[c.TalentLvlSkill()],
 	}
 
-	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1.5, false, core.TargettableEnemy), 0, 34)
+	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(1.5, false, core.TargettableEnemy), 0, f)
 
 	c.QueueParticle("kazuha", 4, core.Anemo, 100)
 

--- a/internal/characters/kazuha/frames.go
+++ b/internal/characters/kazuha/frames.go
@@ -8,48 +8,147 @@ func (c *char) ActionFrames(a core.ActionType, p map[string]int) (int, int) {
 	switch a {
 	case core.ActionAttack:
 		f := 0
+		a := 0
 		switch c.NormalCounter {
 		//TODO: need to add atkspd mod
 		case 0:
-			//add frames if last action is also attack
-			if c.Core.LastAction.Target == core.Kazuha && c.Core.LastAction.Typ == core.ActionAttack {
-				f += 60
-			}
-			f = 14
+			f = 12
+			a = 18
 		case 1:
-			f = 34 - 14
+			f = 11
+			a = 25
 		case 2:
-			f = 70 - 34 //hit at 60, 70
+			f = 25 //hit mark 16, 25
+			a = 35
 		case 3:
-			f = 97 - 70
+			f = 15 //hit mark
+			a = 40
 		case 4:
-			f = 140 - 97
+			f = 31 //hit mark 15, 23, 31
+			a = 71
 		}
 		f = int(float64(f) / (1 + c.Stat(core.AtkSpd)))
-		return f, f
+		return f, a
 	case core.ActionCharge:
-		return 44, 44 // kqm lib
+		return 21, 55 // kqm lib
 	case core.ActionHighPlunge:
 		c.Core.Log.NewEvent("plunge skill check", core.LogCharacterEvent, c.Index, "previous", c.Core.LastAction)
 		if c.Core.LastAction.Target == core.Kazuha && c.Core.LastAction.Typ == core.ActionSkill {
-			_, ok := c.Core.LastAction.Param["hold"]
-			if ok {
-				return 41, 41
+			h := c.Core.LastAction.Param["hold"]
+			if h > 0 {
+				return 41, 60
 			}
-			return 36, 36
+			return 36, 55
 		}
 		c.Core.Log.NewEvent("invalid plunge (missing skill use)", core.LogActionEvent, c.Index, "action", a)
 		return 0, 0
 	case core.ActionSkill:
-		_, ok := p["hold"]
-		if ok {
-			return 58, 58
+		h := p["hold"]
+		if h > 0 {
+			return 34, 180
 		}
-		return 27, 27
+		return 14, 88
 	case core.ActionBurst:
-		return 95, 95
+		return 95, 100
 	default:
 		c.Core.Log.NewEventBuildMsg(core.LogActionEvent, c.Index, "unknown action (invalid frames): ", a.String())
 		return 0, 0
+	}
+}
+
+func (c *char) InitCancelFrames() {
+	//normal cancels
+	c.SetNormalCancelFrames(0, core.ActionAttack, 16-12) //n1 -> next attack
+	c.SetNormalCancelFrames(0, core.ActionCharge, 16-12) //n1 -> charge
+
+	c.SetNormalCancelFrames(1, core.ActionAttack, 20-11) //n2 -> next attack
+	c.SetNormalCancelFrames(1, core.ActionCharge, 25-11) //n2 -> charge
+
+	c.SetNormalCancelFrames(2, core.ActionAttack, 30-25) //n3 -> next attack
+	c.SetNormalCancelFrames(2, core.ActionCharge, 35-25) //n3 -> charge
+
+	c.SetNormalCancelFrames(3, core.ActionAttack, 40-15) //n4 -> next attack
+	c.SetNormalCancelFrames(3, core.ActionCharge, 36-15) //n4 -> charge
+
+	c.SetNormalCancelFrames(4, core.ActionAttack, 71-31) //n5 -> next attack (n1)
+	// c.SetNormalCancelFrames(4, core.ActionCharge, 36-15) //n5 -> charge, missing this one
+
+	c.SetAbilCancelFrames(core.ActionCharge, core.ActionAttack, 55-21) //charge -> n1
+	c.SetAbilCancelFrames(core.ActionCharge, core.ActionSkill, 34-21)  //charge -> skill
+	c.SetAbilCancelFrames(core.ActionCharge, core.ActionBurst, 33-21)  //charge -> burst
+	c.SetAbilCancelFrames(core.ActionCharge, core.SwapCDFrames, 32-21) //charge -> swap
+
+	// c.SetAbilCancelFrames(core.ActionBurst, core.ActionAttack, 55-21) //burst -> n1
+	// c.SetAbilCancelFrames(core.ActionBurst, core.ActionSkill, 34-21)  //burst -> skill
+	c.SetAbilCancelFrames(core.ActionBurst, core.ActionDash, 100-95) //burst -> burst
+	c.SetAbilCancelFrames(core.ActionBurst, core.JumpFrames, 100-95) //burst -> burst
+	// c.SetAbilCancelFrames(core.ActionBurst, core.SwapCDFrames, 32-21) //burst -> swap
+
+	//skill press frames, dmg at 14
+	c.SetAbilCancelFrames(core.ActionSkill, core.ActionAttack, 85-14)     //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkill, core.ActionBurst, 85-14)      //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkill, core.ActionDash, 85-14)       //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkill, core.ActionJump, 85-14)       //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkill, core.ActionSwap, 80-14)       //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkill, core.ActionHighPlunge, 27-14) //58 frames before you can start plunge
+
+	//skill hold frames
+	c.SetAbilCancelFrames(core.ActionSkillHoldFramesOnly, core.ActionAttack, 177-34)    //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkillHoldFramesOnly, core.ActionBurst, 177-34)     //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkillHoldFramesOnly, core.ActionDash, 177-34)      //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkillHoldFramesOnly, core.ActionJump, 177-34)      //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkillHoldFramesOnly, core.ActionSwap, 177-34)      //85 frames to float down
+	c.SetAbilCancelFrames(core.ActionSkillHoldFramesOnly, core.ActionHighPlunge, 58-34) //58 frames before you can start plunge
+
+}
+
+func (c *char) ActionInterruptableDelay(next core.ActionType, p map[string]int) int {
+	//provide override for skill and plunge cause it depends on hold vs press
+	switch next {
+	case core.ActionSkill:
+		//have to check for press vs hold
+		h := p["hold"]
+		if h > 0 {
+			return c.Tmpl.ActionInterruptableDelay(core.ActionSkillHoldFramesOnly, p)
+		}
+		return c.Tmpl.ActionInterruptableDelay(next, p)
+	case core.ActionHighPlunge:
+		//depends on if it was hold or press before so this has to be custom
+		prev := c.Core.LastAction
+		if prev.Typ != core.ActionSkill {
+			//this should not happen
+			c.Core.Log.NewEvent("ERROR: plunge used without skill use on kazuha!!", core.LogActionEvent, c.Index)
+			return 0
+		}
+		//check if hold
+		h := prev.Param["hold"]
+		if h > 0 {
+			return plungeHoldSkillFrames(next)
+		}
+		return plungePressSkillFrames(next)
+	default:
+		return c.Tmpl.ActionInterruptableDelay(next, p)
+	}
+}
+
+func plungePressSkillFrames(next core.ActionType) int {
+	switch next {
+	case core.ActionAttack:
+		return 55 - 36
+	case core.ActionBurst:
+		return 55 - 36
+	default:
+		return 47 - 36
+	}
+}
+
+func plungeHoldSkillFrames(next core.ActionType) int {
+	switch next {
+	case core.ActionAttack:
+		return 60 - 42
+	case core.ActionBurst:
+		return 60 - 42
+	default:
+		return 50 - 42
 	}
 }

--- a/internal/characters/kazuha/kazuha.go
+++ b/internal/characters/kazuha/kazuha.go
@@ -33,6 +33,8 @@ func NewChar(s *core.Core, p core.CharacterProfile) (core.Character, error) {
 	c.NormalHitNum = 5
 	c.CharZone = core.ZoneInazuma
 
+	c.InitCancelFrames()
+
 	return &c, nil
 }
 

--- a/internal/tmpl/action/action.go
+++ b/internal/tmpl/action/action.go
@@ -228,7 +228,7 @@ func (a *Ctrl) execAction(n *core.ActionItem) (int, bool, error) {
 		"swap_cd_post", a.core.SwapCD,
 		"stam_post", a.core.Stam,
 		"animation", f,
-	)
+	).SetEnded(a.core.F + f)
 
 	a.core.LastAction = *n
 

--- a/internal/tmpl/character/actions.go
+++ b/internal/tmpl/character/actions.go
@@ -46,11 +46,6 @@ func (c *Tmpl) ActionStam(a core.ActionType, p map[string]int) float64 {
 	}
 }
 
-func (c *Tmpl) ActionFrames(a core.ActionType, p map[string]int) (int, int) {
-	c.Core.Log.NewEvent("ActionFrames not implemented", core.LogActionEvent, c.Index)
-	return 0, 0
-}
-
 func (c *Tmpl) ActionReady(a core.ActionType, p map[string]int) bool {
 	switch a {
 	case core.ActionBurst:
@@ -63,10 +58,6 @@ func (c *Tmpl) ActionReady(a core.ActionType, p map[string]int) bool {
 		return c.ActionCD[a] <= c.Core.F
 	}
 	return true
-}
-
-func (c *Tmpl) ActionInterruptableDelay(next core.ActionType) int {
-	return 0
 }
 
 func (c *Tmpl) AddCDAdjustFunc(rd core.CDAdjust) {

--- a/internal/tmpl/character/frames.go
+++ b/internal/tmpl/character/frames.go
@@ -16,7 +16,7 @@ func (t *Tmpl) ActionInterruptableDelay(next core.ActionType, p map[string]int) 
 		//check our hit counter; should be hit counter - 1
 		lastHit := t.NormalCounter - 1
 		if lastHit < 0 {
-			lastHit = t.NormalHitNum
+			lastHit = t.NormalHitNum - 1
 		}
 		n, ok := t.normalCancelFrames[lastHit]
 		if !ok {

--- a/internal/tmpl/character/frames.go
+++ b/internal/tmpl/character/frames.go
@@ -1,0 +1,52 @@
+package character
+
+import "github.com/genshinsim/gcsim/pkg/core"
+
+func (t *Tmpl) ActionFrames(a core.ActionType, p map[string]int) (int, int) {
+	t.Core.Log.NewEvent("ActionFrames not implemented", core.LogActionEvent, t.Index)
+	return 0, 0
+}
+
+func (t *Tmpl) ActionInterruptableDelay(next core.ActionType, p map[string]int) int {
+	switch t.Core.LastAction.Typ {
+	case core.ActionSwap:
+		//if not same character then there should be no delay
+		return 0
+	case core.ActionAttack:
+		//check our hit counter; should be hit counter - 1
+		lastHit := t.NormalCounter - 1
+		if lastHit < 0 {
+			lastHit = t.NormalHitNum
+		}
+		n, ok := t.normalCancelFrames[lastHit]
+		if !ok {
+			//sanity check just in case no frames are set
+			return 0
+		}
+		return n[next]
+	default:
+		n, ok := t.cancelFrames[t.Core.LastAction.Typ]
+		if !ok {
+			return 0
+		}
+		return n[next]
+	}
+}
+
+func (t *Tmpl) SetNormalCancelFrames(normalHitNum int, nextAbil core.ActionType, frames int) {
+
+	if _, ok := t.normalCancelFrames[normalHitNum]; !ok {
+		t.normalCancelFrames[normalHitNum] = make(map[core.ActionType]int)
+	}
+
+	t.normalCancelFrames[normalHitNum][nextAbil] = frames
+}
+
+func (t *Tmpl) SetAbilCancelFrames(prevAbil core.ActionType, nextAbil core.ActionType, frames int) {
+
+	if _, ok := t.cancelFrames[prevAbil]; !ok {
+		t.cancelFrames[prevAbil] = make(map[core.ActionType]int)
+	}
+
+	t.cancelFrames[prevAbil][nextAbil] = frames
+}

--- a/internal/tmpl/character/tmpl.go
+++ b/internal/tmpl/character/tmpl.go
@@ -41,44 +41,51 @@ type Tmpl struct {
 	NormalHitNum  int //how many hits in a normal combo
 	NormalCounter int
 
+	//map to track frames
+	normalCancelFrames map[int]map[core.ActionType]int             //this maps normal hit number into
+	cancelFrames       map[core.ActionType]map[core.ActionType]int //this maps all other skills
+
 	//infusion
 	Infusion core.WeaponInfusion //TODO currently just overides the old; disregarding any existing
 }
 
 func NewTemplateChar(x *core.Core, p core.CharacterProfile) (*Tmpl, error) {
-	c := Tmpl{}
-	c.Core = x
-	c.Rand = x.Rand
+	t := Tmpl{}
+	t.Core = x
+	t.Rand = x.Rand
 
-	c.ActionCD = make([]int, core.EndActionType)
-	c.Mods = make([]core.CharStatMod, 0, 10)
-	c.Tags = make(map[string]int)
-	c.CDReductionFuncs = make([]core.CDAdjust, 0, 5)
-	c.Base = p.Base
-	c.Weapon = p.Weapon
-	c.Talents = p.Talents
-	c.SkillCon = 3
-	c.BurstCon = 5
-	if c.Talents.Attack < 1 || c.Talents.Attack > 15 {
-		return nil, fmt.Errorf("invalid talent lvl: attack - %v", c.Talents.Attack)
+	t.ActionCD = make([]int, core.EndActionType)
+	t.Mods = make([]core.CharStatMod, 0, 10)
+	t.Tags = make(map[string]int)
+	t.CDReductionFuncs = make([]core.CDAdjust, 0, 5)
+	t.Base = p.Base
+	t.Weapon = p.Weapon
+	t.Talents = p.Talents
+	t.SkillCon = 3
+	t.BurstCon = 5
+	if t.Talents.Attack < 1 || t.Talents.Attack > 15 {
+		return nil, fmt.Errorf("invalid talent lvl: attack - %v", t.Talents.Attack)
 	}
-	if c.Talents.Attack < 1 || c.Talents.Attack > 12 {
-		return nil, fmt.Errorf("invalid talent lvl: skill - %v", c.Talents.Skill)
+	if t.Talents.Attack < 1 || t.Talents.Attack > 12 {
+		return nil, fmt.Errorf("invalid talent lvl: skill - %v", t.Talents.Skill)
 	}
-	if c.Talents.Attack < 1 || c.Talents.Attack > 12 {
-		return nil, fmt.Errorf("invalid talent lvl: burst - %v", c.Talents.Burst)
+	if t.Talents.Attack < 1 || t.Talents.Attack > 12 {
+		return nil, fmt.Errorf("invalid talent lvl: burst - %v", t.Talents.Burst)
 	}
 	for i, v := range p.Stats {
-		c.Stats[i] = v
+		t.Stats[i] = v
 	}
 	if p.Base.StartHP > -1 {
-		c.Core.Log.NewEvent("setting starting hp", core.LogCharacterEvent, c.Index, "character", p.Base.Key.String(), "hp", p.Base.StartHP)
-		c.HPCurrent = p.Base.StartHP
+		t.Core.Log.NewEvent("setting starting hp", core.LogCharacterEvent, t.Index, "character", p.Base.Key.String(), "hp", p.Base.StartHP)
+		t.HPCurrent = p.Base.StartHP
 	} else {
-		c.HPCurrent = math.MaxInt64
+		t.HPCurrent = math.MaxInt64
 	}
 
-	return &c, nil
+	t.normalCancelFrames = make(map[int]map[core.ActionType]int)
+	t.cancelFrames = make(map[core.ActionType]map[core.ActionType]int)
+
+	return &t, nil
 }
 
 // Character initialization function. Occurs AFTER all char/weapons are initially loaded

--- a/pkg/core/action.go
+++ b/pkg/core/action.go
@@ -111,6 +111,8 @@ const (
 	ActionSwap
 	ActionWalk
 	EndActionType
+	//these are only used for frames purposes and that's why it's after end
+	ActionSkillHoldFramesOnly
 )
 
 var astr = []string{

--- a/pkg/core/cfg.go
+++ b/pkg/core/cfg.go
@@ -39,7 +39,7 @@ func (c *SimulationConfig) Clone() SimulationConfig {
 type SimulatorSettings struct {
 	Duration   int
 	DamageMode bool
-	SwapDelay  int
+	Delays     Delays
 
 	//modes
 	QueueMode  SimulationQueueMode

--- a/pkg/core/character.go
+++ b/pkg/core/character.go
@@ -45,7 +45,7 @@ type Character interface {
 	// ActionFrames(a ActionType, p map[string]int) int
 	//return the number of frames the current action must wait before it can be
 	//executed;
-	ActionInterruptableDelay(next ActionType) int
+	ActionInterruptableDelay(next ActionType, p map[string]int) int
 
 	//char stat mods
 	AddMod(mod CharStatMod)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -214,7 +214,7 @@ func (c *Core) Swap(next CharKey) int {
 	return 1
 }
 
-func (c *Core) AnimationCancelDelay(next ActionType) int {
+func (c *Core) AnimationCancelDelay(next ActionType, p map[string]int) int {
 	//if last action is jump, dash, swap,
 	switch c.LastAction.Typ {
 	case ActionSwap:
@@ -225,7 +225,7 @@ func (c *Core) AnimationCancelDelay(next ActionType) int {
 		return 0
 	}
 	//other wise check with the current character
-	return c.Chars[c.ActiveChar].ActionInterruptableDelay(next)
+	return c.Chars[c.ActiveChar].ActionInterruptableDelay(next, p)
 }
 
 func (c *Core) UserCustomDelay() int {
@@ -246,7 +246,6 @@ func (c *Core) UserCustomDelay() int {
 	case ActionSwap:
 		d = c.Flags.Delays.Swap
 	}
-	c.Log.NewEvent("custom delay triggered", LogActionEvent, -1, "d", d, "param", c.LastAction.Param["delay"], "delays", c.Flags.Delays)
 	return c.LastAction.Param["delay"] + d
 }
 

--- a/pkg/parse/parseOptions.go
+++ b/pkg/parse/parseOptions.go
@@ -47,7 +47,37 @@ func parseOptions(p *Parser) (parseFn, error) {
 			case "swap_delay":
 				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
 				if err == nil {
-					p.cfg.Settings.SwapDelay, err = itemNumberToInt(n)
+					p.cfg.Settings.Delays.Swap, err = itemNumberToInt(n)
+				}
+			case "attack_delay":
+				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
+				if err == nil {
+					p.cfg.Settings.Delays.Attack, err = itemNumberToInt(n)
+				}
+			case "charge_delay":
+				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
+				if err == nil {
+					p.cfg.Settings.Delays.Charge, err = itemNumberToInt(n)
+				}
+			case "skill_delay":
+				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
+				if err == nil {
+					p.cfg.Settings.Delays.Skill, err = itemNumberToInt(n)
+				}
+			case "burst_delay":
+				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
+				if err == nil {
+					p.cfg.Settings.Delays.Burst, err = itemNumberToInt(n)
+				}
+			case "jump_delay":
+				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
+				if err == nil {
+					p.cfg.Settings.Delays.Jump, err = itemNumberToInt(n)
+				}
+			case "dash_delay":
+				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
+				if err == nil {
+					p.cfg.Settings.Delays.Dash, err = itemNumberToInt(n)
 				}
 			case "er_calc":
 				//does nothing thus far...

--- a/pkg/parse/parseOptions.go
+++ b/pkg/parse/parseOptions.go
@@ -79,6 +79,22 @@ func parseOptions(p *Parser) (parseFn, error) {
 				if err == nil {
 					p.cfg.Settings.Delays.Dash, err = itemNumberToInt(n)
 				}
+			case "frame_defaults":
+				n, err = p.acceptSeqReturnLast(itemEqual, itemIdentifier)
+				if err == nil {
+					switch n.val {
+					case "human":
+						p.cfg.Settings.Delays.Swap = 8
+						p.cfg.Settings.Delays.Attack = 5
+						p.cfg.Settings.Delays.Charge = 5
+						p.cfg.Settings.Delays.Skill = 5
+						p.cfg.Settings.Delays.Burst = 5
+						p.cfg.Settings.Delays.Dash = 5
+						p.cfg.Settings.Delays.Jump = 5
+					default:
+						return nil, fmt.Errorf("unrecognized option for frame_defaults specified: %v", n.val)
+					}
+				}
 			case "er_calc":
 				//does nothing thus far...
 			default:

--- a/pkg/simulation/core.go
+++ b/pkg/simulation/core.go
@@ -50,8 +50,9 @@ func NewCore(seed int64, debug bool, cfg core.SimulatorSettings) (*core.Core, er
 		return nil, errors.New("no action mode set - please add either mode=sl or mode=apl to the options")
 	}
 
-	if cfg.SwapDelay > 0 {
-		c.Flags.SwapFrames = cfg.SwapDelay
+	c.Flags.Delays = cfg.Delays
+	if c.Flags.Delays.Swap == 0 {
+		c.Flags.Delays.Swap = 1 //default 1 frame if none set
 	}
 
 	return c, nil

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -111,8 +111,9 @@ func (s *Simulation) AdvanceFrame() error {
 		var delay int
 		//check if the current action is executable right now; if not then delay
 		act, isAction := s.queue[0].(*core.ActionItem)
-		if isAction {
+		if isAction && s.lastActionCheckedAt != s.lastActionUsedAt {
 			delay = s.C.AnimationCancelDelay(act.Typ) + s.C.UserCustomDelay()
+			s.lastActionCheckedAt = s.lastActionUsedAt
 		}
 
 		if delay > 0 {
@@ -127,6 +128,7 @@ func (s *Simulation) AdvanceFrame() error {
 		// )
 
 		s.skip, done, err = s.C.Action.Exec(s.queue[0])
+		s.lastActionUsedAt = s.C.F
 		if err != nil {
 			return err
 		}

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -124,24 +124,24 @@ func (s *Simulation) AdvanceFrame() error {
 		//so if current frame - when the last action is used is >= delay, then we shouldn't
 		//delay at all
 		if s.C.F-s.lastActionUsedAt >= delay {
-			s.C.Log.NewEvent(
-				"custom delay skipped",
-				core.LogActionEvent,
-				-1,
-				"time_passed_since_last", s.C.F-s.lastActionUsedAt,
-				"total_delay", delay,
-				"param", s.C.LastAction.Param["delay"],
-				"default_delays", s.C.Flags.Delays,
-			)
+			// s.C.Log.NewEvent(
+			// 	"custom delay skipped",
+			// 	core.LogActionEvent,
+			// 	-1,
+			// 	"time_passed_since_last", s.C.F-s.lastActionUsedAt,
+			// 	"total_delay", delay,
+			// 	"param", s.C.LastAction.Param["delay"],
+			// 	"default_delays", s.C.Flags.Delays,
+			// )
 			delay = 0
 		}
 
 		//other wise we can add delay
 		if delay > 0 {
 			s.C.Log.NewEvent(
-				"custom delay triggered",
+				"animation delay triggered",
 				core.LogActionEvent,
-				-1,
+				s.C.ActiveChar,
 				"total_delay", delay,
 				"param", s.C.LastAction.Param["delay"],
 				"default_delays", s.C.Flags.Delays,

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -108,15 +108,44 @@ func (s *Simulation) AdvanceFrame() error {
 
 	if len(s.queue) > 0 {
 
+		//here we need to check for delay but only if the next action is an action
+		//i.e. not a wait
 		var delay int
-		//check if the current action is executable right now; if not then delay
 		act, isAction := s.queue[0].(*core.ActionItem)
-		if isAction && s.lastActionCheckedAt != s.lastActionUsedAt {
-			delay = s.C.AnimationCancelDelay(act.Typ) + s.C.UserCustomDelay()
-			s.lastActionCheckedAt = s.lastActionUsedAt
+
+		//we need to check for when the previous action finished "executing"
+		//this is because sometimes the next action isn't queued for a while
+		//so we can end up with a situation where the last action was queued 100 frames ago
+		//and then we're still trying to add more delay on top of 100 frame
+		if isAction {
+			delay = s.C.AnimationCancelDelay(act.Typ, act.Param) + s.C.UserCustomDelay()
 		}
 
+		//so if current frame - when the last action is used is >= delay, then we shouldn't
+		//delay at all
+		if s.C.F-s.lastActionUsedAt >= delay {
+			s.C.Log.NewEvent(
+				"custom delay skipped",
+				core.LogActionEvent,
+				-1,
+				"time_passed_since_last", s.C.F-s.lastActionUsedAt,
+				"total_delay", delay,
+				"param", s.C.LastAction.Param["delay"],
+				"default_delays", s.C.Flags.Delays,
+			)
+			delay = 0
+		}
+
+		//other wise we can add delay
 		if delay > 0 {
+			s.C.Log.NewEvent(
+				"custom delay triggered",
+				core.LogActionEvent,
+				-1,
+				"total_delay", delay,
+				"param", s.C.LastAction.Param["delay"],
+				"default_delays", s.C.Flags.Delays,
+			)
 			s.skip = delay
 			return nil
 		}
@@ -128,7 +157,8 @@ func (s *Simulation) AdvanceFrame() error {
 		// )
 
 		s.skip, done, err = s.C.Action.Exec(s.queue[0])
-		s.lastActionUsedAt = s.C.F
+		//last action used should then be current frame + how much we are skipping (i.e. first frame queueable)
+		s.lastActionUsedAt = s.C.F + s.skip
 		if err != nil {
 			return err
 		}

--- a/pkg/simulation/sim.go
+++ b/pkg/simulation/sim.go
@@ -18,6 +18,9 @@ type Simulation struct {
 	lastEnergyDrop int
 	//result
 	stats Result
+	//prevs action that was checked
+	lastActionUsedAt    int
+	lastActionCheckedAt int
 }
 
 func New(cfg core.SimulationConfig, c *core.Core) (*Simulation, error) {

--- a/pkg/simulation/sim.go
+++ b/pkg/simulation/sim.go
@@ -19,8 +19,7 @@ type Simulation struct {
 	//result
 	stats Result
 	//prevs action that was checked
-	lastActionUsedAt    int
-	lastActionCheckedAt int
+	lastActionUsedAt int
 }
 
 func New(cfg core.SimulationConfig, c *core.Core) (*Simulation, error) {


### PR DESCRIPTION
fixes #267 
@Tsym-or-Tysm this one probably need extensive testing

I tested with the following config and it works fine but I'm not overly confident on the logic especially on `/pkg/simulation/run.go` L114

```
options debug=true iteration=1 duration=90 workers=24 mode=apl attack_delay=100 skill_delay=100;

bennett char lvl=90/90 cons=5 talent=9,9,9; 
bennett add weapon="aquilafavonia" refine=1 lvl=90/90;

##Default Enemy
target lvl=100 pyro=0.1 dendro=0.1 hydro=0.1 electro=0.1 geo=0.1 anemo=0.1 physical=.1 cryo=.1;


active bennett;

bennett attack;
```