### PR TITLE
Allow fractional durations

### DIFF
--- a/pkg/core/cfg.go
+++ b/pkg/core/cfg.go
@@ -37,7 +37,7 @@ func (c *SimulationConfig) Clone() SimulationConfig {
 }
 
 type SimulatorSettings struct {
-	Duration   int
+	Duration   float64
 	DamageMode bool
 	Delays     Delays
 

--- a/pkg/parse/parseOptions.go
+++ b/pkg/parse/parseOptions.go
@@ -27,7 +27,7 @@ func parseOptions(p *Parser) (parseFn, error) {
 			case "duration":
 				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)
 				if err == nil {
-					p.cfg.Settings.Duration, err = itemNumberToInt(n)
+					p.cfg.Settings.Duration, err = itemNumberToFloat64(n)
 				}
 			case "workers":
 				n, err = p.acceptSeqReturnLast(itemEqual, itemNumber)

--- a/pkg/simulation/characters.go
+++ b/pkg/simulation/characters.go
@@ -60,7 +60,7 @@ func (s *Simulation) initChars() error {
 		s.stats.AbilUsageCountByChar[i] = make(map[string]int)
 		s.stats.CharNames[i] = v.Base.Key.String()
 		s.stats.EnergyDetail[i] = make(map[string][4]float64)
-		s.stats.EnergyWhenBurst[i] = make([]float64, 0, s.cfg.Settings.Duration/12+2)
+		s.stats.EnergyWhenBurst[i] = make([]float64, 0, int(s.cfg.Settings.Duration/12+2))
 
 		//log the character data
 		s.stats.CharDetails = append(s.stats.CharDetails, CharDetail{

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -9,7 +9,7 @@ func (s *Simulation) Run() (Result, error) {
 	if !s.cfg.DamageMode && s.cfg.Settings.Duration == 0 {
 		s.cfg.Settings.Duration = 90
 	}
-	f := s.cfg.Settings.Duration*60 - 1
+	f := int(s.cfg.Settings.Duration*60 - 1)
 	stop := false
 
 	//check for once energy and hurt event


### PR DESCRIPTION
Seems like there are some rounding errors from result/results.go, but they should just be aesthetic 

<https://gcsim.app/viewer/share/Y4LJSdYvATtgEURXvAsUS>