### PR TITLE
Add remaining swords

### DIFF
--- a/internal/weapons/common/common.go
+++ b/internal/weapons/common/common.go
@@ -213,3 +213,9 @@ func Wavebreaker(char core.Character, c *core.Core, r int, param map[string]int)
 	}, fmt.Sprintf("wavebreaker-%v", char.Name()))
 
 }
+
+func NoEffectWeapon(key string) core.NewWeaponFunc {
+	return func(char core.Character, c *core.Core, r int, param map[string]int) string {
+		return key
+	}
+}

--- a/internal/weapons/sword/darkironsword/darkironsword.go
+++ b/internal/weapons/sword/darkironsword/darkironsword.go
@@ -1,0 +1,49 @@
+package darkironsword
+
+import (
+	"fmt"
+	"github.com/genshinsim/gcsim/pkg/core"
+)
+
+func init() {
+	core.RegisterWeaponFunc("darkironsword", weapon)
+}
+
+// Overloaded
+// Upon causing an Overloaded, Superconduct, Electro-Charged, or an Electro-infused Swirl reaction,
+// ATK is increased by 20/25/30/35/40% for 12s.
+func weapon(char core.Character, c *core.Core, r int, param map[string]int) string {
+	dur := 12 * 60
+	m := make([]float64, core.EndStatType)
+	m[core.ATKP] = 0.15 + float64(r)*0.05
+
+	c.Events.Subscribe(core.OnDamage, func(args ...interface{}) bool {
+		atk := args[1].(*core.AttackEvent)
+
+		if atk.Info.ActorIndex != char.CharIndex() {
+			return false
+		}
+
+		//ignore if character not on field
+		if c.ActiveChar != char.CharIndex() {
+			return false
+		}
+
+		switch atk.Info.AttackTag {
+		case core.AttackTagSuperconductDamage,
+			core.AttackTagECDamage,
+			core.AttackTagOverloadDamage,
+			core.AttackTagSwirlElectro:
+			char.AddMod(core.CharStatMod{
+				Key: "darkironsword",
+				Amount: func() ([]float64, bool) {
+					return m, true
+				},
+				Expiry: c.F + dur,
+			})
+		}
+
+		return false
+	}, fmt.Sprintf("darkironsword-%v", char.Name()))
+	return "darkironsword"
+}

--- a/internal/weapons/sword/silversword/silversword.go
+++ b/internal/weapons/sword/silversword/silversword.go
@@ -1,0 +1,10 @@
+package silversword
+
+import (
+	"github.com/genshinsim/gcsim/internal/weapons/common"
+	"github.com/genshinsim/gcsim/pkg/core"
+)
+
+func init() {
+	core.RegisterWeaponFunc("silversword", common.NoEffectWeapon("silversword"))
+}

--- a/internal/weapons/sword/swordofdescension/swordofdescension.go
+++ b/internal/weapons/sword/swordofdescension/swordofdescension.go
@@ -1,0 +1,86 @@
+package swordofdescension
+
+import (
+	"fmt"
+	"github.com/genshinsim/gcsim/pkg/core"
+)
+
+func init() {
+	core.RegisterWeaponFunc("swordofdescension", weapon)
+}
+
+// Descension
+// This weapon's effect is only applied on the following platform(s):
+// "PlayStation Network"
+// Hitting enemies with Normal or Charged Attacks grants a 50% chance to deal 200% ATK as DMG in a small AoE. This effect can only occur once every 10s.
+// Additionally, if the Traveler equips the Sword of Descension, their ATK is increased by 66.
+//  * Weapon refines do not affect this weapon
+func weapon(char core.Character, c *core.Core, r int, param map[string]int) string {
+	icd := 0
+	m := make([]float64, core.EndStatType)
+
+	switch char.Key() {
+	case core.TravelerCryo,
+		core.TravelerAnemo,
+		core.TravelerDendro,
+		core.TravelerElectro,
+		core.TravelerGeo,
+		core.TravelerHydro:
+		char.AddMod(core.CharStatMod{
+			Key:    "swordofdescension",
+			Expiry: -1,
+			Amount: func() ([]float64, bool) {
+				m[core.ATK] = 66
+				return m, true
+			},
+		})
+		break
+	default:
+	}
+
+	c.Events.Subscribe(core.OnDamage, func(args ...interface{}) bool {
+		atk := args[1].(*core.AttackEvent)
+
+		if atk.Info.ActorIndex != char.CharIndex() {
+			return false
+		}
+
+		// ignore if character not on field
+		if c.ActiveChar != char.CharIndex() {
+			return false
+		}
+
+		// Ignore if neither a charged nor normal attack
+		if atk.Info.AttackTag != core.AttackTagNormal && atk.Info.AttackTag != core.AttackTagExtra {
+			return false
+		}
+
+		// Ignore 50% of the time, 1:1 ratio
+		if c.Rand.Float64() < 0.5 {
+			return false
+		}
+
+		// Ignore if icd is still up
+		if c.F < icd {
+			return false
+		}
+
+		icd = c.F + 10*60
+
+		ai := core.AttackInfo{
+			ActorIndex: char.CharIndex(),
+			Abil:       "Sword of Descension Proc",
+			AttackTag:  core.AttackTagWeaponSkill,
+			ICDTag:     core.ICDTagNone,
+			ICDGroup:   core.ICDGroupDefault,
+			Element:    core.Physical,
+			Durability: 100,
+			Mult:       0.50,
+		}
+
+		c.Combat.QueueAttack(ai, core.NewDefCircHit(2, false, core.TargettableEnemy), 0, 1)
+
+		return false
+	}, fmt.Sprintf("swordofdescension-%v", char.Name()))
+	return "swordofdescension"
+}

