### PR TITLE
add ability to load result in browser automatically

### DIFF
--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -102,7 +102,7 @@ func main() {
 		serverDone := &sync.WaitGroup{}
 		serverDone.Add(1)
 		serveLocal(serverDone, "./serve_data.json.gz")
-		url := "http://localhost:1234/viewer/local"
+		url := "https://gcsim.app/viewer/local"
 		err = open(url)
 		if err != nil {
 			//try "xdg-open-wsl"

--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -1,9 +1,18 @@
 package main
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+	"time"
 
 	"github.com/genshinsim/gcsim/internal/simulator"
 	"github.com/genshinsim/gcsim/internal/substatoptimizer"
@@ -23,6 +32,7 @@ type opts struct {
 	substatOptim bool
 	verbose      bool
 	options      string
+	serve        bool
 }
 
 //command line tool; following options are available:
@@ -37,6 +47,7 @@ func main() {
 	flag.BoolVar(&opt.prof, "p", false, "run cpu profile; default false")
 	flag.BoolVar(&opt.substatOptim, "substatOptim", false, "optimize substats according to KQM standards. Set the out flag to output config with optimal substats inserted to a given file path")
 	flag.BoolVar(&opt.verbose, "v", false, "Verbose output log (currently only for substat optimization)")
+	flag.BoolVar(&opt.serve, "s", false, "serve file to viewer (local). default false")
 	flag.StringVar(&opt.options, "options", "", `Additional options for substat optimization mode. Currently supports the following flags, set in a semi-colon delimited list (e.g. -options="total_liquid_substats=15;indiv_liquid_cap=8"):
 - total_liquid_substats (default = 20): Total liquid substats available to be assigned across all substats
 - indiv_liquid_cap (default = 10): Total liquid substats that can be assigned to a single substat
@@ -58,6 +69,11 @@ func main() {
 
 	// defer profile.Start(profile.ProfilePath("./mem.pprof"), profile.MemProfileHeap).Stop()
 
+	if opt.serve {
+		opt.out = "serve_data.json"
+		opt.gz = true
+	}
+
 	simopt := simulator.Options{
 		ConfigPath:       opt.config,
 		ResultSaveToPath: opt.out,
@@ -76,6 +92,146 @@ func main() {
 	res, err := simulator.Run(simopt)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 	fmt.Println(res.PrettyPrint())
+
+	if opt.serve {
+		fmt.Println("Serving result to HTTP...")
+		//start server to listen for token
+		serverDone := &sync.WaitGroup{}
+		serverDone.Add(1)
+		serveLocal(serverDone, "./serve_data.json.gz")
+		url := "http://localhost:1234/viewer/local"
+		err = open(url)
+		if err != nil {
+			//try "xdg-open-wsl"
+			err = openWSL(url)
+			if err != nil {
+				fmt.Printf("Error opening default browser... please visit: %v\n", url)
+			}
+		}
+		serverDone.Wait()
+	}
+}
+
+// open opens the specified URL in the default browser of the user.
+func open(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
+	case "darwin":
+		cmd = "open"
+	default: // "linux", "freebsd", "openbsd", "netbsd"
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
+}
+
+func openWSL(url string) error {
+	cmd := "powershell.exe"
+	args := []string{"/c", "start", url}
+	return exec.Command(cmd, args...).Start()
+}
+
+var ctxShutdown, cancel = context.WithCancel(context.Background())
+
+var quit = make(chan bool, 1)
+
+type viewerData struct {
+	Data        string `json:"data"`
+	Author      string `json:"author"`
+	Description string `json:"description"`
+}
+
+func serveLocal(wg *sync.WaitGroup, path string) {
+	srv := &http.Server{Addr: "127.0.0.1:8381"}
+	http.HandleFunc("/data", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-ctxShutdown.Done():
+			fmt.Println("HTTP server shuting down ...")
+			return
+		default:
+		}
+		//check CORS
+		switch r.Method {
+		case "OPTIONS":
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Accept, Access-Control-Allow-Origin, Content-Type, Content-Length, Accept-Encoding, Authorization")
+			w.WriteHeader(http.StatusNoContent)
+			fmt.Println("OPTIONS request received, responding")
+			return
+		case "GET":
+		default:
+			fmt.Printf("Invalid request method: %v\n", r.Method)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		//read the gz file
+		gzData, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Printf("error reading gz data: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		b64string := base64.StdEncoding.EncodeToString(gzData)
+
+		x := viewerData{
+			Data:        b64string,
+			Author:      "none",
+			Description: "none",
+		}
+
+		jsonData, err := json.Marshal(x)
+		if err != nil {
+			fmt.Printf("error marshal json: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonData)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		// // Shut down server here
+		cancel() // to say sorry, above.
+
+		close(quit)
+
+	})
+
+	go gracefullShutdown(srv)
+
+	go func() {
+		defer wg.Done()
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatalf("ListenAndServe(): %v", err)
+		}
+		fmt.Println("HTTP server closed.")
+	}()
+}
+
+func gracefullShutdown(server *http.Server) {
+	<-quit
+	fmt.Println("Server is shutting down...")
+
+	ctx, c := context.WithTimeout(context.Background(), 30*time.Second)
+	defer c()
+
+	server.SetKeepAlivesEnabled(false)
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatalf("Could not gracefully shutdown the server: %v\n", err)
+	}
 }


### PR DESCRIPTION
allow `gcsim.exe` local build to serve results directly (instead of having to drag and drop to viewer)

`gcsim.exe -s` to do so