### PR TITLE
Move Yoimiya's skill buff effect

### DIFF
--- a/internal/characters/yoimiya/abil.go
+++ b/internal/characters/yoimiya/abil.go
@@ -31,14 +31,14 @@ func (c *char) Attack(p map[string]int) (int, int) {
 		if c.Core.Status.Duration("yoimiyaskill") > 0 {
 			// ds.ICDTag = core.ICDTagNone
 			//multiplier
-			ai.Element = core.Pyro
+
 			ai.Mult = skill[c.TalentLvlSkill()] * mult[c.TalentLvlAttack()]
 			c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", mult[c.TalentLvlAttack()], "next", ai.Mult, "char", c.Index)
 		} else {
 			ai.Mult = mult[c.TalentLvlAttack()]
 		}
 
-		totalMV += mult[c.TalentLvlAttack()]
+		totalMV += ai.Mult
 
 		// TODO - double check snapshotDelay
 		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.1, false, core.TargettableEnemy), f-5+i, travel+f-5+i)

--- a/internal/characters/yoimiya/abil.go
+++ b/internal/characters/yoimiya/abil.go
@@ -29,12 +29,11 @@ func (c *char) Attack(p map[string]int) (int, int) {
 	for i, mult := range attack[c.NormalCounter] {
 		//infusion to normal attack only
 		if c.Core.Status.Duration("yoimiyaskill") > 0 {
-			c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", ai.Mult, "next", skill[c.TalentLvlSkill()]*ai.Mult, "char", c.Index)
-
 			// ds.ICDTag = core.ICDTagNone
 			//multiplier
 			ai.Element = core.Pyro
 			ai.Mult = skill[c.TalentLvlSkill()] * mult[c.TalentLvlAttack()]
+			c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", mult[c.TalentLvlAttack()], "next", ai.Mult, "char", c.Index)
 		} else {
 			ai.Mult = mult[c.TalentLvlAttack()]
 		}

--- a/internal/characters/yoimiya/abil.go
+++ b/internal/characters/yoimiya/abil.go
@@ -27,18 +27,8 @@ func (c *char) Attack(p map[string]int) (int, int) {
 	}
 
 	for i, mult := range attack[c.NormalCounter] {
-		//infusion to normal attack only
-		if c.Core.Status.Duration("yoimiyaskill") > 0 {
-			// ds.ICDTag = core.ICDTagNone
-			//multiplier
-
-			ai.Mult = skill[c.TalentLvlSkill()] * mult[c.TalentLvlAttack()]
-			c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", mult[c.TalentLvlAttack()], "next", ai.Mult, "char", c.Index)
-		} else {
-			ai.Mult = mult[c.TalentLvlAttack()]
-		}
-
-		totalMV += ai.Mult
+		ai.Mult = mult[c.TalentLvlAttack()]
+		totalMV += mult[c.TalentLvlAttack()]
 
 		// TODO - double check snapshotDelay
 		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.1, false, core.TargettableEnemy), f-5+i, travel+f-5+i)

--- a/internal/characters/yoimiya/abil.go
+++ b/internal/characters/yoimiya/abil.go
@@ -27,8 +27,20 @@ func (c *char) Attack(p map[string]int) (int, int) {
 	}
 
 	for i, mult := range attack[c.NormalCounter] {
-		ai.Mult = mult[c.TalentLvlAttack()]
-		totalMV += mult[c.TalentLvlAttack()]
+		//infusion to normal attack only
+		if c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == core.AttackTagNormal {
+			c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", ai.Mult, "next", skill[c.TalentLvlSkill()]*ai.Mult, "char", c.Index)
+
+			// ds.ICDTag = core.ICDTagNone
+			//multiplier
+			ai.Element = core.Pyro
+			ai.Mult = skill[c.TalentLvlSkill()] * mult[c.TalentLvlAttack()]
+			totalMV += skill[c.TalentLvlSkill()] * mult[c.TalentLvlAttack()]
+		} else {
+			ai.Mult = mult[c.TalentLvlAttack()]
+			totalMV += mult[c.TalentLvlAttack()]
+		}
+
 		// TODO - double check snapshotDelay
 		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.1, false, core.TargettableEnemy), f-5+i, travel+f-5+i)
 	}

