### PR TITLE
Add infusion condition

### DIFF
--- a/internal/tmpl/character/tmpl.go
+++ b/internal/tmpl/character/tmpl.go
@@ -225,6 +225,17 @@ func (c *Tmpl) ReactBonusModIsActive(key string) bool {
 	return true
 }
 
+func (c *Tmpl) WeaponInfuseIsActive(key string) bool {
+	if c.Infusion.Key != key {
+		return false
+	}
+	//check expiry
+	if c.Infusion.Expiry < c.Core.F && c.Infusion.Expiry > -1 {
+		return false
+	}
+	return true
+}
+
 func (t *Tmpl) AddReactBonusMod(mod core.ReactionBonusMod) {
 	ind := -1
 	for i, v := range t.ReactMod {

--- a/internal/tmpl/queue/conditions.go
+++ b/internal/tmpl/queue/conditions.go
@@ -58,6 +58,8 @@ func (q *Queuer) evalCond(cond core.Condition) (bool, error) {
 		return q.evalAbilReady(cond)
 	case ".mods":
 		return q.evalCharMods(cond)
+	case ".infusion":
+		return q.evalInfusion(cond)
 	}
 	return false, nil
 }

--- a/internal/tmpl/queue/infusion.go
+++ b/internal/tmpl/queue/infusion.go
@@ -1,0 +1,28 @@
+package queue
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/genshinsim/gcsim/pkg/core"
+)
+
+func (q *Queuer) evalInfusion(cond core.Condition) (bool, error) {
+	if len(cond.Fields) < 3 {
+		return false, errors.New("eval infusion: unexpected short field, expected at least 3")
+	}
+	name := strings.TrimPrefix(cond.Fields[1], ".")
+	key := core.CharNameToKey[name]
+	char, ok := q.core.CharByName(key)
+	if !ok {
+		return false, errors.New("eval infusion: invalid char in condition")
+	}
+
+	active := 0
+	inf := strings.TrimPrefix(cond.Fields[2], ".")
+	if char.WeaponInfuseIsActive(inf) {
+		active = 1
+	}
+
+	return compInt(cond.Op, active, cond.Value), nil
+}

--- a/pkg/core/character.go
+++ b/pkg/core/character.go
@@ -52,6 +52,7 @@ type Character interface {
 	ModIsActive(key string) bool
 	AddPreDamageMod(mod PreDamageMod)
 	AddWeaponInfuse(inf WeaponInfusion)
+	WeaponInfuseIsActive(key string) bool
 	AddReactBonusMod(mod ReactionBonusMod)
 	ReactBonus(AttackInfo) float64
 


### PR DESCRIPTION
Implementation of #347, but instead of the element now the name of the infusion

| field1     | field2           | field3                                          | field4 | description
| ---        | ---              | ---                                             | ---    | ---
| `infusion` | `any char name`  | weapon infusion name  | none | is active a weapon infusion (`1` - yes, `0` - no)

weapon infusion names:
- `aloy-rushing-ice` (Aloy Skill);
- `ayaka-dash` (Ayaka Dash);
- `bennett-fire-weapon` (Bennett Burst with C6);
- `chongyun-ice-weapon` (Chongyun Skill);
- `diluc-fire-weapon` (Diluc Burst);
- `a2` (Keqing Skill);