### PR TITLE
FIX: Do a 1 sim_iter run of the sim before any optimizations to get p…

### DIFF
--- a/internal/substatoptimizer/substatoptimizer.go
+++ b/internal/substatoptimizer/substatoptimizer.go
@@ -155,6 +155,14 @@ func RunSubstatOptim(simopt simulator.Options, verbose bool, additionalOptions s
 		}
 	}
 
+	// Hacky solution to run init mods for characters like kokomi
+	simcfg.Settings.Iterations = 1
+	simcfg.Settings.Duration = 10
+	basisResult := runSimWithConfig(cfg, simcfg, simopt)
+	for i := range simcfg.Characters.Profile {
+		simcfg.Characters.Profile[i].Stats = basisResult.CharDetails[i].Stats
+	}
+
 	// Fix iterations at 350 for performance
 	// TODO: Seems to be a roughly good number at KQM standards
 	simcfg.Settings.Iterations = int(optionsMap["sim_iter"])


### PR DESCRIPTION
…roper stats, including any init mods. Resolves kokomi crit sub allocations