### PR TITLE
Issue 435 raiden e proc on reaction

### DIFF
--- a/internal/characters/raiden/abil.go
+++ b/internal/characters/raiden/abil.go
@@ -234,6 +234,10 @@ func (c *char) eyeOnDamage() {
 		if c.Core.Status.Duration("raidenskill") == 0 {
 			return false
 		}
+		//ignore EC and hydro swirl damage
+		if ae.Info.AttackTag == core.AttackTagECDamage || ae.Info.AttackTag == core.AttackTagSwirlHydro {
+			return false
+		}
 		//ignore self dmg
 		if ae.Info.Abil == "Eye of Stormy Judgement" {
 			return false

--- a/internal/characters/raiden/abil.go
+++ b/internal/characters/raiden/abil.go
@@ -234,10 +234,6 @@ func (c *char) eyeOnDamage() {
 		if c.Core.Status.Duration("raidenskill") == 0 {
 			return false
 		}
-		//ignore reaction damage
-		if ae.Info.AttackTag > core.ReactionAttackDelim {
-			return false
-		}
 		//ignore self dmg
 		if ae.Info.Abil == "Eye of Stormy Judgement" {
 			return false


### PR DESCRIPTION
Raiden E now procs on reaction damage, except for Hydro Swirl and EC.