### PR TITLE
fix animation delays playing twice

### DIFF
--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -133,7 +133,7 @@ func (s *Simulation) AdvanceFrame() error {
 		}
 
 		//other wise we can add delay
-		if delay > 0 {
+		if delay > 0 && s.lastDelayAt < s.lastActionUsedAt {
 			s.C.Log.NewEvent(
 				"animation delay triggered",
 				core.LogActionEvent,
@@ -143,13 +143,17 @@ func (s *Simulation) AdvanceFrame() error {
 				"default_delays", s.C.Flags.Delays,
 			)
 			s.skip = delay - 1
+			s.lastDelayAt = s.C.F
 			return nil
 		}
 	}
 
 	s.skip, done, err = s.C.Action.Exec(s.queue[0])
 	//last action used should then be current frame + how much we are skipping (i.e. first frame queueable)
-	s.lastActionUsedAt = s.C.F + s.skip
+	//if skip is 0, the action either failed or was invalid.
+	if s.skip > 0 {
+		s.lastActionUsedAt = s.C.F + s.skip
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/simulation/sim.go
+++ b/pkg/simulation/sim.go
@@ -20,6 +20,8 @@ type Simulation struct {
 	stats Result
 	//prevs action that was checked
 	lastActionUsedAt int
+	//prevs delay that was triggered
+	lastDelayAt int
 }
 
 func New(cfg core.SimulationConfig, c *core.Core) (*Simulation, error) {


### PR DESCRIPTION
Fixes two bugs: Animation delays playing on failed actions, and animation delays playing on status changes (ie raiden Q expired). The solution is somewhat hacky but this part of the code is getting rewritten anyway so it's just meant as a temporary solution to keep sims accurate.