### PR TITLE
change yae totem status to oldest_totem_expiry

### DIFF
--- a/internal/characters/yaemiko/yaemiko.go
+++ b/internal/characters/yaemiko/yaemiko.go
@@ -22,7 +22,7 @@ type char struct {
 }
 
 const (
-	yaeTotemStatus = "oldestTotemTime"
+	yaeTotemStatus = "yae_oldest_totem_expiry"
 	yaeTotemCount  = "totems"
 )
 


### PR DESCRIPTION
fixes #332 

test config: https://gcsim.app/viewer/share/NzAud0AZxqV_otlG-JWEu

status duration is 900, set to attack only if expiry < 500, attack starts at frame 401 as expected