### PR TITLE
Added skill_issue mode for bennett burst

### DIFF
--- a/internal/characters/bennett/bennett.go
+++ b/internal/characters/bennett/bennett.go
@@ -249,7 +249,15 @@ func (c *char) Burst(p map[string]int) (int, int) {
 		Mult:       burst[c.TalentLvlBurst()],
 	}
 	//TODO: review bennett AOE size
-	c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(5, false, core.TargettableEnemy), 33, 33)
+	switch p["skill_issue"] {
+	case 1:
+		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(0.1, false, core.TargettableEnemy), 15, 15)
+	case 2:
+		c.Core.Log.NewEvent("Bennett burst failed successfully", core.LogCharacterEvent,c.Index)
+	default:
+		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(5, false, core.TargettableEnemy), 33, 33)
+	}
+	
 	stats, _ := c.SnapshotStats()
 
 	//apply right away


### PR DESCRIPTION
LIST OF CHANGES

1. recoded every single ability in sim to match in game hitbox
2. recoded parser to allow for setting target position
3. recoded parser to allow for changing default attack center point
4. recodedparser to allow for moving targets around
5. recoded queue and abil execute to handle that logic
6. made sure every abil in sim is respecting default attack center point

Just kidding, skill issue=0 is the same as current burst, =1 makes it hit 1 enemy only, =2 skips everything, trial and tested
https://gcsim.app/viewer/share/y-peJYe64DWofCPwJ06Bb 
https://gcsim.app/viewer/share/-RazN_MpUpdausi8WX5mP
https://gcsim.app/viewer/share/aRg45Ac51XqcVqNutXFwk