--- a/internal/characters/yoimiya/abil.go
+++ b/internal/characters/yoimiya/abil.go
@@ -28,18 +28,18 @@ func (c *char) Attack(p map[string]int) (int, int) {
 
 	for i, mult := range attack[c.NormalCounter] {
 		//infusion to normal attack only
-		if c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == core.AttackTagNormal {
+		if c.Core.Status.Duration("yoimiyaskill") > 0 {
 			c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", ai.Mult, "next", skill[c.TalentLvlSkill()]*ai.Mult, "char", c.Index)
 
 			// ds.ICDTag = core.ICDTagNone
 			//multiplier
 			ai.Element = core.Pyro
 			ai.Mult = skill[c.TalentLvlSkill()] * mult[c.TalentLvlAttack()]
-			totalMV += skill[c.TalentLvlSkill()] * mult[c.TalentLvlAttack()]
 		} else {
 			ai.Mult = mult[c.TalentLvlAttack()]
-			totalMV += mult[c.TalentLvlAttack()]
 		}
+
+		totalMV += mult[c.TalentLvlAttack()]
 
 		// TODO - double check snapshotDelay
 		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.1, false, core.TargettableEnemy), f-5+i, travel+f-5+i)
@@ -47,7 +47,7 @@ func (c *char) Attack(p map[string]int) (int, int) {
 
 	c.AdvanceNormalIndex()
 
-	if c.Base.Cons == 6 && c.Core.Rand.Float64() < 0.5 {
+	if c.Base.Cons == 6 && c.Core.Status.Duration("yoimiyaskill") > 0 && c.Core.Rand.Float64() < 0.5 {
 		//trigger attack
 		ai := core.AttackInfo{
 			ActorIndex: c.Index,
@@ -57,7 +57,7 @@ func (c *char) Attack(p map[string]int) (int, int) {
 			ICDGroup:   core.ICDGroupDefault,
 			Element:    core.Pyro,
 			Durability: 25,
-			Mult:       totalMV,
+			Mult:       totalMV * 0.6,
 		}
 		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.1, false, core.TargettableEnemy), 0, travel+f+5)
 

--- a/internal/characters/yoimiya/yoimiya.go
+++ b/internal/characters/yoimiya/yoimiya.go
@@ -11,9 +11,8 @@ func init() {
 
 type char struct {
 	*character.Tmpl
-	a2stack               int
-	lastPart              int
-	skillMultiplierLookup map[string]bool
+	a2stack  int
+	lastPart int
 }
 
 func NewChar(s *core.Core, p core.CharacterProfile) (core.Character, error) {

--- a/internal/characters/yoimiya/yoimiya.go
+++ b/internal/characters/yoimiya/yoimiya.go
@@ -11,9 +11,8 @@ func init() {
 
 type char struct {
 	*character.Tmpl
-	a2stack                     int
-	lastPart                    int
-	attacksWithSkillMultApplied map[*core.AttackInfo]bool
+	a2stack  int
+	lastPart int
 }
 
 func NewChar(s *core.Core, p core.CharacterProfile) (core.Character, error) {
@@ -36,7 +35,6 @@ func NewChar(s *core.Core, p core.CharacterProfile) (core.Character, error) {
 	c.BurstCon = 5
 	c.SkillCon = 3
 	c.CharZone = core.ZoneInazuma
-	c.attacksWithSkillMultApplied = make(map[*core.AttackInfo]bool)
 
 	c.a2()
 	c.onExit()
@@ -95,16 +93,13 @@ func (c *char) a2() {
 func (c *char) Snapshot(ai *core.AttackInfo) core.Snapshot {
 	ds := c.Tmpl.Snapshot(ai)
 
-	_, multHasBeenAppliedToAttack := c.attacksWithSkillMultApplied[ai]
-
 	//infusion to normal attack only
-	if !multHasBeenAppliedToAttack && c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == core.AttackTagNormal {
+	if c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == core.AttackTagNormal {
 		ai.Element = core.Pyro
 		// ds.ICDTag = core.ICDTagNone
 		//multiplier
 		c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", ai.Mult, "next", skill[c.TalentLvlSkill()]*ai.Mult, "char", c.Index)
 		ai.Mult = skill[c.TalentLvlSkill()] * ai.Mult
-		c.attacksWithSkillMultApplied[ai] = true
 	}
 
 	return ds

--- a/internal/characters/yoimiya/yoimiya.go
+++ b/internal/characters/yoimiya/yoimiya.go
@@ -11,8 +11,9 @@ func init() {
 
 type char struct {
 	*character.Tmpl
-	a2stack  int
-	lastPart int
+	a2stack                     int
+	lastPart                    int
+	attacksWithSkillMultApplied map[*core.AttackInfo]bool
 }
 
 func NewChar(s *core.Core, p core.CharacterProfile) (core.Character, error) {
@@ -35,6 +36,7 @@ func NewChar(s *core.Core, p core.CharacterProfile) (core.Character, error) {
 	c.BurstCon = 5
 	c.SkillCon = 3
 	c.CharZone = core.ZoneInazuma
+	c.attacksWithSkillMultApplied = make(map[*core.AttackInfo]bool)
 
 	c.a2()
 	c.onExit()
@@ -93,8 +95,17 @@ func (c *char) a2() {
 func (c *char) Snapshot(ai *core.AttackInfo) core.Snapshot {
 	ds := c.Tmpl.Snapshot(ai)
 
-	if c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == core.AttackTagNormal {
+	_, multHasBeenAppliedToAttack := c.attacksWithSkillMultApplied[ai]
+
+	//infusion to normal attack only
+	if !multHasBeenAppliedToAttack && c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == core.AttackTagNormal {
 		ai.Element = core.Pyro
+		// ds.ICDTag = core.ICDTagNone
+		//multiplier
+		c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", ai.Mult, "next", skill[c.TalentLvlSkill()]*ai.Mult, "char", c.Index)
+		ai.Mult = skill[c.TalentLvlSkill()] * ai.Mult
+		c.attacksWithSkillMultApplied[ai] = true
 	}
+
 	return ds
 }

--- a/internal/characters/yoimiya/yoimiya.go
+++ b/internal/characters/yoimiya/yoimiya.go
@@ -11,8 +11,9 @@ func init() {
 
 type char struct {
 	*character.Tmpl
-	a2stack  int
-	lastPart int
+	a2stack               int
+	lastPart              int
+	skillMultiplierLookup map[string]bool
 }
 
 func NewChar(s *core.Core, p core.CharacterProfile) (core.Character, error) {
@@ -93,13 +94,5 @@ func (c *char) a2() {
 func (c *char) Snapshot(ai *core.AttackInfo) core.Snapshot {
 	ds := c.Tmpl.Snapshot(ai)
 
-	//infusion to normal attack only
-	if c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == core.AttackTagNormal {
-		ai.Element = core.Pyro
-		// ds.ICDTag = core.ICDTagNone
-		//multiplier
-		c.Core.Log.NewEvent("skill mult applied", core.LogCharacterEvent, c.Index, "prev", ai.Mult, "next", skill[c.TalentLvlSkill()]*ai.Mult, "char", c.Index)
-		ai.Mult = skill[c.TalentLvlSkill()] * ai.Mult
-	}
 	return ds
 }

--- a/internal/characters/yoimiya/yoimiya.go
+++ b/internal/characters/yoimiya/yoimiya.go
@@ -93,5 +93,8 @@ func (c *char) a2() {
 func (c *char) Snapshot(ai *core.AttackInfo) core.Snapshot {
 	ds := c.Tmpl.Snapshot(ai)
 
+	if c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == core.AttackTagNormal {
+		ai.Element = core.Pyro
+	}
 	return ds
 }


### PR DESCRIPTION
* Previously Yoi's snapshot routine was apply the effect of her skill multiplier. This was causing additional talent multiplier in the calculation of her damage when multiple snapshots are made of the same attack.