### PR TITLE
fix beidou q proc'ing off-field

### DIFF
--- a/internal/characters/beidou/abil.go
+++ b/internal/characters/beidou/abil.go
@@ -143,6 +143,10 @@ func (c *char) burstProc() {
 		if ae.Info.AttackTag != core.AttackTagNormal && ae.Info.AttackTag != core.AttackTagExtra {
 			return false
 		}
+		//make sure the person triggering the attack is on field still
+		if ae.Info.ActorIndex != c.Core.ActiveChar {
+			return false
+		}
 		if c.Core.Status.Duration("beidouburst") == 0 {
 			return false
 		}


### PR DESCRIPTION
Fix issue with Beidou Q proc'ing on normals that hit after char is already no longer on field