### PR TITLE
Fixes Instructors not proccing on freeze (Issue #546)

### DIFF
--- a/internal/reactable/freeze.go
+++ b/internal/reactable/freeze.go
@@ -20,6 +20,7 @@ func (r *Reactable) tryFreeze(a *core.AttackEvent) {
 			//ec should have been taken care of already
 			a.Info.Durability -= consumed
 			a.Info.Durability = max(a.Info.Durability, 0)
+			r.core.Events.Emit(core.OnFrozen, r.self, a)
 			return
 		}
 		//otherwise attach hydro only if frozen exists
@@ -37,6 +38,7 @@ func (r *Reactable) tryFreeze(a *core.AttackEvent) {
 			r.Durability[core.Hydro] = max(r.Durability[core.Hydro], 0)
 			a.Info.Durability -= consumed
 			a.Info.Durability = max(a.Info.Durability, 0)
+			r.core.Events.Emit(core.OnFrozen, r.self, a)
 			return
 		}
 		//otherwise attach cryo only if frozen exists
@@ -51,7 +53,7 @@ func (r *Reactable) tryFreeze(a *core.AttackEvent) {
 		//should be here
 		return
 	}
-	r.core.Events.Emit(core.OnFrozen, r.self, a)
+
 }
 
 func max(a, b core.Durability) core.Durability {


### PR DESCRIPTION
Moved the onFreeze event emit to occur before the tryFreeze function returns.