### PR TITLE
adjust substat optimizer to reliably give more cr to fav weapon users

### DIFF
--- a/internal/substatoptimizer/substatoptimizer.go
+++ b/internal/substatoptimizer/substatoptimizer.go
@@ -391,9 +391,9 @@ func RunSubstatOptim(simopt simulator.Options, verbose bool, additionalOptions s
 
 			// fixes cases in which fav holders don't get enough crit rate to reliably proc fav (an important example would be fav kazuha)
 			// might give them "too much" cr (= max out liquid cr subs) but that's probably not a big deal
-			if charWithFavonius[idxChar] && idxSubstat == 1 {
+			if charWithFavonius[idxChar] && substat == core.CR {
 				substatGradients[idxSubstat] += 1000
-			}	
+			}
 
 			charProfilesCopy[idxChar].Stats[substat] -= 10 * substatValues[substat] * charSubstatRarityMod[idxChar]
 		}

--- a/internal/substatoptimizer/substatoptimizer.go
+++ b/internal/substatoptimizer/substatoptimizer.go
@@ -389,6 +389,12 @@ func RunSubstatOptim(simopt simulator.Options, verbose bool, additionalOptions s
 
 			substatGradients[idxSubstat] = substatEvalResult.DPS.Mean - initialMean
 
+			// fixes cases in which fav holders don't get enough crit rate to reliably proc fav (an important example would be fav kazuha)
+			// might give them "too much" cr (= max out liquid cr subs) but that's probably not a big deal
+			if charWithFavonius[idxChar] && idxSubstat == 1 {
+				substatGradients[idxSubstat] += 1000
+			}	
+
 			charProfilesCopy[idxChar].Stats[substat] -= 10 * substatValues[substat] * charSubstatRarityMod[idxChar]
 		}
 


### PR DESCRIPTION
In some configs the substat optimizer fails to give Favonius weapon users enough CR. This fix increases the gradient for CR so that the optimizer picks it instead of ATK% (+1000 seemed like a good number because that makes CR usually end up being chosen after CD (gradient is usually > 1000) but before ATK% (gradient is usually < 1000).
The main reason for this fix is that EM/EM/EM Fav Kazuha sometimes gets max'd out ATK% subs instead of crit rate subs leading to less dps and a higher standard deviation.