### PR TITLE
Assorted animation fixes

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -195,11 +195,18 @@ func (c *Core) UserCustomDelay() int {
 	case ActionJump:
 		d = c.Flags.Delays.Jump
 	case ActionSwap:
-		d = c.Flags.Delays.Swap
+		d = 0 //swap delay is handled separately, since it's before the swap rather than after it
 	case ActionAim:
 		d = c.Flags.Delays.Aim
 	}
-	return c.LastAction.Param["delay"] + d
+
+	//it takes one frame to queue an action, so delay should be reduced by one.
+	d += c.LastAction.Param["delay"] - 1
+	if d < 0 {
+		d = 0
+	}
+
+	return d
 }
 
 func (c *Core) ResetAllNormalCounter() {

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -128,7 +128,7 @@ func (s *Simulation) AdvanceFrame() error {
 		//If some delay, like a wait command, caused us to not be able to start delay immediately, shorten delay by this amount
 		delay -= s.C.F - s.lastActionUsedAt
 
-		//other wise we can add delay
+		//otherwise we can add delay - but only do so if we haven't already delayed since the previous action.
 		if delay > 0 && s.lastDelayAt < s.lastActionUsedAt {
 			s.C.Log.NewEvent(
 				"animation delay triggered",

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -77,7 +77,7 @@ func (s *Simulation) AdvanceFrame() error {
 	s.collectStats()
 	// }
 
-	if s.skip > 1 {
+	if s.skip > 1 { //We end lockouts one frame early, so that the next action can be queued right when the previous one ends
 		//if in cooldown, do nothing
 		s.skip--
 		return nil

--- a/pkg/simulation/sim.go
+++ b/pkg/simulation/sim.go
@@ -20,6 +20,8 @@ type Simulation struct {
 	stats Result
 	//prevs action that was checked
 	lastActionUsedAt int
+	//prevs delay that was triggered
+	lastDelayAt int
 }
 
 func New(cfg core.SimulationConfig, c *core.Core) (*Simulation, error) {


### PR DESCRIPTION
- Fixes @shizukayuki 's comment in https://github.com/genshinsim/gcsim/issues/486.
- Make swap delay before swaps rather than after
- Fixes actions taking an extra frame (#464)
- Fixes some animation delays playing twice when statuses end (#486)
- Full dbcompare: [dbcompare.txt](https://github.com/genshinsim/gcsim/files/8845256/dbcompare.txt) 
- Testing: https://docs.google.com/document/d/1cm4jPnzahBvEd3DGedLLq-9IU3G6ZhDwabXR1fRmX_s/edit?usp=sharing