### PR TITLE
Kuki feature update

### DIFF
--- a/internal/characters/kuki/cons.go
+++ b/internal/characters/kuki/cons.go
@@ -42,7 +42,7 @@ func (c *char) c4() {
 			ActorIndex: c.Index,
 			Abil:       "C4 proc",
 			AttackTag:  core.AttackTagElementalArt,
-			ICDTag:     core.ICDTagElementalArt,
+			ICDTag:     core.ICDTagNone,
 			ICDGroup:   core.ICDGroupDefault,
 			Element:    core.Electro,
 			Durability: 25,
@@ -50,7 +50,11 @@ func (c *char) c4() {
 			FlatDmg:    c.MaxHP() * 0.097,
 		}
 
+		//Particle check is 45% for particle
 		c.Core.Combat.QueueAttack(ai, core.NewDefCircHit(2, false, core.TargettableEnemy), 5, 5)
+		if c.Core.Rand.Float64() < .45 {
+			c.QueueParticle("Kuki", 1, core.Electro, 100) // TODO: idk the particle timing yet fml (or probability)
+		}
 		c.c4ICD = c.Core.F + 300 //5 sec icd
 		return false
 	}, "kuki-c4")


### PR DESCRIPTION
C4 now generates particles on each proc with a %45 chance of doing so.

Additionally the ICD tag changed to none, since it isn't shared with the skill

Disclaimer: This PR is NOT meant to be a bugfix, instead, it's a feature addition, so please treat is as such