### PR TITLE
Fix itto C1 and NA counter not being reset by CA

### DIFF
--- a/internal/characters/itto/abil.go
+++ b/internal/characters/itto/abil.go
@@ -102,6 +102,8 @@ func (c *char) ChargeAttack(p map[string]int) (int, int) {
 		c.sCACount = 0
 		c.Tags["strStack"] = 0
 	}
+	
+	c.dasshuUsed = false
 
 	return f, a
 }
@@ -207,10 +209,11 @@ func (c *char) Burst(p map[string]int) (int, int) {
 	}
 
 	if c.Base.Cons >= 1 {
-		if c.Tags["strStack"] <= 3 {
-			c.Tags["strStack"] += 2
-		}
-		for frame := 60; frame < 60*1.5; frame += 30 {
+		c.Tags["strStack"] += 2
+		if c.Tags["strStack"] > 5 {
+			c.Tags["strStack"] = 5
+		}		
+		for frame := 140; frame <= 200 ; frame += 30 {
 			c.AddTask(func() {
 				if c.Tags["strStack"] <= 4 {
 					c.Tags["strStack"]++
@@ -218,6 +221,7 @@ func (c *char) Burst(p map[string]int) (int, int) {
 			}, "c1-itto", frame)
 		}
 	}
+
 	if c.Base.Cons >= 2 {
 		c.AddTask(func() {
 			count := 0
@@ -275,3 +279,4 @@ func (c *char) c4cb(delay int, buff []float64) func() {
 		}, "ittoqend", delay)
 	}
 }
+


### PR DESCRIPTION
Bugfixes:
1. Fixes Itto not recieving the last SSS stack from C1 when he already had 4.
2. Corrects the frames at which Itto recieves SSS stacks from C1.
3. Fixes Itto's NA combo not being reset by CAs.