### PR TITLE
Tag nightly builds as prerelease

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -22,18 +22,11 @@ jobs:
 
           # run the script
           "${GITHUB_WORKSPACE}/scripts/build.sh"
-      # - run: ls
-      #   working-directory: ./cmd/gcsim
-      - run: ls
-        working-directory: ./
-      # - run: ls
-      #   working-directory: ./scripts
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
+          prerelease: true
           automatic_release_tag: nightly
           files: |
-            release-notes.txt
             LICENSE
             gcsim.exe


### PR DESCRIPTION
Fix the issue with the latest release URL redirecting to nightly.