--- a/internal/weapons/sword/swordofdescension/swordofdescension.go
+++ b/internal/weapons/sword/swordofdescension/swordofdescension.go
@@ -19,13 +19,7 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 	icd := 0
 	m := make([]float64, core.EndStatType)
 
-	switch char.Key() {
-	case core.TravelerCryo,
-		core.TravelerAnemo,
-		core.TravelerDendro,
-		core.TravelerElectro,
-		core.TravelerGeo,
-		core.TravelerHydro:
+	if char.Key() < core.TravelerDelim {
 		char.AddMod(core.CharStatMod{
 			Key:    "swordofdescension",
 			Expiry: -1,
@@ -34,8 +28,6 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 				return m, true
 			},
 		})
-		break
-	default:
 	}
 
 	c.Events.Subscribe(core.OnDamage, func(args ...interface{}) bool {
@@ -55,13 +47,13 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 			return false
 		}
 
-		// Ignore 50% of the time, 1:1 ratio
-		if c.Rand.Float64() < 0.5 {
+		// Ignore if icd is still up
+		if c.F < icd {
 			return false
 		}
 
-		// Ignore if icd is still up
-		if c.F < icd {
+		// Ignore 50% of the time, 1:1 ratio
+		if c.Rand.Float64() < 0.5 {
 			return false
 		}
 
@@ -75,7 +67,7 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 			ICDGroup:   core.ICDGroupDefault,
 			Element:    core.Physical,
 			Durability: 100,
-			Mult:       0.50,
+			Mult:       2.00,
 		}
 
 		c.Combat.QueueAttack(ai, core.NewDefCircHit(2, false, core.TargettableEnemy), 0, 1)

--- a/internal/weapons/sword/travelershandysword/travelershandysword.go
+++ b/internal/weapons/sword/travelershandysword/travelershandysword.go
@@ -1,0 +1,32 @@
+package travelershandysword
+
+import (
+	"fmt"
+	"github.com/genshinsim/gcsim/pkg/core"
+)
+
+func init() {
+	core.RegisterWeaponFunc("travelershandysword", weapon)
+}
+
+// Each Elemental Orb or Particle collected restores 1/1.25/1.5/1.75/2% HP.
+func weapon(char core.Character, c *core.Core, r int, param map[string]int) string {
+	c.Events.Subscribe(core.OnParticleReceived, func(args ...interface{}) bool {
+		// ignore if character not on field
+		if c.ActiveChar != char.CharIndex() {
+			return false
+		}
+
+		c.Health.Heal(core.HealInfo{
+			Caller:  char.CharIndex(),
+			Target:  c.ActiveChar,
+			Message: "Traveler's Handy Sword (Proc)",
+			Src:     char.MaxHP() * (0.0075 + float64(r)*0.0025),
+			Bonus:   char.Stat(core.Heal),
+		})
+
+		return false
+	}, fmt.Sprintf("travelershandysword-%v", char.Name()))
+
+	return "travelershandysword"
+}

--- a/internal/weapons/sword/travelershandysword/travelershandysword.go
+++ b/internal/weapons/sword/travelershandysword/travelershandysword.go
@@ -18,11 +18,9 @@ func weapon(char core.Character, c *core.Core, r int, param map[string]int) stri
 		}
 
 		c.Health.Heal(core.HealInfo{
-			Caller:  char.CharIndex(),
-			Target:  c.ActiveChar,
+			Type:    core.HealTypePercent,
 			Message: "Traveler's Handy Sword (Proc)",
-			Src:     char.MaxHP() * (0.0075 + float64(r)*0.0025),
-			Bonus:   char.Stat(core.Heal),
+			Src:     0.0075 + float64(r)*0.0025,
 		})
 
 		return false

--- a/pkg/simulation/imports.go
+++ b/pkg/simulation/imports.go
@@ -167,6 +167,7 @@ import (
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/black"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/blackcliff"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/cinnabar"
+	_ "github.com/genshinsim/gcsim/internal/weapons/sword/darkironsword"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/dullblade"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/favonius"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/festering"
@@ -183,7 +184,10 @@ import (
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/prototype"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/royal"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/sacrifical"
+	_ "github.com/genshinsim/gcsim/internal/weapons/sword/silversword"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/skyrider"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/skyward"
 	_ "github.com/genshinsim/gcsim/internal/weapons/sword/summit"
+	_ "github.com/genshinsim/gcsim/internal/weapons/sword/swordofdescension"
+	_ "github.com/genshinsim/gcsim/internal/weapons/sword/travelershandysword"
 )


### PR DESCRIPTION
* Implements darkironsword, silversword, swordofdescension, travelershandysword
* Add common.NoEffectWeapon(string) for weapons that are primarily stat sticks and offer no meaningful weapon effect for the sim.
* Add simple tests for the weapon effects.

Weapon tests;

* Traveler's Handy Sword Heals - https://gcsim.app/viewer/share/perm_UsWjYrLkVo-1ajtzWtSwX
* Sword of Descension Attack Procs & Buff Applies to Trav - https://gcsim.app/viewer/share/perm_7Sx-jirFSYoOTe2oBeffX
* Dark Iron Sword procs on superconduct, overload, electrocharge - https://gcsim.app/viewer/share/perm_ZvZcdhrcAHJ6AzqgQgT93