### PR TITLE
Remove extra allocations from Log.NewEvent()

### DIFF
--- a/internal/artifacts/archaic/archaic.go
+++ b/internal/artifacts/archaic/archaic.go
@@ -54,7 +54,8 @@ func NewSet(core *core.Core, char *character.CharWrapper, count int, param map[s
 			// Activate
 			// TODO: cd for proc?
 			core.Status.Add("archaic", 10*60)
-			core.Log.NewEvent("archaic petra proc'd", glog.LogArtifactEvent, char.Index, "ele", s.element)
+			core.Log.NewEvent("archaic petra proc'd", glog.LogArtifactEvent, char.Index).
+				Write("ele", s.element)
 
 			m[attributes.PyroP] = 0
 			m[attributes.HydroP] = 0

--- a/internal/artifacts/crimson/crimson.go
+++ b/internal/artifacts/crimson/crimson.go
@@ -40,7 +40,8 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 			mult := 0.5*float64(s.stacks) + 1
 			m[attributes.PyroP] = 0.15 * mult
 			if mult > 1 {
-				c.Log.NewEvent("crimson witch 4pc", glog.LogArtifactEvent, char.Index, "mult", mult)
+				c.Log.NewEvent("crimson witch 4pc", glog.LogArtifactEvent, char.Index).
+					Write("mult", mult)
 			}
 
 			return m, true
@@ -62,7 +63,8 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 				s.stacks++
 			}
 
-			c.Log.NewEvent("crimson witch 4pc adding stack", glog.LogArtifactEvent, char.Index, "current stacks", s.stacks)
+			c.Log.NewEvent("crimson witch 4pc adding stack", glog.LogArtifactEvent, char.Index).
+				Write("current stacks", s.stacks)
 			c.Status.Add(s.key, 10*60)
 			return false
 		}, s.key)

--- a/internal/artifacts/echoes/echoes.go
+++ b/internal/artifacts/echoes/echoes.go
@@ -72,10 +72,10 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 			if c.F < s.procExpireF {
 				dmgAdded = snATK * 0.7
 				atk.Info.FlatDmg += dmgAdded
-				c.Log.NewEvent("echoes 4pc adding dmg", glog.LogArtifactEvent, char.Index,
-					"buff_expiry", s.procExpireF,
-					"dmg_added", dmgAdded,
-				)
+				c.Log.NewEvent("echoes 4pc adding dmg", glog.LogArtifactEvent, char.Index).
+					Write("buff_expiry", s.procExpireF).
+					Write("dmg_added", dmgAdded)
+
 				return false
 			}
 
@@ -95,12 +95,11 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 			s.procExpireF = c.F + procDuration
 			s.icd = c.F + 12 // 0.2s
 
-			c.Log.NewEvent("echoes 4pc proc'd", glog.LogArtifactEvent, char.Index,
-				"probability", s.prob,
-				"icd", s.icd,
-				"buff_expiry", s.procExpireF,
-				"dmg_added", dmgAdded,
-			)
+			c.Log.NewEvent("echoes 4pc proc'd", glog.LogArtifactEvent, char.Index).
+				Write("probability", s.prob).
+				Write("icd", s.icd).
+				Write("buff_expiry", s.procExpireF).
+				Write("dmg_added", dmgAdded)
 
 			s.prob = 0.36
 

--- a/internal/artifacts/huskofopulentdreams/huskofopulentdreams.go
+++ b/internal/artifacts/huskofopulentdreams/huskofopulentdreams.go
@@ -98,11 +98,10 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 				s.stacks++
 			}
 
-			c.Log.NewEvent("Husk gained on-field stack", glog.LogArtifactEvent, char.Index,
-				"stacks", s.stacks,
-				"last_swap", s.lastSwap,
-				"last_stack_change", s.lastStackGain,
-			)
+			c.Log.NewEvent("Husk gained on-field stack", glog.LogArtifactEvent, char.Index).
+				Write("stacks", s.stacks).
+				Write("last_swap", s.lastSwap).
+				Write("last_stack_change", s.lastStackGain)
 
 			s.lastStackGain = c.F
 			s.stackGainICDExpiry = c.F + 18 // 0.3 sec
@@ -128,11 +127,10 @@ func (s *Set) checkStackLoss() {
 		return
 	}
 	s.stacks--
-	s.core.Log.NewEvent("Husk lost stack", glog.LogArtifactEvent, s.char.Index,
-		"stacks", s.stacks,
-		"last_swap", s.lastSwap,
-		"last_stack_change", s.lastStackGain,
-	)
+	s.core.Log.NewEvent("Husk lost stack", glog.LogArtifactEvent, s.char.Index).
+		Write("stacks", s.stacks).
+		Write("last_swap", s.lastSwap).
+		Write("last_stack_change", s.lastStackGain)
 
 	// queue up again if we still have stacks
 	if s.stacks > 0 {
@@ -142,12 +140,12 @@ func (s *Set) checkStackLoss() {
 
 func (s *Set) gainStackOfffield(src int) func() {
 	return func() {
-		s.core.Log.NewEvent("Husk check for off-field stack", glog.LogArtifactEvent, s.char.Index,
-			"stacks", s.stacks,
-			"last_swap", s.lastSwap,
-			"last_stack_change", s.lastStackGain,
-			"source", src,
-		)
+		s.core.Log.NewEvent("Husk check for off-field stack", glog.LogArtifactEvent, s.char.Index).
+			Write("stacks", s.stacks).
+			Write("last_swap", s.lastSwap).
+			Write("last_stack_change", s.lastStackGain).
+			Write("source", src)
+
 		if s.core.Player.Active() == s.char.Index {
 			return
 		}
@@ -160,11 +158,10 @@ func (s *Set) gainStackOfffield(src int) func() {
 			s.stacks++
 		}
 
-		s.core.Log.NewEvent("Husk gained off-field stack", glog.LogArtifactEvent, s.char.Index,
-			"stacks", s.stacks,
-			"last_swap", s.lastSwap,
-			"last_stack_change", s.lastStackGain,
-		)
+		s.core.Log.NewEvent("Husk gained off-field stack", glog.LogArtifactEvent, s.char.Index).
+			Write("stacks", s.stacks).
+			Write("last_swap", s.lastSwap).
+			Write("last_stack_change", s.lastStackGain)
 
 		s.lastStackGain = s.core.F
 

--- a/internal/artifacts/maiden/maiden.go
+++ b/internal/artifacts/maiden/maiden.go
@@ -43,7 +43,8 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 				return false
 			}
 			dur = c.F + 10*60
-			c.Log.NewEvent("maiden 4pc proc", glog.LogArtifactEvent, char.Index, "expiry", dur)
+			c.Log.NewEvent("maiden 4pc proc", glog.LogArtifactEvent, char.Index).
+				Write("expiry", dur)
 			return false
 		}
 		c.Events.Subscribe(event.OnBurst, f, fmt.Sprintf("maiden-4pc-%v", char.Base.Name))

--- a/internal/artifacts/noblesse/noblesse.go
+++ b/internal/artifacts/noblesse/noblesse.go
@@ -69,7 +69,8 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 				c.Flags.Custom["nob-4pc"] = char.Index
 			}
 
-			c.Log.NewEvent("noblesse 4pc proc", glog.LogArtifactEvent, char.Index, "expiry", c.Status.Duration("nob-4pc"))
+			c.Log.NewEvent("noblesse 4pc proc", glog.LogArtifactEvent, char.Index).
+				Write("expiry", c.Status.Duration("nob-4pc"))
 			return false
 		}, fmt.Sprintf("nob-4pc-%v", char.Base.Name))
 	}

--- a/internal/artifacts/oceanhuedclam/oceanhuedclam.go
+++ b/internal/artifacts/oceanhuedclam/oceanhuedclam.go
@@ -120,16 +120,15 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 					s.bubbleHealStacks = 0
 				}, 3*60)
 
-				c.Log.NewEvent("ohc bubble activated", glog.LogArtifactEvent, char.Index,
-					"bubble_pops_at", s.bubbleDurationExpiry,
-					"ohc_icd_expiry", bubbleICDExpiry,
-				)
+				c.Log.NewEvent("ohc bubble activated", glog.LogArtifactEvent, char.Index).
+					Write("bubble_pops_at", s.bubbleDurationExpiry).
+					Write("ohc_icd_expiry", bubbleICDExpiry)
+
 			}
 
-			c.Log.NewEvent("ohc bubble accumulation", glog.LogArtifactEvent, char.Index,
-				"bubble_pops_at", s.bubbleDurationExpiry,
-				"bubble_total", s.bubbleHealStacks,
-			)
+			c.Log.NewEvent("ohc bubble accumulation", glog.LogArtifactEvent, char.Index).
+				Write("bubble_pops_at", s.bubbleDurationExpiry).
+				Write("bubble_total", s.bubbleHealStacks)
 
 			return false
 		}, fmt.Sprintf("ohc-4pc-heal-accumulation-%v", char.Base.Name))

--- a/internal/artifacts/paleflame/paleflame.go
+++ b/internal/artifacts/paleflame/paleflame.go
@@ -64,11 +64,11 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 
 			s.icd = c.F + 18
 			s.dur = c.F + 420
-			c.Log.NewEvent("pale flame 4pc proc", glog.LogArtifactEvent, char.Index,
-				"stacks", s.stacks,
-				"expiry", s.dur,
-				"icd", s.icd,
-			)
+			c.Log.NewEvent("pale flame 4pc proc", glog.LogArtifactEvent, char.Index).
+				Write("stacks", s.stacks).
+				Write("expiry", s.dur).
+				Write("icd", s.icd)
+
 			return false
 		}, fmt.Sprintf("pf4-%v", char.Base.Name))
 

--- a/internal/artifacts/tenacity/tenacity.go
+++ b/internal/artifacts/tenacity/tenacity.go
@@ -78,7 +78,9 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 			c.Status.Add("tom-proc", 3*60)
 			s.icd = c.F + 30 // .5 second icd
 
-			c.Log.NewEvent("tom 4pc proc", glog.LogArtifactEvent, char.Index, "expiry", c.F+180, "icd", s.icd)
+			c.Log.NewEvent("tom 4pc proc", glog.LogArtifactEvent, char.Index).
+				Write("expiry", c.F+180).
+				Write("icd", s.icd)
 			return false
 		}, fmt.Sprintf("tom4-%v", char.Base.Name))
 	}

--- a/internal/artifacts/thunderingfury/thunderingfury.go
+++ b/internal/artifacts/thunderingfury/thunderingfury.go
@@ -64,7 +64,9 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 			}
 			icd = c.F + 48
 			char.ReduceActionCooldown(action.ActionSkill, 60)
-			c.Log.NewEvent("thunderfury 4pc proc", glog.LogArtifactEvent, char.Index, "reaction", atk.Info.Abil, "new cd", char.Cooldown(action.ActionSkill))
+			c.Log.NewEvent("thunderfury 4pc proc", glog.LogArtifactEvent, char.Index).
+				Write("reaction", atk.Info.Abil).
+				Write("new cd", char.Cooldown(action.ActionSkill))
 			return false
 		}
 

--- a/internal/artifacts/thundersoother/thundersoother.go
+++ b/internal/artifacts/thundersoother/thundersoother.go
@@ -25,7 +25,8 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 	s := Set{}
 
 	if count >= 2 {
-		c.Log.NewEvent("thundersoother 2 pc not implemented", glog.LogArtifactEvent, char.Index, "frame", c.F)
+		c.Log.NewEvent("thundersoother 2 pc not implemented", glog.LogArtifactEvent, char.Index).
+			Write("frame", c.F)
 	}
 	if count >= 4 {
 		m := make([]float64, attributes.EndStatType)

--- a/internal/artifacts/vermillion/vermillion.go
+++ b/internal/artifacts/vermillion/vermillion.go
@@ -70,7 +70,8 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 				s.stacks = 0
 			}
 
-			c.Log.NewEvent("verm 4pc proc", glog.LogArtifactEvent, char.Index, "expiry", c.Status.Duration("verm-4pc"))
+			c.Log.NewEvent("verm 4pc proc", glog.LogArtifactEvent, char.Index).
+				Write("expiry", c.Status.Duration("verm-4pc"))
 			return false
 
 		}, fmt.Sprintf("verm-4pc-%v", char.Base.Name))
@@ -78,7 +79,8 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 		c.Events.Subscribe(event.OnCharacterHurt, func(args ...interface{}) bool {
 			if c.F >= s.HPicd && s.stacks < 4 && c.Status.Duration("verm-4pc") > 0 { // grants stack if conditions are met
 				s.stacks++
-				c.Log.NewEvent("Vermillion stack gained", glog.LogArtifactEvent, char.Index, "stacks", s.stacks)
+				c.Log.NewEvent("Vermillion stack gained", glog.LogArtifactEvent, char.Index).
+					Write("stacks", s.stacks)
 				s.HPicd = c.F + 48
 			}
 			return false

--- a/internal/artifacts/viridescent/viridescent.go
+++ b/internal/artifacts/viridescent/viridescent.go
@@ -70,7 +70,9 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 				}
 
 				t.AddResistMod(key, 10*60, ele, -0.4)
-				c.Log.NewEvent("vv 4pc proc", glog.LogArtifactEvent, char.Index, "reaction", key, "char", char.Index)
+				c.Log.NewEvent("vv 4pc proc", glog.LogArtifactEvent, char.Index).
+					Write("reaction", key).
+					Write("char", char.Index)
 
 				return false
 			}
@@ -110,7 +112,9 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 			}
 
 			t.AddResistMod(key, 10*60, ele, -0.4)
-			c.Log.NewEvent("vv 4pc proc", glog.LogArtifactEvent, char.Index, "reaction", key, "char", char.Index)
+			c.Log.NewEvent("vv 4pc proc", glog.LogArtifactEvent, char.Index).
+				Write("reaction", key).
+				Write("char", char.Index)
 
 			return false
 		}, fmt.Sprintf("vv-4pc-secondary-%v", char.Base.Name))

--- a/internal/characters/albedo/skill.go
+++ b/internal/characters/albedo/skill.go
@@ -86,7 +86,9 @@ func (c *char) skillHook() {
 		// a1: skill tick deal 25% more dmg if enemy hp < 50%
 		if c.Core.Combat.DamageMode && t.HP()/t.MaxHP() < .5 {
 			snap.Stats[attributes.DmgP] += 0.25
-			c.Core.Log.NewEvent("a1 proc'd, dealing extra dmg", glog.LogCharacterEvent, c.Index, "hp %", t.HP()/t.MaxHP(), "final dmg", snap.Stats[attributes.DmgP])
+			c.Core.Log.NewEvent("a1 proc'd, dealing extra dmg", glog.LogCharacterEvent, c.Index).
+				Write("hp %", t.HP()/t.MaxHP()).
+				Write("final dmg", snap.Stats[attributes.DmgP])
 		}
 
 		c.Core.QueueAttackWithSnap(c.skillAttackInfo, snap, combat.NewDefCircHit(3, false, combat.TargettableEnemy), 1)

--- a/internal/characters/amber/bunny.go
+++ b/internal/characters/amber/bunny.go
@@ -46,7 +46,8 @@ func (c *char) makeBunny() {
 
 func (c *char) explode(src int) {
 	n := 0
-	c.Core.Log.NewEvent("amber exploding bunny", glog.LogCharacterEvent, c.Index, "src", src)
+	c.Core.Log.NewEvent("amber exploding bunny", glog.LogCharacterEvent, c.Index).
+		Write("src", src)
 	for _, v := range c.bunnies {
 		if v.src == src {
 			c.Core.QueueAttackEvent(&v.ae, 1)

--- a/internal/characters/ayato/ayato.go
+++ b/internal/characters/ayato/ayato.go
@@ -98,7 +98,10 @@ func (c *char) Snapshot(ai *combat.AttackInfo) combat.Snapshot {
 		//add namisen stack
 		flatdmg := (c.Base.HP*(1+ds.Stats[attributes.HPP]) + ds.Stats[attributes.HP]) * skillpp[c.TalentLvlSkill()] * float64(c.stacks)
 		ai.FlatDmg += flatdmg
-		c.Core.Log.NewEvent("namisen add damage", glog.LogCharacterEvent, c.Index, "damage_added", flatdmg, "stacks", c.stacks, "expiry", c.Core.Status.Duration("soukaikanka"))
+		c.Core.Log.NewEvent("namisen add damage", glog.LogCharacterEvent, c.Index).
+			Write("damage_added", flatdmg).
+			Write("stacks", c.stacks).
+			Write("expiry", c.Core.Status.Duration("soukaikanka"))
 	}
 	return ds
 }

--- a/internal/characters/ayato/skill.go
+++ b/internal/characters/ayato/skill.go
@@ -46,7 +46,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}, delay)
 
 	c.Core.Status.Add("soukaikanka", 6*60+skillStart+hitlag) //add animation to the duration
-	c.Core.Log.NewEvent("Soukai Kanka acivated", glog.LogCharacterEvent, c.Index, "expiry", c.Core.F+6*60+skillStart+hitlag)
+	c.Core.Log.NewEvent("Soukai Kanka acivated", glog.LogCharacterEvent, c.Index).
+		Write("expiry", c.Core.F+6*60+skillStart+hitlag)
 	//figure out atk buff
 	if c.Base.Cons >= 6 {
 		c.c6ready = true
@@ -76,7 +77,8 @@ func (c *char) generateParticles(ac combat.AttackCB) {
 func (c *char) skillStacks(ac combat.AttackCB) {
 	if c.stacks < c.stacksMax {
 		c.stacks++
-		c.Core.Log.NewEvent("gained namisen stack", glog.LogCharacterEvent, c.Index, "stacks", c.stacks)
+		c.Core.Log.NewEvent("gained namisen stack", glog.LogCharacterEvent, c.Index).
+			Write("stacks", c.stacks)
 	}
 }
 

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -121,7 +121,9 @@ func (c *char) burstProc() {
 		}
 		c.Core.QueueAttackEvent(&atk, 1)
 
-		c.Core.Log.NewEvent("beidou Q proc'd", glog.LogCharacterEvent, c.Index, "char", ae.Info.ActorIndex, "attack tag", ae.Info.AttackTag)
+		c.Core.Log.NewEvent("beidou Q proc'd", glog.LogCharacterEvent, c.Index).
+			Write("char", ae.Info.ActorIndex).
+			Write("attack tag", ae.Info.AttackTag)
 
 		icd = c.Core.F + 60 // once per second
 		return false

--- a/internal/characters/beidou/cons.go
+++ b/internal/characters/beidou/cons.go
@@ -13,7 +13,8 @@ func (c *char) c4() {
 			return false
 		}
 		c.Core.Status.Add("beidouc4", 600)
-		c.Core.Log.NewEvent("c4 triggered on damage", glog.LogCharacterEvent, c.Index, "expiry", c.Core.F+600)
+		c.Core.Log.NewEvent("c4 triggered on damage", glog.LogCharacterEvent, c.Index).
+			Write("expiry", c.Core.F+600)
 		return false
 	}, "beidouc4")
 
@@ -30,7 +31,8 @@ func (c *char) c4() {
 			return false
 		}
 
-		c.Core.Log.NewEvent("c4 proc'd on attack", glog.LogCharacterEvent, c.Index, "char", c.Index)
+		c.Core.Log.NewEvent("c4 proc'd on attack", glog.LogCharacterEvent, c.Index).
+			Write("char", c.Index)
 		ai := combat.AttackInfo{
 			ActorIndex: c.Index,
 			Abil:       "Beidou C4",

--- a/internal/characters/bennett/burst.go
+++ b/internal/characters/bennett/burst.go
@@ -129,7 +129,8 @@ func (c *char) applyBennettField(stats [attributes.EndStatType]float64) func() {
 				return m, true
 			})
 
-			c.Core.Log.NewEvent("bennett field - adding attack", glog.LogCharacterEvent, c.Index, "threshold", threshold)
+			c.Core.Log.NewEvent("bennett field - adding attack", glog.LogCharacterEvent, c.Index).
+				Write("threshold", threshold)
 		}
 	}
 }

--- a/internal/characters/chongyun/cons.go
+++ b/internal/characters/chongyun/cons.go
@@ -28,7 +28,8 @@ func (c *char) c4() {
 
 		c.AddEnergy("chongyun-c4", 2)
 
-		c.Core.Log.NewEvent("chongyun c4 recovering 2 energy", glog.LogCharacterEvent, c.Index, "final energy", c.Energy)
+		c.Core.Log.NewEvent("chongyun c4 recovering 2 energy", glog.LogCharacterEvent, c.Index).
+			Write("final energy", c.Energy)
 		icd = c.Core.F + 120
 
 		return false

--- a/internal/characters/chongyun/skill.go
+++ b/internal/characters/chongyun/skill.go
@@ -117,7 +117,8 @@ func (c *char) onSwapHook() {
 			return false
 		}
 		//add infusion on swap
-		c.Core.Log.NewEvent("chongyun adding infusion on swap", glog.LogCharacterEvent, c.Index, "expiry", c.Core.F+infuseDur[c.TalentLvlSkill()])
+		c.Core.Log.NewEvent("chongyun adding infusion on swap", glog.LogCharacterEvent, c.Index).
+			Write("expiry", c.Core.F+infuseDur[c.TalentLvlSkill()])
 		active := c.Core.Player.ActiveChar()
 		c.infuse(active)
 		return false
@@ -150,7 +151,8 @@ func (c *char) infuse(active *character.CharWrapper) {
 			true,
 			combat.AttackTagNormal, combat.AttackTagExtra, combat.AttackTagPlunge,
 		)
-		c.Core.Log.NewEvent("chongyun adding infusion", glog.LogCharacterEvent, c.Index, "expiry", c.Core.F+infuseDur[c.TalentLvlSkill()])
+		c.Core.Log.NewEvent("chongyun adding infusion", glog.LogCharacterEvent, c.Index).
+			Write("expiry", c.Core.F+infuseDur[c.TalentLvlSkill()])
 	default:
 		return
 	}

--- a/internal/characters/eula/burst.go
+++ b/internal/characters/eula/burst.go
@@ -32,7 +32,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 	// lights up 9.5s from cast
 	c.Core.Status.Add("eulaq", 9*60+30)
-	c.Core.Log.NewEvent("eula burst started", glog.LogCharacterEvent, c.Index, "stacks", c.burstCounter, "expiry", c.Core.Status.Duration("eulaq"))
+	c.Core.Log.NewEvent("eula burst started", glog.LogCharacterEvent, c.Index).
+		Write("stacks", c.burstCounter).
+		Write("expiry", c.Core.Status.Duration("eulaq"))
 
 	//add initial damage
 	ai := combat.AttackInfo{
@@ -54,7 +56,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		v++
 	}
 	c.Tags["grimheart"] = v
-	c.Core.Log.NewEvent("eula: grimheart stack", glog.LogCharacterEvent, c.Index, "current count", v)
+	c.Core.Log.NewEvent("eula: grimheart stack", glog.LogCharacterEvent, c.Index).
+		Write("current count", v)
 
 	// lightfall hitmark is 600f from cast
 	c.Core.Tasks.Add(func() {
@@ -93,7 +96,9 @@ func (c *char) triggerBurst() {
 		Mult:       burstExplodeBase[c.TalentLvlBurst()] + burstExplodeStack[c.TalentLvlBurst()]*float64(stacks),
 	}
 
-	c.Core.Log.NewEvent("eula burst triggering", glog.LogCharacterEvent, c.Index, "stacks", stacks, "mult", ai.Mult)
+	c.Core.Log.NewEvent("eula burst triggering", glog.LogCharacterEvent, c.Index).
+		Write("stacks", stacks).
+		Write("mult", ai.Mult)
 
 	c.Core.QueueAttack(ai, combat.NewDefCircHit(5, false, combat.TargettableEnemy), lightfallHitmark, lightfallHitmark)
 	c.Core.Status.Delete("eulaq")
@@ -122,11 +127,13 @@ func (c *char) burstStacks() {
 
 		//add to counter
 		c.burstCounter++
-		c.Core.Log.NewEvent("eula burst add stack", glog.LogCharacterEvent, c.Index, "stack count", c.burstCounter)
+		c.Core.Log.NewEvent("eula burst add stack", glog.LogCharacterEvent, c.Index).
+			Write("stack count", c.burstCounter)
 		//check for c6
 		if c.Base.Cons == 6 && c.Core.Rand.Float64() < 0.5 {
 			c.burstCounter++
-			c.Core.Log.NewEvent("eula c6 add additional stack", glog.LogCharacterEvent, c.Index, "stack count", c.burstCounter)
+			c.Core.Log.NewEvent("eula c6 add additional stack", glog.LogCharacterEvent, c.Index).
+				Write("stack count", c.burstCounter)
 		}
 		c.burstCounterICD = c.Core.F + 6
 		return false

--- a/internal/characters/eula/skill.go
+++ b/internal/characters/eula/skill.go
@@ -61,7 +61,8 @@ func (c *char) pressSkill(p map[string]int) action.ActionInfo {
 
 		if c.Tags["grimheart"] < 2 {
 			c.Tags["grimheart"]++
-			c.Core.Log.NewEvent("eula: grimheart stack", glog.LogCharacterEvent, c.Index, "current count", c.Tags["grimheart"])
+			c.Core.Log.NewEvent("eula: grimheart stack", glog.LogCharacterEvent, c.Index).
+				Write("current count", c.Tags["grimheart"])
 		}
 		c.grimheartReset = 18 * 60
 	}

--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -84,7 +84,10 @@ func (c *char) queueOz(src string) {
 		SourceFrame: c.Core.F,
 	}
 	c.Core.Tasks.Add(c.ozTick(c.Core.F), 60)
-	c.Core.Log.NewEvent("Oz activated", glog.LogCharacterEvent, c.Index, "source", src, "expected end", c.ozActiveUntil, "next expected tick", c.Core.F+60)
+	c.Core.Log.NewEvent("Oz activated", glog.LogCharacterEvent, c.Index).
+		Write("source", src).
+		Write("expected end", c.ozActiveUntil).
+		Write("next expected tick", c.Core.F+60)
 
 	c.Core.Status.Add("fischloz", dur)
 
@@ -92,12 +95,16 @@ func (c *char) queueOz(src string) {
 
 func (c *char) ozTick(src int) func() {
 	return func() {
-		c.Core.Log.NewEvent("Oz checking for tick", glog.LogCharacterEvent, c.Index, "src", src)
+		c.Core.Log.NewEvent("Oz checking for tick", glog.LogCharacterEvent, c.Index).
+			Write("src", src)
 		//if src != ozSource then this is no longer the same oz, do nothing
 		if src != c.ozSource {
 			return
 		}
-		c.Core.Log.NewEvent("Oz ticked", glog.LogCharacterEvent, c.Index, "next expected tick", c.Core.F+60, "active", c.ozActiveUntil, "src", src)
+		c.Core.Log.NewEvent("Oz ticked", glog.LogCharacterEvent, c.Index).
+			Write("next expected tick", c.Core.F+60).
+			Write("active", c.ozActiveUntil).
+			Write("src", src)
 		//trigger damage
 		ae := c.ozSnapshot
 		c.Core.QueueAttackEvent(&ae, 0)

--- a/internal/characters/ganyu/aimed.go
+++ b/internal/characters/ganyu/aimed.go
@@ -47,7 +47,8 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 	skip := 0
 	if c.Core.Status.Duration("ganyuc6") > 0 {
 		c.Core.Status.Delete("ganyuc6")
-		c.Core.Log.NewEvent("ganyu c6 proc used", glog.LogCharacterEvent, c.Index, "char", c.Index)
+		c.Core.Log.NewEvent("ganyu c6 proc used", glog.LogCharacterEvent, c.Index).
+			Write("char", c.Index)
 		// skip aimed charge time
 		skip = 83
 	}
@@ -59,7 +60,10 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		if c.Core.F < c.a1Expiry {
 			old := snap.Stats[attributes.CR]
 			snap.Stats[attributes.CR] += .20
-			c.Core.Log.NewEvent("a1 adding crit rate", glog.LogCharacterEvent, c.Index, "old", old, "new", snap.Stats[attributes.CR], "expiry", c.a1Expiry)
+			c.Core.Log.NewEvent("a1 adding crit rate", glog.LogCharacterEvent, c.Index).
+				Write("old", old).
+				Write("new", snap.Stats[attributes.CR]).
+				Write("expiry", c.a1Expiry)
 		}
 
 		c.Core.QueueAttackWithSnap(ai, snap, combat.NewDefSingleTarget(1, combat.TargettableEnemy), travel)

--- a/internal/characters/ganyu/burst.go
+++ b/internal/characters/ganyu/burst.go
@@ -58,7 +58,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				return m, true
 			})
 			if tick >= 900+burstStart-18 {
-				c.Core.Log.NewEvent("a4 last tick", glog.LogCharacterEvent, c.Index, "ends_on", c.Core.F+60)
+				c.Core.Log.NewEvent("a4 last tick", glog.LogCharacterEvent, c.Index).
+					Write("ends_on", c.Core.F+60)
 			}
 
 			// increase C4 stacks at 3s interval
@@ -68,7 +69,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				if c.c4Stacks > 5 {
 					c.c4Stacks = 5
 				}
-				c.Core.Log.NewEvent("ganyu c4 tick", glog.LogCharacterEvent, c.Index, "stacks", c.c4Stacks)
+				c.Core.Log.NewEvent("ganyu c4 tick", glog.LogCharacterEvent, c.Index).
+					Write("stacks", c.c4Stacks)
 			}
 
 			// damage ticks and C4

--- a/internal/characters/hutao/burst.go
+++ b/internal/characters/hutao/burst.go
@@ -50,7 +50,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	//[2:29 PM] Isu: yes, what Aluminum said. PP can't expire during the burst animation, but any other buff can
 	if burstHitmark > c.Core.Status.Duration("paramita") && c.Core.Status.Duration("paramita") > 0 {
 		c.Core.Status.Add("paramita", burstHitmark) //extend this to barely cover the burst
-		c.Core.Log.NewEvent("Paramita status extension for burst", glog.LogCharacterEvent, c.Index, "new_duration", c.Core.Status.Duration("paramita"))
+		c.Core.Log.NewEvent("Paramita status extension for burst", glog.LogCharacterEvent, c.Index).
+			Write("new_duration", c.Core.Status.Duration("paramita"))
 	}
 
 	if c.Core.Status.Duration("paramita") > 0 && c.Base.Cons >= 2 {

--- a/internal/characters/hutao/skill.go
+++ b/internal/characters/hutao/skill.go
@@ -27,7 +27,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	//drains hp
 	c.Core.Status.Add("paramita", 540+skillStart) //to account for animation
 	c.Core.Tasks.Add(c.a1, 540+skillStart)
-	c.Core.Log.NewEvent("paramita activated", glog.LogCharacterEvent, c.Index, "expiry", c.Core.F+540+skillStart)
+	c.Core.Log.NewEvent("paramita activated", glog.LogCharacterEvent, c.Index).
+		Write("expiry", c.Core.F+540+skillStart)
 	//figure out atk buff
 	c.ppBonus = ppatk[c.TalentLvlSkill()] * c.MaxHP()
 	max := (c.Base.Atk + c.Weapon.Atk) * 4
@@ -68,23 +69,29 @@ func (c *char) ppParticles(ac combat.AttackCB) {
 }
 
 func (c *char) applyBB() {
-	c.Core.Log.NewEvent("Applying Blood Blossom", glog.LogCharacterEvent, c.Index, "current dur", c.Core.Status.Duration("htbb"))
+	c.Core.Log.NewEvent("Applying Blood Blossom", glog.LogCharacterEvent, c.Index).
+		Write("current dur", c.Core.Status.Duration("htbb"))
 	//check if blood blossom already active, if active extend duration by 8 second
 	//other wise start first tick func
 	if !c.tickActive {
 		//TODO: does BB tick immediately on first application?
 		c.Core.Tasks.Add(c.bbtickfunc(c.Core.F), 240)
 		c.tickActive = true
-		c.Core.Log.NewEvent("Blood Blossom applied", glog.LogCharacterEvent, c.Index, "expected end", c.Core.F+570, "next expected tick", c.Core.F+240)
+		c.Core.Log.NewEvent("Blood Blossom applied", glog.LogCharacterEvent, c.Index).
+			Write("expected end", c.Core.F+570).
+			Write("next expected tick", c.Core.F+240)
 	}
 	// c.CD["bb"] = c.Core.F + 570 //TODO: no idea how accurate this is, does this screw up the ticks?
 	c.Core.Status.Add("htbb", 570)
-	c.Core.Log.NewEvent("Blood Blossom duration extended", glog.LogCharacterEvent, c.Index, "new expiry", c.Core.Status.Duration("htbb"))
+	c.Core.Log.NewEvent("Blood Blossom duration extended", glog.LogCharacterEvent, c.Index).
+		Write("new expiry", c.Core.Status.Duration("htbb"))
 }
 
 func (c *char) bbtickfunc(src int) func() {
 	return func() {
-		c.Core.Log.NewEvent("Blood Blossom checking for tick", glog.LogCharacterEvent, c.Index, "cd", c.Core.Status.Duration("htbb"), "src", src)
+		c.Core.Log.NewEvent("Blood Blossom checking for tick", glog.LogCharacterEvent, c.Index).
+			Write("cd", c.Core.Status.Duration("htbb")).
+			Write("src", src)
 		if c.Core.Status.Duration("htbb") == 0 {
 			c.tickActive = false
 			return
@@ -106,7 +113,10 @@ func (c *char) bbtickfunc(src int) func() {
 			ai.FlatDmg += c.MaxHP() * 0.1
 		}
 		c.Core.QueueAttack(ai, combat.NewDefSingleTarget(1, combat.TargettableEnemy), 0, 0)
-		c.Core.Log.NewEvent("Blood Blossom ticked", glog.LogCharacterEvent, c.Index, "next expected tick", c.Core.F+240, "dur", c.Core.Status.Duration("htbb"), "src", src)
+		c.Core.Log.NewEvent("Blood Blossom ticked", glog.LogCharacterEvent, c.Index).
+			Write("next expected tick", c.Core.F+240).
+			Write("dur", c.Core.Status.Duration("htbb")).
+			Write("src", src)
 		//only queue if next tick buff will be active still
 		// if c.Core.F+240 > c.CD["bb"] {
 		// 	return

--- a/internal/characters/itto/abil.go
+++ b/internal/characters/itto/abil.go
@@ -197,7 +197,11 @@ func (c *char) Burst(p map[string]int) (int, int) {
 			return val, true
 		},
 	})
-	c.Core.Log.NewEvent("itto burst", core.LogSnapshotEvent, c.Index, "frame", c.Core.F, "total def", burstDefSnapshot, "atk added", fa, "mult", mult)
+	c.Core.Log.NewEvent("itto burst", core.LogSnapshotEvent, c.Index).
+		Write("frame", c.Core.F).
+		Write("total def", burstDefSnapshot).
+		Write("atk added", fa).
+		Write("mult", mult)
 
 	c.Core.Status.AddStatus("ittoq", 960+f) // inflated from 11.55 seconds to cover basic combo
 

--- a/internal/characters/itto/itto.go
+++ b/internal/characters/itto/itto.go
@@ -64,7 +64,8 @@ func (c *char) ActionStam(a core.ActionType, p map[string]int) float64 {
 		}
 		return 20
 	default:
-		c.Core.Log.NewEvent("ActionStam not implemented", core.LogActionEvent, c.Index, "action", a.String())
+		c.Core.Log.NewEvent("ActionStam not implemented", core.LogActionEvent, c.Index).
+			Write("action", a.String())
 		return 0
 	}
 

--- a/internal/characters/jean/skill.go
+++ b/internal/characters/jean/skill.go
@@ -42,7 +42,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	if c.Base.Cons >= 1 && p["hold"] >= 60 {
 		//add 40% dmg
 		snap.Stats[attributes.DmgP] += .4
-		c.Core.Log.NewEvent("jean c1 adding 40% dmg", glog.LogCharacterEvent, c.Index, "final dmg%", snap.Stats[attributes.DmgP])
+		c.Core.Log.NewEvent("jean c1 adding 40% dmg", glog.LogCharacterEvent, c.Index).
+			Write("final dmg%", snap.Stats[attributes.DmgP])
 	}
 
 	c.Core.QueueAttackWithSnap(ai, snap, combat.NewDefCircHit(1, false, combat.TargettableEnemy), hitmark)

--- a/internal/characters/kazuha/asc.go
+++ b/internal/characters/kazuha/asc.go
@@ -47,7 +47,8 @@ func (c *char) a4() {
 				})
 			}
 
-			c.Core.Log.NewEvent("kazuha a4 proc", glog.LogCharacterEvent, c.Index, "reaction", ele.String())
+			c.Core.Log.NewEvent("kazuha a4 proc", glog.LogCharacterEvent, c.Index).
+				Write("reaction", ele.String())
 
 			return false
 		}

--- a/internal/characters/kazuha/kazuha.go
+++ b/internal/characters/kazuha/kazuha.go
@@ -60,6 +60,8 @@ func (c *char) Snapshot(ai *combat.AttackInfo) combat.Snapshot {
 
 	//add 0.2% dmg for every EM
 	ds.Stats[attributes.DmgP] += 0.002 * ds.Stats[attributes.EM]
-	c.Core.Log.NewEvent("c6 adding dmg", glog.LogCharacterEvent, c.Index, "em", ds.Stats[attributes.EM], "final", ds.Stats[attributes.DmgP])
+	c.Core.Log.NewEvent("c6 adding dmg", glog.LogCharacterEvent, c.Index).
+		Write("em", ds.Stats[attributes.EM]).
+		Write("final", ds.Stats[attributes.DmgP])
 	return ds
 }

--- a/internal/characters/keqing/cons.go
+++ b/internal/characters/keqing/cons.go
@@ -19,7 +19,8 @@ func (c *char) c2() {
 		if c.Core.Rand.Float64() < 0.5 {
 			c.c2ICD = c.Core.F + 300
 			c.Core.QueueParticle("keqing", 1, attributes.Electro, 100)
-			c.Core.Log.NewEvent("keqing c2 proc'd", glog.LogCharacterEvent, c.Index, "next ready", c.c2ICD)
+			c.Core.Log.NewEvent("keqing c2 proc'd", glog.LogCharacterEvent, c.Index).
+				Write("next ready", c.c2ICD)
 		}
 		return false
 	}, "keqing-c2")

--- a/internal/characters/klee/asc.go
+++ b/internal/characters/klee/asc.go
@@ -15,7 +15,8 @@ func (c *char) a1(a combat.AttackCB) {
 	}
 	c.sparkICD = c.Core.F + 60*4
 	c.Core.Status.Add("kleespark", 60*30)
-	c.Core.Log.NewEvent("klee gained spark", glog.LogCharacterEvent, c.Index, "icd", c.sparkICD)
+	c.Core.Log.NewEvent("klee gained spark", glog.LogCharacterEvent, c.Index).
+		Write("icd", c.sparkICD)
 }
 
 func (c *char) a4() {

--- a/internal/characters/klee/charge.go
+++ b/internal/characters/klee/charge.go
@@ -41,7 +41,8 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	if c.Core.Status.Duration("kleespark") > 0 {
 		snap.Stats[attributes.DmgP] += .50
 		c.Core.Status.Delete("kleespark")
-		c.Core.Log.NewEvent("klee consumed spark", glog.LogCharacterEvent, c.Index, "icd", c.sparkICD)
+		c.Core.Log.NewEvent("klee consumed spark", glog.LogCharacterEvent, c.Index).
+			Write("icd", c.sparkICD)
 	}
 
 	c.Core.QueueAttackWithSnap(ai, snap, combat.NewDefCircHit(2, false, combat.TargettableEnemy), chargeHitmark+travel)

--- a/internal/characters/kokomi/skill.go
+++ b/internal/characters/kokomi/skill.go
@@ -115,7 +115,10 @@ func (c *char) skillTick(d *combat.AttackEvent) {
 // Skill snapshots, so inputs into the function are the originating snapshot
 func (c *char) skillTickTask(originalSnapshot *combat.AttackEvent, src int) func() {
 	return func() {
-		c.Core.Log.NewEvent("Skill Tick Debug", glog.LogCharacterEvent, c.Index, "current dur", c.Core.Status.Duration("kokomiskill"), "skilllastused", c.skillLastUsed, "src", src)
+		c.Core.Log.NewEvent("Skill Tick Debug", glog.LogCharacterEvent, c.Index).
+			Write("current dur", c.Core.Status.Duration("kokomiskill")).
+			Write("skilllastused", c.skillLastUsed).
+			Write("src", src)
 		if c.Core.Status.Duration("kokomiskill") == 0 {
 			return
 		}

--- a/internal/characters/kuki/skill.go
+++ b/internal/characters/kuki/skill.go
@@ -49,7 +49,9 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	c.SetCD(action.ActionSkill, skillHitmark+15*60) // what's the diff between f and a again? Nice question Yakult
 	c.Core.Tasks.Add(c.bellTick(), 90)              //Assuming this executes every 90 frames-1.5s
 	c.bellActiveUntil = c.Core.F + skilldur
-	c.Core.Log.NewEvent("Bell activated", glog.LogCharacterEvent, c.Index, "expected end", c.bellActiveUntil, "next expected tick", c.Core.F+90)
+	c.Core.Log.NewEvent("Bell activated", glog.LogCharacterEvent, c.Index).
+		Write("expected end", c.bellActiveUntil).
+		Write("next expected tick", c.Core.F+90)
 
 	c.Core.Status.Add("kukibell", skilldur)
 
@@ -88,7 +90,9 @@ func (c *char) bellTick() func() {
 			Bonus:   c.Stat(attributes.Heal),
 		})
 
-		c.Core.Log.NewEvent("Bell ticked", glog.LogCharacterEvent, c.Index, "next expected tick", c.Core.F+90, "active", c.bellActiveUntil)
+		c.Core.Log.NewEvent("Bell ticked", glog.LogCharacterEvent, c.Index).
+			Write("next expected tick", c.Core.F+90).
+			Write("active", c.bellActiveUntil)
 		//trigger damage
 		//TODO: Check for snapshots
 

--- a/internal/characters/mona/burst.go
+++ b/internal/characters/mona/burst.go
@@ -42,7 +42,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		//bubble is applied to each target on a per target basis
 		//lasts 8 seconds if not popped normally
 		t.SetTag(bubbleKey, c.Core.F+481) //1 frame extra so we don't run into problems breaking
-		c.Core.Log.NewEvent("mona bubble on target", glog.LogCharacterEvent, c.Index, "char", c.Index)
+		c.Core.Log.NewEvent("mona bubble on target", glog.LogCharacterEvent, c.Index).
+			Write("char", c.Index)
 	}
 	c.Core.QueueAttack(ai, combat.NewDefCircHit(4, false, combat.TargettableEnemy), -1, burstHitmark, cb)
 

--- a/internal/characters/ningguang/attack.go
+++ b/internal/characters/ningguang/attack.go
@@ -51,7 +51,8 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			if count > 3 {
 				count = 3
 			} else {
-				c.Core.Log.NewEvent("adding star jade", glog.LogCharacterEvent, c.Index, "count", count)
+				c.Core.Log.NewEvent("adding star jade", glog.LogCharacterEvent, c.Index).
+					Write("count", count)
 			}
 			c.Tags["jade"] = count
 		}

--- a/internal/characters/ningguang/burst.go
+++ b/internal/characters/ningguang/burst.go
@@ -52,7 +52,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	if c.Base.Cons >= 6 {
 		c.Tags["jade"] = 7
-		c.Core.Log.NewEvent("c6 - adding star jade", glog.LogCharacterEvent, c.Index, "count", c.Tags["jade"])
+		c.Core.Log.NewEvent("c6 - adding star jade", glog.LogCharacterEvent, c.Index).
+			Write("count", c.Tags["jade"])
 	}
 
 	c.ConsumeEnergy(8)

--- a/internal/characters/noelle/burst.go
+++ b/internal/characters/noelle/burst.go
@@ -43,7 +43,10 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	c.AddStatMod("noelle-burst", 900+burstStart, attributes.ATK, func() ([]float64, bool) {
 		return m, true
 	})
-	c.Core.Log.NewEvent("noelle burst", glog.LogSnapshotEvent, c.Index, "total def", burstDefSnapshot, "atk added", m[attributes.ATK], "mult", mult)
+	c.Core.Log.NewEvent("noelle burst", glog.LogSnapshotEvent, c.Index).
+		Write("total def", burstDefSnapshot).
+		Write("atk added", m[attributes.ATK]).
+		Write("mult", mult)
 
 	c.Core.Status.Add("noelleq", 900+burstStart)
 	// Queue up task for Noelle burst extension
@@ -57,7 +60,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			c.AddStatMod("noelle-burst", 600, attributes.ATK, func() ([]float64, bool) {
 				return m, true
 			})
-			c.Core.Log.NewEvent("noelle max burst extension activated", glog.LogCharacterEvent, c.Index, "new_expiry", c.Core.F+600)
+			c.Core.Log.NewEvent("noelle max burst extension activated", glog.LogCharacterEvent, c.Index).
+				Write("new_expiry", c.Core.F+600)
 			c.Core.Status.Add("noelleq", 600)
 		}, 900+burstStart)
 	}

--- a/internal/characters/qiqi/burst.go
+++ b/internal/characters/qiqi/burst.go
@@ -114,10 +114,11 @@ func (c *char) onNACAHitHook() {
 					"Qiqi A4 Adding Talisman",
 					glog.LogCharacterEvent,
 					c.Index,
-					"target", e.Index(),
-					"talisman_expiry", e.GetTag(talismanKey),
-					"c4_icd_expiry", c.c4ICDExpiry,
-				)
+				).
+					Write("target", e.Index()).
+					Write("talisman_expiry", e.GetTag(talismanKey)).
+					Write("c4_icd_expiry", c.c4ICDExpiry)
+
 			}
 		}
 

--- a/internal/characters/qiqi/cons.go
+++ b/internal/characters/qiqi/cons.go
@@ -18,7 +18,8 @@ func (c *char) c1(a combat.AttackCB) {
 	}
 
 	c.AddEnergy("qiqi-c1", 2)
-	c.Core.Log.NewEvent("Qiqi C1 Activation - Adding 2 energy", glog.LogCharacterEvent, c.Index, "target", a.Target.Index())
+	c.Core.Log.NewEvent("Qiqi C1 Activation - Adding 2 energy", glog.LogCharacterEvent, c.Index).
+		Write("target", a.Target.Index())
 }
 
 //Qiqi's Normal and Charge Attack DMG against opponents affected by Cryo is increased by 15%.

--- a/internal/characters/raiden/burst.go
+++ b/internal/characters/raiden/burst.go
@@ -49,7 +49,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		c.c6Count = 0
 	}
 
-	c.Core.Log.NewEvent("resolve stacks", glog.LogCharacterEvent, c.Index, "stacks", c.stacksConsumed)
+	c.Core.Log.NewEvent("resolve stacks", glog.LogCharacterEvent, c.Index).
+		Write("stacks", c.stacksConsumed)
 
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -85,7 +86,9 @@ func (c *char) burstRestorefunc(a combat.AttackCB) {
 		energy := burstRestore[c.TalentLvlBurst()]
 		//apply a4
 		excess := int(a.AttackEvent.Snapshot.Stats[attributes.ER] / 0.01)
-		c.Core.Log.NewEvent("a4 energy restore stacks", glog.LogCharacterEvent, c.Index, "stacks", excess, "increase", float64(excess)*0.006)
+		c.Core.Log.NewEvent("a4 energy restore stacks", glog.LogCharacterEvent, c.Index).
+			Write("stacks", excess).
+			Write("increase", float64(excess)*0.006)
 		energy = energy * (1 + float64(excess)*0.006)
 		for _, char := range c.Core.Player.Chars() {
 			char.AddEnergy("raiden-burst", energy)

--- a/internal/characters/raiden/cons.go
+++ b/internal/characters/raiden/cons.go
@@ -35,7 +35,9 @@ func (c *char) c6(ac combat.AttackCB) {
 	}
 	c.c6ICD = c.Core.F + 60
 	c.c6Count++
-	c.Core.Log.NewEvent("raiden c6 triggered", glog.LogCharacterEvent, c.Index, "next_icd", c.c6ICD, "count", c.c6Count)
+	c.Core.Log.NewEvent("raiden c6 triggered", glog.LogCharacterEvent, c.Index).
+		Write("next_icd", c.c6ICD).
+		Write("count", c.c6Count)
 	for i, char := range c.Core.Player.Chars() {
 		if i == c.Index {
 			continue

--- a/internal/characters/raiden/raiden.go
+++ b/internal/characters/raiden/raiden.go
@@ -72,7 +72,9 @@ func (c *char) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 	excess := int(s.Stats[attributes.ER] / 0.01)
 
 	s.Stats[attributes.ElectroP] += float64(excess) * 0.004 /// 0.4% extra dmg
-	c.Core.Log.NewEvent("a4 adding electro dmg", glog.LogCharacterEvent, c.Index, "stacks", excess, "final", s.Stats[attributes.ElectroP])
+	c.Core.Log.NewEvent("a4 adding electro dmg", glog.LogCharacterEvent, c.Index).
+		Write("stacks", excess).
+		Write("final", s.Stats[attributes.ElectroP])
 
 	return s
 }

--- a/internal/characters/rosaria/burst.go
+++ b/internal/characters/rosaria/burst.go
@@ -93,7 +93,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			return m, true
 		})
 	}
-	c.Core.Log.NewEvent("Rosaria A4 activation", glog.LogCharacterEvent, c.Index, "ends_on", c.Core.F+600, "crit_share", crit_share)
+	c.Core.Log.NewEvent("Rosaria A4 activation", glog.LogCharacterEvent, c.Index).
+		Write("ends_on", c.Core.F+600).
+		Write("crit_share", crit_share)
 
 	c.SetCD(action.ActionBurst, 15*60)
 	c.ConsumeEnergy(6)

--- a/internal/characters/rosaria/skill.go
+++ b/internal/characters/rosaria/skill.go
@@ -45,7 +45,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		c.AddStatMod("rosaria-a1", 300+skillHitmark, attributes.CR, func() ([]float64, bool) {
 			return m, true
 		})
-		c.Core.Log.NewEvent("Rosaria A1 activation", glog.LogCharacterEvent, c.Index, "ends_on", c.Core.F+300+skillHitmark)
+		c.Core.Log.NewEvent("Rosaria A1 activation", glog.LogCharacterEvent, c.Index).
+			Write("ends_on", c.Core.F+300+skillHitmark)
 	}
 
 	// Rosaria E is dynamic, so requires a second snapshot

--- a/internal/characters/sara/cons.go
+++ b/internal/characters/sara/cons.go
@@ -16,7 +16,8 @@ func (c *char) c1() {
 	}
 	c.c1LastProc = c.Core.F + 180
 	c.ReduceActionCooldown(action.ActionSkill, 60)
-	c.Core.Log.NewEvent("c1 reducing skill cooldown", glog.LogCharacterEvent, c.Index, "new_cooldown", c.Cooldown(action.ActionSkill))
+	c.Core.Log.NewEvent("c1 reducing skill cooldown", glog.LogCharacterEvent, c.Index).
+		Write("new_cooldown", c.Cooldown(action.ActionSkill))
 }
 
 // The Electro DMG of characters who have had their ATK increased by Tengu Juurai has its Crit DMG increased by 60%.

--- a/internal/characters/sara/skill.go
+++ b/internal/characters/sara/skill.go
@@ -63,7 +63,10 @@ func (c *char) attackBuff(delay int) {
 
 		active := c.Core.Player.ActiveChar()
 		active.SetTag("sarabuff", c.Core.F+360)
-		c.Core.Log.NewEvent("sara attack buff applied", glog.LogCharacterEvent, c.Index, "char", active.Index, "buff", buff, "expiry", c.Core.F+360)
+		c.Core.Log.NewEvent("sara attack buff applied", glog.LogCharacterEvent, c.Index).
+			Write("char", active.Index).
+			Write("buff", buff).
+			Write("expiry", c.Core.F+360)
 
 		m := make([]float64, attributes.EndStatType)
 		m[attributes.ATK] = buff

--- a/internal/characters/sayu/skill.go
+++ b/internal/characters/sayu/skill.go
@@ -96,7 +96,8 @@ func (c *char) skillHold(p map[string]int, duration int) action.ActionInfo {
 
 			if c.Base.Cons >= 2 && c.c2Bonus < 0.66 {
 				c.c2Bonus += 0.033
-				c.Core.Log.NewEvent("sayu c2 adding 3.3% dmg", glog.LogCharacterEvent, c.Index, "dmg bonus%", c.c2Bonus)
+				c.Core.Log.NewEvent("sayu c2 adding 3.3% dmg", glog.LogCharacterEvent, c.Index).
+					Write("dmg bonus%", c.c2Bonus)
 			}
 		}, 18+i)
 

--- a/internal/characters/shenhe/skill.go
+++ b/internal/characters/shenhe/skill.go
@@ -174,11 +174,12 @@ func (c *char) quillDamageMod() {
 				"Shenhe Quill proc dmg add",
 				glog.LogPreDamageMod,
 				atk.Info.ActorIndex,
-				"before", atk.Info.FlatDmg,
-				"addition", amt,
-				"effect_ends_at", c.Core.Status.Duration(quillKey),
-				"quills left", c.quillcount[atk.Info.ActorIndex],
-			)
+			).
+				Write("before", atk.Info.FlatDmg).
+				Write("addition", amt).
+				Write("effect_ends_at", c.Core.Status.Duration(quillKey)).
+				Write("quills left", c.quillcount[atk.Info.ActorIndex])
+
 			atk.Info.FlatDmg += amt
 			if c.Base.Cons >= 4 {
 				if c.c4count < 50 {

--- a/internal/characters/sucrose/asc.go
+++ b/internal/characters/sucrose/asc.go
@@ -35,7 +35,9 @@ func (c *char) a1() {
 				})
 			}
 
-			c.Core.Log.NewEvent("sucrose a1 triggered", glog.LogCharacterEvent, c.Index, "reaction", "swirl-"+ele.String(), "expiry", c.Core.F+dur)
+			c.Core.Log.NewEvent("sucrose a1 triggered", glog.LogCharacterEvent, c.Index).
+				Write("reaction", "swirl-"+ele.String()).
+				Write("expiry", c.Core.F+dur)
 			return false
 		}
 	}
@@ -61,5 +63,7 @@ func (c *char) a4() {
 		})
 	}
 
-	c.Core.Log.NewEvent("sucrose a4 triggered", glog.LogCharacterEvent, c.Index, "em snapshot", m[attributes.EM], "expiry", c.Core.F+dur)
+	c.Core.Log.NewEvent("sucrose a4 triggered", glog.LogCharacterEvent, c.Index).
+		Write("em snapshot", m[attributes.EM]).
+		Write("expiry", c.Core.F+dur)
 }

--- a/internal/characters/sucrose/cons.go
+++ b/internal/characters/sucrose/cons.go
@@ -21,7 +21,8 @@ func (c *char) c4() {
 	//we simply reduce the action cd
 	c.ReduceActionCooldown(action.ActionSkill, cdReduction)
 
-	c.Core.Log.NewEvent("sucrose c4 reducing E CD", glog.LogCharacterEvent, c.Index, "cd_reduction", cdReduction)
+	c.Core.Log.NewEvent("sucrose c4 reducing E CD", glog.LogCharacterEvent, c.Index).
+		Write("cd_reduction", cdReduction)
 }
 
 func (c *char) c6() {

--- a/internal/characters/tartaglia/charge.go
+++ b/internal/characters/tartaglia/charge.go
@@ -22,7 +22,8 @@ func init() {
 // Evidence: https://youtu.be/oOfeu5pW0oE
 func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	if c.Core.Status.Duration("tartagliamelee") == 0 {
-		c.Core.Log.NewEvent("charge called when not in melee stance", glog.LogActionEvent, c.Index, "action", action.ActionCharge)
+		c.Core.Log.NewEvent("charge called when not in melee stance", glog.LogActionEvent, c.Index).
+			Write("action", action.ActionCharge)
 		return action.ActionInfo{
 			Frames:          func(action.Action) int { return 1200 },
 			AnimationLength: 1200,

--- a/internal/characters/tartaglia/riptide.go
+++ b/internal/characters/tartaglia/riptide.go
@@ -52,9 +52,10 @@ func (c *char) applyRiptide(src string, t *enemy.Enemy) {
 		fmt.Sprintf("riptide applied (%v)", src),
 		glog.LogCharacterEvent,
 		c.Index,
-		"target", t.Index(),
-		"expiry", c.Core.F+riptideDuration,
-	)
+	).
+		Write("target", t.Index()).
+		Write("expiry", c.Core.F+riptideDuration)
+
 }
 
 // if tartaglia is in melee stance, triggers Riptide Slash against opponents on the field affected by Riptide every 4s, otherwise, triggers Riptide Flash.
@@ -119,11 +120,11 @@ func (c *char) rtFlashTick(t *enemy.Enemy) {
 		"riptide flash triggered",
 		glog.LogCharacterEvent,
 		c.Index,
-		"dur", c.Core.Status.Duration("tartagliamelee"),
-		"target", t.Index(),
-		"riptide_flash_icd", t.GetTag(riptideFlashICDKey),
-		"riptide_expiry", t.GetTag(riptideKey),
-	)
+	).
+		Write("dur", c.Core.Status.Duration("tartagliamelee")).
+		Write("target", t.Index()).
+		Write("riptide_flash_icd", t.GetTag(riptideFlashICDKey)).
+		Write("riptide_expiry", t.GetTag(riptideKey))
 
 	//queue particles
 	if c.rtParticleICD < c.Core.F {
@@ -175,11 +176,11 @@ func (c *char) rtSlashTick(t *enemy.Enemy) {
 		"riptide slash ticked",
 		glog.LogCharacterEvent,
 		c.Index,
-		"dur", c.Core.Status.Duration("tartagliamelee"),
-		"target", t.Index(),
-		"riptide_slash_icd", t.GetTag(riptideSlashICDKey),
-		"riptide_expiry", t.GetTag(riptideKey),
-	)
+	).
+		Write("dur", c.Core.Status.Duration("tartagliamelee")).
+		Write("target", t.Index()).
+		Write("riptide_slash_icd", t.GetTag(riptideSlashICDKey)).
+		Write("riptide_expiry", t.GetTag(riptideKey))
 
 	//queue particle if not on icd
 	if c.rtParticleICD < c.Core.F {
@@ -223,10 +224,10 @@ func (c *char) rtBlastCallback(a combat.AttackCB) {
 		"riptide blast triggered",
 		glog.LogCharacterEvent,
 		c.Index,
-		"dur", c.Core.Status.Duration("tartagliamelee"),
-		"target", t.Index(),
-		"rtExpiry", t.GetTag(riptideKey),
-	)
+	).
+		Write("dur", c.Core.Status.Duration("tartagliamelee")).
+		Write("target", t.Index()).
+		Write("rtExpiry", t.GetTag(riptideKey))
 
 	//clear riptide status
 	t.RemoveTag(riptideKey)

--- a/internal/characters/tartaglia/skill.go
+++ b/internal/characters/tartaglia/skill.go
@@ -38,7 +38,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	c.eCast = c.Core.F
 	c.Core.Status.Add("tartagliamelee", 30*60)
-	c.Core.Log.NewEvent("Foul Legacy activated", glog.LogCharacterEvent, c.Index, "rtexpiry", c.Core.F+30*60)
+	c.Core.Log.NewEvent("Foul Legacy activated", glog.LogCharacterEvent, c.Index).
+		Write("rtexpiry", c.Core.F+30*60)
 
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,

--- a/internal/characters/thoma/burst.go
+++ b/internal/characters/thoma/burst.go
@@ -79,7 +79,8 @@ func (c *char) burstProc() {
 			return false
 		}
 		if icd > c.Core.F {
-			c.Core.Log.NewEvent("thoma Q (active) on icd", glog.LogCharacterEvent, c.Index, "frame", c.Core.F)
+			c.Core.Log.NewEvent("thoma Q (active) on icd", glog.LogCharacterEvent, c.Index).
+				Write("frame", c.Core.F)
 			return false
 		}
 
@@ -110,7 +111,10 @@ func (c *char) burstProc() {
 		}
 		c.Core.QueueAttackEvent(&atk, 1)
 
-		c.Core.Log.NewEvent("thoma Q proc'd", glog.LogCharacterEvent, c.Index, "frame", c.Core.F, "char", ae.Info.ActorIndex, "attack tag", ae.Info.AttackTag)
+		c.Core.Log.NewEvent("thoma Q proc'd", glog.LogCharacterEvent, c.Index).
+			Write("frame", c.Core.F).
+			Write("char", ae.Info.ActorIndex).
+			Write("attack tag", ae.Info.AttackTag)
 
 		icd = c.Core.F + 60 // once per second
 		return false

--- a/internal/characters/travelerelectro/burst.go
+++ b/internal/characters/travelerelectro/burst.go
@@ -114,7 +114,9 @@ func (c *char) burstProc() {
 
 		c.Core.QueueAttackEvent(&atk, 1)
 
-		c.Core.Log.NewEvent("travelerelectro Q proc'd", glog.LogCharacterEvent, c.Index, "char", ae.Info.ActorIndex, "attack tag", ae.Info.AttackTag)
+		c.Core.Log.NewEvent("travelerelectro Q proc'd", glog.LogCharacterEvent, c.Index).
+			Write("char", ae.Info.ActorIndex).
+			Write("attack tag", ae.Info.AttackTag)
 
 		icd = c.Core.F + 30 // 0.5s
 		return false

--- a/internal/characters/travelerelectro/skill.go
+++ b/internal/characters/travelerelectro/skill.go
@@ -80,7 +80,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		c.abundanceAmulets++
 		c.SetTag("generated", c.abundanceAmulets)
 
-		c.Core.Log.NewEvent("travelerelectro abundance amulet generated", glog.LogCharacterEvent, c.Index, "amulets", c.abundanceAmulets)
+		c.Core.Log.NewEvent("travelerelectro abundance amulet generated", glog.LogCharacterEvent, c.Index).
+			Write("amulets", c.abundanceAmulets)
 	}
 
 	for i := 0; i < hits; i++ {

--- a/internal/characters/venti/plunge.go
+++ b/internal/characters/venti/plunge.go
@@ -23,7 +23,8 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 	// check if hold skill was used
 	lastAct := c.Core.Player.LastAction
 	if lastAct.Char != c.Index || lastAct.Type != action.ActionSkill || lastAct.Param["hold"] != 0 {
-		c.Core.Log.NewEvent("high_plunge should be preceded by hold skill", glog.LogActionEvent, c.Index, "action", action.ActionHighPlunge)
+		c.Core.Log.NewEvent("high_plunge should be preceded by hold skill", glog.LogActionEvent, c.Index).
+			Write("action", action.ActionHighPlunge)
 		return action.ActionInfo{
 			Frames:          func(action.Action) int { return 1200 },
 			AnimationLength: 1200,

--- a/internal/characters/xiao/cons.go
+++ b/internal/characters/xiao/cons.go
@@ -54,7 +54,9 @@ func (c *char) c6() {
 			c.ResetActionCooldown(action.ActionSkill)
 
 			c.Core.Status.Add("xiaoc6", 60)
-			c.Core.Log.NewEvent("Xiao C6 activated", glog.LogCharacterEvent, c.Index, "new E charges", c.Tags["eCharge"], "expiry", c.Core.F+60)
+			c.Core.Log.NewEvent("Xiao C6 activated", glog.LogCharacterEvent, c.Index).
+				Write("new E charges", c.Tags["eCharge"]).
+				Write("expiry", c.Core.F+60)
 
 			c.c6Count = 0
 			return false

--- a/internal/characters/xiao/skill.go
+++ b/internal/characters/xiao/skill.go
@@ -62,7 +62,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	if c.Base.Cons < 6 || c.Core.Status.Duration("xiaoc6") == 0 {
 		c.SetCD(action.ActionSkill, 600)
 	} else {
-		c.Core.Log.NewEvent("xiao c6 active, Xiao E used, no charge used, no CD", glog.LogCharacterEvent, c.Index, "c6 remaining duration", c.Core.Status.Duration("xiaoc6"))
+		c.Core.Log.NewEvent("xiao c6 active, Xiao E used, no charge used, no CD", glog.LogCharacterEvent, c.Index).
+			Write("c6 remaining duration", c.Core.Status.Duration("xiaoc6"))
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/xiao/xiao.go
+++ b/internal/characters/xiao/xiao.go
@@ -76,7 +76,10 @@ func (c *char) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 			stacks = 5
 		}
 		ds.Stats[attributes.DmgP] += float64(stacks) * 0.05
-		c.Core.Log.NewEvent("a1 adding dmg %", glog.LogCharacterEvent, c.Index, "stacks", stacks, "final", ds.Stats[attributes.DmgP], "time since burst start", c.Core.F-c.qStarted)
+		c.Core.Log.NewEvent("a1 adding dmg %", glog.LogCharacterEvent, c.Index).
+			Write("stacks", stacks).
+			Write("final", ds.Stats[attributes.DmgP]).
+			Write("time since burst start", c.Core.F-c.qStarted)
 
 		// Anemo conversion and dmg bonus application to normal, charged, and plunge attacks
 		// Also handle burst CA ICD change to share with Normal
@@ -91,7 +94,9 @@ func (c *char) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 		a.Element = attributes.Anemo
 		bonus := burstBonus[c.TalentLvlBurst()]
 		ds.Stats[attributes.DmgP] += bonus
-		c.Core.Log.NewEvent("xiao burst damage bonus", glog.LogCharacterEvent, c.Index, "bonus", bonus, "final", ds.Stats[attributes.DmgP])
+		c.Core.Log.NewEvent("xiao burst damage bonus", glog.LogCharacterEvent, c.Index).
+			Write("bonus", bonus).
+			Write("final", ds.Stats[attributes.DmgP])
 	}
 	return ds
 }

--- a/internal/characters/xingqiu/burst.go
+++ b/internal/characters/xingqiu/burst.go
@@ -47,7 +47,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 	dur = dur * 60
 	c.Core.Status.Add("xqburst", dur+33) // add 33f for anim
-	c.Core.Log.NewEvent("Xingqiu burst activated", glog.LogCharacterEvent, c.Index, "expiry", c.Core.F+dur+33)
+	c.Core.Log.NewEvent("Xingqiu burst activated", glog.LogCharacterEvent, c.Index).
+		Write("expiry", c.Core.F+dur+33)
 
 	orbital, ok := p["orbital"]
 	if !ok {
@@ -156,7 +157,9 @@ func (c *char) burstStateHook() {
 		}
 		//this should start a new ticker if not on ICD and state is correct
 		c.summonSwordWave()
-		c.Core.Log.NewEvent("xq burst on state change", glog.LogCharacterEvent, c.Index, "state", next, "icd", c.burstSwordICD)
+		c.Core.Log.NewEvent("xq burst on state change", glog.LogCharacterEvent, c.Index).
+			Write("state", next).
+			Write("icd", c.burstSwordICD)
 		c.burstTickSrc = c.Core.F
 		c.Core.Tasks.Add(c.burstTickerFunc(c.Core.F), 60) //check every 1sec
 
@@ -171,16 +174,23 @@ func (c *char) burstTickerFunc(src int) func() {
 			return
 		}
 		if c.burstTickSrc != src {
-			c.Core.Log.NewEvent("xq burst tick check ignored, src diff", glog.LogCharacterEvent, c.Index, "src", src, "new src", c.burstTickSrc)
+			c.Core.Log.NewEvent("xq burst tick check ignored, src diff", glog.LogCharacterEvent, c.Index).
+				Write("src", src).
+				Write("new src", c.burstTickSrc)
 			return
 		}
 		//stop if we are no longer in normal animation state
 		state := c.Core.Player.CurrentState()
 		if state != action.NormalAttackState {
-			c.Core.Log.NewEvent("xq burst tick check stopped, not normal state", glog.LogCharacterEvent, c.Index, "src", src, "state", state)
+			c.Core.Log.NewEvent("xq burst tick check stopped, not normal state", glog.LogCharacterEvent, c.Index).
+				Write("src", src).
+				Write("state", state)
 			return
 		}
-		c.Core.Log.NewEvent("xq burst triggered from ticker", glog.LogCharacterEvent, c.Index, "src", src, "state", state, "icd", c.burstSwordICD)
+		c.Core.Log.NewEvent("xq burst triggered from ticker", glog.LogCharacterEvent, c.Index).
+			Write("src", src).
+			Write("state", state).
+			Write("icd", c.burstSwordICD)
 		//we can trigger a wave here b/c we're in normal state still and src is still the same
 		c.summonSwordWave()
 		//in theory this should not hit an icd?

--- a/internal/characters/xingqiu/orbital.go
+++ b/internal/characters/xingqiu/orbital.go
@@ -8,22 +8,28 @@ import (
 
 func (c *char) applyOrbital(duration int, delay int) {
 	src := c.Core.F
-	c.Core.Log.NewEvent("Applying orbital", glog.LogCharacterEvent, c.Index, "current status", c.Core.Status.Duration("xqorb"))
+	c.Core.Log.NewEvent("Applying orbital", glog.LogCharacterEvent, c.Index).
+		Write("current status", c.Core.Status.Duration("xqorb"))
 	//check if orbitals already active, if active extend duration
 	//other wise start first tick func
 	if !c.orbitalActive {
 		c.Core.Tasks.Add(c.orbitalTickTask(src), delay)
 		c.orbitalActive = true
-		c.Core.Log.NewEvent("orbital applied", glog.LogCharacterEvent, c.Index, "expected end", src+900, "next expected tick", src+40)
+		c.Core.Log.NewEvent("orbital applied", glog.LogCharacterEvent, c.Index).
+			Write("expected end", src+900).
+			Write("next expected tick", src+40)
 	}
 
 	c.Core.Status.Add("xqorb", duration)
-	c.Core.Log.NewEvent("orbital duration extended", glog.LogCharacterEvent, c.Index, "new expiry", c.Core.Status.Duration("xqorb"))
+	c.Core.Log.NewEvent("orbital duration extended", glog.LogCharacterEvent, c.Index).
+		Write("new expiry", c.Core.Status.Duration("xqorb"))
 }
 
 func (c *char) orbitalTickTask(src int) func() {
 	return func() {
-		c.Core.Log.NewEvent("orbital checking tick", glog.LogCharacterEvent, c.Index, "expiry", c.Core.Status.Duration("xqorb"), "src", src)
+		c.Core.Log.NewEvent("orbital checking tick", glog.LogCharacterEvent, c.Index).
+			Write("expiry", c.Core.Status.Duration("xqorb")).
+			Write("src", src)
 		if c.Core.Status.Duration("xqorb") == 0 {
 			c.orbitalActive = false
 			return
@@ -38,7 +44,10 @@ func (c *char) orbitalTickTask(src int) func() {
 			Element:    attributes.Hydro,
 			Durability: 25,
 		}
-		c.Core.Log.NewEvent("orbital ticked", glog.LogCharacterEvent, c.Index, "next expected tick", c.Core.F+135, "expiry", c.Core.Status.Duration("xqorb"), "src", src)
+		c.Core.Log.NewEvent("orbital ticked", glog.LogCharacterEvent, c.Index).
+			Write("next expected tick", c.Core.F+135).
+			Write("expiry", c.Core.Status.Duration("xqorb")).
+			Write("src", src)
 
 		//queue up next instance
 		c.Core.Tasks.Add(c.orbitalTickTask(src), 135)

--- a/internal/characters/yaemiko/kitsune.go
+++ b/internal/characters/yaemiko/kitsune.go
@@ -83,7 +83,9 @@ func (c *char) kitsuneBurst(ai combat.AttackInfo, pattern combat.AttackPattern) 
 			}, 94+54+i*24)
 		}
 		c.ResetActionCooldown(action.ActionSkill)
-		c.Core.Log.NewEvent("sky kitsune thunderbolt", glog.LogCharacterEvent, c.Index, "src", c.kitsunes[i].src, "delay", 94+54+i*24)
+		c.Core.Log.NewEvent("sky kitsune thunderbolt", glog.LogCharacterEvent, c.Index).
+			Write("src", c.kitsunes[i].src).
+			Write("delay", 94+54+i*24)
 	}
 	c.popAllKitsune()
 }
@@ -114,7 +116,8 @@ func (c *char) kitsuneTick(totem *kitsune) func() {
 			Durability: 25,
 		}
 
-		c.Core.Log.NewEvent("sky kitsune tick at level", glog.LogCharacterEvent, c.Index, "sakura level", lvl)
+		c.Core.Log.NewEvent("sky kitsune tick at level", glog.LogCharacterEvent, c.Index).
+			Write("sakura level", lvl)
 
 		if c.Base.Cons >= 6 {
 			ai.IgnoreDefPercent = 0.60
@@ -128,7 +131,8 @@ func (c *char) kitsuneTick(totem *kitsune) func() {
 			}
 
 			//on hit check for particles
-			c.Core.Log.NewEvent("sky kitsune particle", glog.LogCharacterEvent, c.Index, "lastParticleF", c.totemParticleICD)
+			c.Core.Log.NewEvent("sky kitsune particle", glog.LogCharacterEvent, c.Index).
+				Write("lastParticleF", c.totemParticleICD)
 			if c.Core.F < c.totemParticleICD {
 				return
 			}

--- a/internal/characters/yanfei/attack.go
+++ b/internal/characters/yanfei/attack.go
@@ -39,7 +39,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			c.Tags["seal"]++
 		}
 		c.sealExpiry = c.Core.F + 600
-		c.Core.Log.NewEvent("yanfei gained a seal from normal attack", glog.LogCharacterEvent, c.Index, "current_seals", c.Tags["seal"], "expiry", c.sealExpiry)
+		c.Core.Log.NewEvent("yanfei gained a seal from normal attack", glog.LogCharacterEvent, c.Index).
+			Write("current_seals", c.Tags["seal"]).
+			Write("expiry", c.sealExpiry)
 		done = true
 	}
 

--- a/internal/characters/yanfei/burst.go
+++ b/internal/characters/yanfei/burst.go
@@ -41,7 +41,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			c.Tags["seal"] = c.maxTags
 		}
 		c.sealExpiry = c.Core.F + 600
-		c.Core.Log.NewEvent("yanfei gained max seals", glog.LogCharacterEvent, c.Index, "current_seals", c.Tags["seal"], "expiry", c.sealExpiry)
+		c.Core.Log.NewEvent("yanfei gained max seals", glog.LogCharacterEvent, c.Index).
+			Write("current_seals", c.Tags["seal"]).
+			Write("expiry", c.sealExpiry)
 		done = true
 	}
 
@@ -85,7 +87,9 @@ func (c *char) burstAddSealHook() func() {
 		}
 		c.sealExpiry = c.Core.F + 600
 
-		c.Core.Log.NewEvent("yanfei gained seal from burst", glog.LogCharacterEvent, c.Index, "current_seals", c.Tags["seal"], "expiry", c.sealExpiry)
+		c.Core.Log.NewEvent("yanfei gained seal from burst", glog.LogCharacterEvent, c.Index).
+			Write("current_seals", c.Tags["seal"]).
+			Write("expiry", c.sealExpiry)
 
 		c.Core.Tasks.Add(c.burstAddSealHook(), 60)
 	}

--- a/internal/characters/yanfei/charge.go
+++ b/internal/characters/yanfei/charge.go
@@ -44,7 +44,9 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	// TODO: Not sure of snapshot timing
 	c.Core.QueueAttack(ai, combat.NewDefCircHit(2, false, combat.TargettableEnemy), chargeHitmark, chargeHitmark)
 
-	c.Core.Log.NewEvent("yanfei charge attack consumed seals", glog.LogCharacterEvent, c.Index, "current_seals", c.Tags["seal"], "expiry", c.sealExpiry)
+	c.Core.Log.NewEvent("yanfei charge attack consumed seals", glog.LogCharacterEvent, c.Index).
+		Write("current_seals", c.Tags["seal"]).
+		Write("expiry", c.sealExpiry)
 
 	// Clear the seals next frame just in case for some reason we call stam check late
 	c.Core.Tasks.Add(func() {

--- a/internal/characters/yanfei/skill.go
+++ b/internal/characters/yanfei/skill.go
@@ -29,7 +29,9 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			c.Tags["seal"] = c.maxTags
 		}
 		c.sealExpiry = c.Core.F + 600
-		c.Core.Log.NewEvent("yanfei gained max seals", glog.LogCharacterEvent, c.Index, "current_seals", c.Tags["seal"], "expiry", c.sealExpiry)
+		c.Core.Log.NewEvent("yanfei gained max seals", glog.LogCharacterEvent, c.Index).
+			Write("current_seals", c.Tags["seal"]).
+			Write("expiry", c.sealExpiry)
 		done = true
 	}
 

--- a/internal/characters/yelan/burst.go
+++ b/internal/characters/yelan/burst.go
@@ -51,7 +51,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		c.Core.Status.Add(c6Status, 20*60)
 		c.c6count = 0
 	}
-	c.Core.Log.NewEvent("burst activated", glog.LogCharacterEvent, c.Index, "expiry", c.Core.F+15*60)
+	c.Core.Log.NewEvent("burst activated", glog.LogCharacterEvent, c.Index).
+		Write("expiry", c.Core.F+15*60)
 
 	c.SetCD(action.ActionBurst, 18*60)
 	c.ConsumeEnergy(6)
@@ -126,7 +127,9 @@ func (c *char) burstStateHook() {
 		}
 		//this should start a new ticker if not on ICD and state is correct
 		c.summonExquisiteThrow()
-		c.Core.Log.NewEvent("yelan burst on state change", glog.LogCharacterEvent, c.Index, "state", next, "icd", c.burstDiceICD)
+		c.Core.Log.NewEvent("yelan burst on state change", glog.LogCharacterEvent, c.Index).
+			Write("state", next).
+			Write("icd", c.burstDiceICD)
 		c.burstTickSrc = c.Core.F
 		c.Core.Tasks.Add(c.burstTickerFunc(c.Core.F), 60) //check every 1sec
 
@@ -141,16 +144,23 @@ func (c *char) burstTickerFunc(src int) func() {
 			return
 		}
 		if c.burstTickSrc != src {
-			c.Core.Log.NewEvent("yelan burst tick check ignored, src diff", glog.LogCharacterEvent, c.Index, "src", src, "new src", c.burstTickSrc)
+			c.Core.Log.NewEvent("yelan burst tick check ignored, src diff", glog.LogCharacterEvent, c.Index).
+				Write("src", src).
+				Write("new src", c.burstTickSrc)
 			return
 		}
 		//stop if we are no longer in normal animation state
 		state := c.Core.Player.CurrentState()
 		if state != action.NormalAttackState {
-			c.Core.Log.NewEvent("yelan burst tick check stopped, not normal state", glog.LogCharacterEvent, c.Index, "src", src, "state", state)
+			c.Core.Log.NewEvent("yelan burst tick check stopped, not normal state", glog.LogCharacterEvent, c.Index).
+				Write("src", src).
+				Write("state", state)
 			return
 		}
-		c.Core.Log.NewEvent("yelan burst triggered from ticker", glog.LogCharacterEvent, c.Index, "src", src, "state", state, "icd", c.burstDiceICD)
+		c.Core.Log.NewEvent("yelan burst triggered from ticker", glog.LogCharacterEvent, c.Index).
+			Write("src", src).
+			Write("state", state).
+			Write("icd", c.burstDiceICD)
 		//we can trigger a wave here b/c we're in normal state still and src is still the same
 		c.summonExquisiteThrow()
 		//in theory this should not hit an icd?

--- a/internal/characters/yelan/skill.go
+++ b/internal/characters/yelan/skill.go
@@ -70,7 +70,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 				continue
 			}
 			e.SetTag(skillMarkedTag, 1)
-			c.Core.Log.NewEvent("marked by Lifeline", glog.LogCharacterEvent, c.Index, "target", e.Index())
+			c.Core.Log.NewEvent("marked by Lifeline", glog.LogCharacterEvent, c.Index).
+				Write("target", e.Index())
 			marked--
 			c.c4count++
 			if c.Base.Cons >= 4 {
@@ -92,7 +93,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		//TODO: icd on this??
 		if c.Core.Status.Duration(burstStatus) > 0 {
 			c.exquisiteThrowSkillProc()
-			c.Core.Log.NewEvent("yelan burst on skill", glog.LogCharacterEvent, c.Index, "icd", c.burstDiceICD)
+			c.Core.Log.NewEvent("yelan burst on skill", glog.LogCharacterEvent, c.Index).
+				Write("icd", c.burstDiceICD)
 		}
 	}
 
@@ -107,7 +109,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 				continue
 			}
 			e.SetTag(skillMarkedTag, 0)
-			c.Core.Log.NewEvent("damaging marked target", glog.LogCharacterEvent, c.Index, "target", e.Index())
+			c.Core.Log.NewEvent("damaging marked target", glog.LogCharacterEvent, c.Index).
+				Write("target", e.Index())
 			marked--
 			//queueing attack one frame later
 			//TODO: does hold have different attack size? don't think so?
@@ -122,7 +125,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			if m[attributes.HPP] > 0.4 {
 				m[attributes.HPP] = 0.4
 			}
-			c.Core.Log.NewEvent("c4 activated", glog.LogCharacterEvent, c.Index, "enemies count", c.c4count)
+			c.Core.Log.NewEvent("c4 activated", glog.LogCharacterEvent, c.Index).
+				Write("enemies count", c.c4count)
 			for _, char := range c.Core.Player.Chars() {
 				char.AddStatMod("yelan-c4", 25*60, attributes.HPP, func() ([]float64, bool) {
 					return m, true

--- a/internal/characters/yoimiya/yoimiya.go
+++ b/internal/characters/yoimiya/yoimiya.go
@@ -58,7 +58,10 @@ func (c *char) Snapshot(ai *combat.AttackInfo) combat.Snapshot {
 	if c.Core.Status.Duration("yoimiyaskill") > 0 && ai.AttackTag == combat.AttackTagNormal {
 		ai.Element = attributes.Pyro
 		ai.Mult = skill[c.TalentLvlSkill()] * ai.Mult
-		c.Core.Log.NewEvent("skill mult applied", glog.LogCharacterEvent, c.Index, "prev", ai.Mult, "next", skill[c.TalentLvlSkill()]*ai.Mult, "char", c.Index)
+		c.Core.Log.NewEvent("skill mult applied", glog.LogCharacterEvent, c.Index).
+			Write("prev", ai.Mult).
+			Write("next", skill[c.TalentLvlSkill()]*ai.Mult).
+			Write("char", c.Index)
 	}
 
 	return ds

--- a/internal/characters/yunjin/burst.go
+++ b/internal/characters/yunjin/burst.go
@@ -88,7 +88,10 @@ func (c *char) burstProc() {
 		c.burstTriggers[ae.Info.ActorIndex]--
 		c.updateBuffTags()
 
-		c.Core.Log.NewEvent("yunjin burst adding damage", glog.LogPreDamageMod, ae.Info.ActorIndex, "damage_added", dmgAdded, "stacks_remaining_for_char", c.burstTriggers[ae.Info.ActorIndex], "burst_def_pct", finalBurstBuff)
+		c.Core.Log.NewEvent("yunjin burst adding damage", glog.LogPreDamageMod, ae.Info.ActorIndex).
+			Write("damage_added", dmgAdded).
+			Write("stacks_remaining_for_char", c.burstTriggers[ae.Info.ActorIndex]).
+			Write("burst_def_pct", finalBurstBuff)
 
 		return false
 	}, "yunjin-burst")

--- a/internal/characters/yunjin/yunjin.go
+++ b/internal/characters/yunjin/yunjin.go
@@ -61,5 +61,6 @@ func (c *char) getPartyElementalTypeCounts() {
 	for range partyElementalTypes {
 		c.partyElementalTypes += 1
 	}
-	c.Core.Log.NewEvent("Yun Jin Party Elemental Types (A4)", glog.LogCharacterEvent, c.Index, "party_elements", c.partyElementalTypes)
+	c.Core.Log.NewEvent("Yun Jin Party Elemental Types (A4)", glog.LogCharacterEvent, c.Index).
+		Write("party_elements", c.partyElementalTypes)
 }

--- a/internal/characters/zhongli/shield.go
+++ b/internal/characters/zhongli/shield.go
@@ -30,7 +30,9 @@ func (c *char) addJadeShield() {
 		}
 	}
 
-	c.Core.Log.NewEvent("zhongli res shred active", glog.LogCharacterEvent, c.Index, "expiry", c.Core.F+1200, "char", c.Index)
+	c.Core.Log.NewEvent("zhongli res shred active", glog.LogCharacterEvent, c.Index).
+		Write("expiry", c.Core.F+1200).
+		Write("char", c.Index)
 }
 
 func (c *char) removeJadeShield() {
@@ -49,7 +51,8 @@ func (c *char) removeJadeShield() {
 			e.DeleteResistMod(key)
 		}
 	}
-	c.Core.Log.NewEvent("zhongli res shred deactivated", glog.LogCharacterEvent, c.Index, "char", c.Index)
+	c.Core.Log.NewEvent("zhongli res shred deactivated", glog.LogCharacterEvent, c.Index).
+		Write("char", c.Index)
 }
 
 func (c *char) newShield(base float64, dur int) *shd {

--- a/internal/characters/zhongli/stele.go
+++ b/internal/characters/zhongli/stele.go
@@ -40,11 +40,12 @@ func (c *char) newStele(dur int, max int) {
 		"Stele added",
 		glog.LogCharacterEvent,
 		c.Index,
-		"orig_count", num,
-		"cur_count", c.steleCount,
-		"max_hit", max,
-		"next_tick", c.Core.F+120,
-	)
+	).
+		Write("orig_count", num).
+		Write("cur_count", c.steleCount).
+		Write("max_hit", max).
+		Write("next_tick", c.Core.F+120)
+
 	// Snapshot buffs for resonance ticks
 	aiSnap := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -71,11 +72,16 @@ func (c *char) newStele(dur int, max int) {
 
 func (c *char) resonance(src, max int) func() {
 	return func() {
-		c.Core.Log.NewEvent("Stele checking for tick", glog.LogCharacterEvent, c.Index, "src", src, "char", c.Index)
+		c.Core.Log.NewEvent("Stele checking for tick", glog.LogCharacterEvent, c.Index).
+			Write("src", src).
+			Write("char", c.Index)
 		if !c.Core.Constructs.Has(src) {
 			return
 		}
-		c.Core.Log.NewEvent("Stele ticked", glog.LogCharacterEvent, c.Index, "next expected", c.Core.F+120, "src", src, "char", c.Index)
+		c.Core.Log.NewEvent("Stele ticked", glog.LogCharacterEvent, c.Index).
+			Write("next expected", c.Core.F+120).
+			Write("src", src).
+			Write("char", c.Index)
 
 		// Use snapshot for damage
 		ae := c.steleSnapshot

--- a/internal/template/character/character.go
+++ b/internal/template/character/character.go
@@ -66,15 +66,13 @@ func (c *Character) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 	var debug []interface{}
 
 	if c.Core.Flags.LogDebug {
-		evt = c.Core.Log.NewEvent(
-			a.Abil, glog.LogSnapshotEvent, c.Index,
-			"abil", a.Abil,
-			"mult", a.Mult,
-			"ele", a.Element.String(),
-			"durability", float64(a.Durability),
-			"icd_tag", a.ICDTag,
-			"icd_group", a.ICDGroup,
-		)
+		evt = c.Core.Log.NewEvent(a.Abil, glog.LogSnapshotEvent, c.Index).
+			Write("abil", a.Abil).
+			Write("mult", a.Mult).
+			Write("ele", a.Element.String()).
+			Write("durability", float64(a.Durability)).
+			Write("icd_tag", a.ICDTag).
+			Write("icd_group", a.ICDGroup)
 	}
 
 	//snapshot the stats
@@ -91,7 +89,7 @@ func (c *Character) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 
 	//check if we need to log
 	if c.Core.Flags.LogDebug {
-		evt.Write(debug...)
+		evt.WriteOld(debug...)
 		evt.Write("final_stats", attributes.PrettyPrintStatsSlice(s.Stats[:]))
 		if inf != attributes.NoElement {
 			evt.Write("infused_ele", inf.String())

--- a/internal/template/character/character.go
+++ b/internal/template/character/character.go
@@ -89,7 +89,7 @@ func (c *Character) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 
 	//check if we need to log
 	if c.Core.Flags.LogDebug {
-		evt.WriteOld(debug...)
+		evt.WriteBuildMsg(debug...)
 		evt.Write("final_stats", attributes.PrettyPrintStatsSlice(s.Stats[:]))
 		if inf != attributes.NoElement {
 			evt.Write("infused_ele", inf.String())

--- a/internal/template/character/cooldown.go
+++ b/internal/template/character/cooldown.go
@@ -45,16 +45,11 @@ func (c *Character) SetCD(a action.Action, dur int) {
 	if c.Tags["skill_charge"] > 0 {
 		c.Tags["skill_charge"]--
 	}
-	c.Core.Log.NewEventBuildMsg(
-		glog.LogCooldownEvent,
-		c.Index,
-		a.String(), " cooldown triggered",
-	).Write(
-		"type", a.String(),
-		"expiry", c.Cooldown(a),
-		"charges_remain", c.AvailableCDCharge,
-		"cooldown_queue", c.cdQueue,
-	)
+	c.Core.Log.NewEventBuildMsg(glog.LogCooldownEvent, c.Index, a.String(), " cooldown triggered").
+		Write("type", a.String()).
+		Write("expiry", c.Cooldown(a)).
+		Write("charges_remain", c.AvailableCDCharge).
+		Write("cooldown_queue", c.cdQueue)
 }
 
 func (c *Character) SetNumCharges(a action.Action, num int) {
@@ -100,15 +95,10 @@ func (c *Character) ResetActionCooldown(a action.Action) {
 	//reset worker time
 	c.cdQueueWorkerStartedAt[a] = c.Core.F
 	c.cdCurrentQueueWorker[a] = nil
-	c.Core.Log.NewEventBuildMsg(
-		glog.LogCooldownEvent,
-		c.Index,
-		a.String(), " cooldown forcefully reset",
-	).Write(
-		"type", a.String(),
-		"charges_remain", c.AvailableCDCharge,
-		"cooldown_queue", c.cdQueue,
-	)
+	c.Core.Log.NewEventBuildMsg(glog.LogCooldownEvent, c.Index, a.String(), " cooldown forcefully reset").
+		Write("type", a.String()).
+		Write("charges_remain", c.AvailableCDCharge).
+		Write("cooldown_queue", c.cdQueue)
 	//check if anymore cd in queue
 	if len(c.cdQueue) > 0 {
 		c.startCooldownQueueWorker(a, true)
@@ -129,16 +119,11 @@ func (c *Character) ReduceActionCooldown(a action.Action, v int) {
 	}
 	//otherwise reduce remain and restart queue
 	c.cdQueue[a][0] = remain - v
-	c.Core.Log.NewEventBuildMsg(
-		glog.LogCooldownEvent,
-		c.Index,
-		a.String(), " cooldown forcefully reduced",
-	).Write(
-		"type", a.String(),
-		"expiry", c.Cooldown(a),
-		"charges_remain", c.AvailableCDCharge,
-		"cooldown_queue", c.cdQueue,
-	)
+	c.Core.Log.NewEventBuildMsg(glog.LogCooldownEvent, c.Index, a.String(), " cooldown forcefully reduced").
+		Write("type", a.String()).
+		Write("expiry", c.Cooldown(a)).
+		Write("charges_remain", c.AvailableCDCharge).
+		Write("cooldown_queue", c.cdQueue)
 	c.startCooldownQueueWorker(a, false)
 	//log.Printf("started: %v, new queue: %v, worker frame: %v\n", c.cdQueueWorkerStartedAt[a], c.cdQueue[a], c.cdQueueWorkerStartedAt[a])
 }
@@ -190,15 +175,10 @@ func (c *Character) startCooldownQueueWorker(a action.Action, cdReduct bool) {
 			panic(fmt.Sprintf("charges > max? index :%v, frame : %v", c.Index, c.Core.F))
 		}
 
-		c.Core.Log.NewEventBuildMsg(
-			glog.LogCooldownEvent,
-			c.Index,
-			a.String(), " cooldown ready",
-		).Write(
-			"type", a.String(),
-			"charges_remain", c.AvailableCDCharge,
-			"cooldown_queue", c.cdQueue,
-		)
+		c.Core.Log.NewEventBuildMsg(glog.LogCooldownEvent, c.Index, a.String(), " cooldown ready").
+			Write("type", a.String()).
+			Write("charges_remain", c.AvailableCDCharge).
+			Write("cooldown_queue", c.cdQueue)
 
 		//if queue still has len > 0 then call start queue again
 		if len(c.cdQueue) > 0 {

--- a/internal/template/character/ready.go
+++ b/internal/template/character/ready.go
@@ -16,14 +16,16 @@ func (c *Character) ActionReady(a action.Action, p map[string]int) bool {
 	case action.ActionCharge:
 		req := c.Core.Player.AbilStamCost(c.Index, a, p)
 		if c.Core.Player.Stam < req {
-			c.Core.Log.NewEvent("insufficient stam: charge attack", glog.LogWarnings, -1, "have", c.Core.Player.Stam)
+			c.Core.Log.NewEvent("insufficient stam: charge attack", glog.LogWarnings, -1).
+				Write("have", c.Core.Player.Stam)
 			return false
 		}
 		return true
 	case action.ActionDash:
 		req := c.Core.Player.AbilStamCost(c.Index, a, p)
 		if c.Core.Player.Stam < req {
-			c.Core.Log.NewEvent("insufficient stam: dash", glog.LogWarnings, -1, "have", c.Core.Player.Stam)
+			c.Core.Log.NewEvent("insufficient stam: dash", glog.LogWarnings, -1).
+				Write("have", c.Core.Player.Stam)
 			return false
 		}
 		return true

--- a/internal/weapons/bow/twilight/twilight.go
+++ b/internal/weapons/bow/twilight/twilight.go
@@ -60,7 +60,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		icd = c.F + 420
 		cycle++
 		cycle = cycle % 3
-		c.Log.NewEvent("fading twillight cycle changed", glog.LogWeaponEvent, char.Index, "cycle", cycle, "next cycle", icd)
+		c.Log.NewEvent("fading twillight cycle changed", glog.LogWeaponEvent, char.Index).
+			Write("cycle", cycle).
+			Write("next cycle", icd)
 
 		return false
 	}, fmt.Sprintf("fadingtwilight-%v", char.Base.Name))

--- a/internal/weapons/catalyst/hakushin/hakushin.go
+++ b/internal/weapons/catalyst/hakushin/hakushin.go
@@ -64,7 +64,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 					return m, true
 				})
 			}
-			c.Log.NewEvent("hakushin proc'd", glog.LogWeaponEvent, char.Index, "trigger", key, "expiring", c.F+6*60)
+			c.Log.NewEvent("hakushin proc'd", glog.LogWeaponEvent, char.Index).
+				Write("trigger", key).
+				Write("expiring", c.F+6*60)
 			return false
 		}
 	}

--- a/internal/weapons/catalyst/mappa/mappa.go
+++ b/internal/weapons/catalyst/mappa/mappa.go
@@ -41,10 +41,14 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if c.F > dur {
 			stacks = 1
 			dur = c.F + 600
-			c.Log.NewEvent("mappa proc'd", glog.LogWeaponEvent, char.Index, "stacks", stacks, "expiry", dur)
+			c.Log.NewEvent("mappa proc'd", glog.LogWeaponEvent, char.Index).
+				Write("stacks", stacks).
+				Write("expiry", dur)
 		} else if stacks < 2 {
 			stacks++
-			c.Log.NewEvent("mappa proc'd", glog.LogWeaponEvent, char.Index, "stacks", stacks, "expiry", dur)
+			c.Log.NewEvent("mappa proc'd", glog.LogWeaponEvent, char.Index).
+				Write("stacks", stacks).
+				Write("expiry", dur)
 		}
 		return false
 	}

--- a/internal/weapons/catalyst/moonglow/moonglow.go
+++ b/internal/weapons/catalyst/moonglow/moonglow.go
@@ -48,7 +48,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		flatdmg := char.MaxHP() * nabuff
 		atk.Info.FlatDmg += flatdmg
 
-		c.Log.NewEvent("moonglow add damage", glog.LogPreDamageMod, char.Index, "damage_added", flatdmg)
+		c.Log.NewEvent("moonglow add damage", glog.LogPreDamageMod, char.Index).
+			Write("damage_added", flatdmg)
 		return false
 	}, fmt.Sprintf("moonglow-nabuff-%v", char.Base.Name))
 

--- a/internal/weapons/catalyst/thrilling/thrilling.go
+++ b/internal/weapons/catalyst/thrilling/thrilling.go
@@ -59,7 +59,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 				return m, true
 			})
 
-			c.Log.NewEvent("ttds activated", glog.LogWeaponEvent, c.Player.Active(), "expiry", c.F+600)
+			c.Log.NewEvent("ttds activated", glog.LogWeaponEvent, c.Player.Active()).
+				Write("expiry", c.F+600)
 		}
 
 		return false

--- a/internal/weapons/catalyst/widsith/widsith.go
+++ b/internal/weapons/catalyst/widsith/widsith.go
@@ -70,7 +70,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			}
 			return buff[state], true
 		})
-		c.Log.NewEvent("widsith proc'd", glog.LogWeaponEvent, char.Index, "stat", stats[state], "expiring", expiry)
+		c.Log.NewEvent("widsith proc'd", glog.LogWeaponEvent, char.Index).
+			Write("stat", stats[state]).
+			Write("expiring", expiry)
 
 		return false
 	}, fmt.Sprintf("width-%v", char.Base.Name))

--- a/internal/weapons/claymore/redhorn/redhorn.go
+++ b/internal/weapons/claymore/redhorn/redhorn.go
@@ -47,7 +47,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		}
 		baseDmgAdd := (atk.Snapshot.BaseDef*(1+atk.Snapshot.Stats[attributes.DEFP]) + atk.Snapshot.Stats[attributes.DEF]) * nacaBoost
 		atk.Info.FlatDmg += baseDmgAdd
-		c.Log.NewEvent("Redhorn proc dmg add", glog.LogPreDamageMod, char.Index, "base_added_dmg", baseDmgAdd)
+		c.Log.NewEvent("Redhorn proc dmg add", glog.LogPreDamageMod, char.Index).
+			Write("base_added_dmg", baseDmgAdd)
 		return false
 	}, fmt.Sprintf("redhorn-%v", char.Base.Name))
 

--- a/internal/weapons/claymore/skyward/skyward.go
+++ b/internal/weapons/claymore/skyward/skyward.go
@@ -48,7 +48,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		}
 		dur = c.F + 1200
 		counter = 0
-		c.Log.NewEvent("Skyward Pride activated", glog.LogWeaponEvent, char.Index, "expiring ", dur)
+		c.Log.NewEvent("Skyward Pride activated", glog.LogWeaponEvent, char.Index).
+			Write("expiring ", dur)
 		return false
 	}, fmt.Sprintf("skyward-pride-%v", char.Base.Name))
 

--- a/internal/weapons/claymore/spine/spine.go
+++ b/internal/weapons/claymore/spine/spine.go
@@ -65,8 +65,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	w.stacks = p.Params["stacks"]
 	c.Log.NewEvent(
 		"serpent spine stack check", glog.LogWeaponEvent, char.Index,
-		"params", p.Params,
-	)
+	).
+		Write("params", p.Params)
+
 	if w.stacks > 5 {
 		w.stacks = 5
 	}

--- a/internal/weapons/common/wavebreaker.go
+++ b/internal/weapons/common/wavebreaker.go
@@ -39,7 +39,11 @@ func NewWavebreaker(c *core.Core, char *character.CharWrapper, p weapon.WeaponPr
 		if amt > max {
 			amt = max
 		}
-		c.Log.NewEvent("wavebreaker dmg calc", glog.LogWeaponEvent, char.Index, "total", energy, "per", per, "max", max, "amt", amt)
+		c.Log.NewEvent("wavebreaker dmg calc", glog.LogWeaponEvent, char.Index).
+			Write("total", energy).
+			Write("per", per).
+			Write("max", max).
+			Write("amt", amt)
 		m := make([]float64, attributes.EndStatType)
 		m[attributes.DmgP] = amt
 		char.AddAttackMod("wavebreaker", -1, func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {

--- a/internal/weapons/spear/crescent/crescent.go
+++ b/internal/weapons/spear/crescent/crescent.go
@@ -35,7 +35,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if c.Player.Active() != char.Index {
 			return false
 		}
-		c.Log.NewEvent("crescent pike active", glog.LogWeaponEvent, char.Index, "expiry", c.F+300)
+		c.Log.NewEvent("crescent pike active", glog.LogWeaponEvent, char.Index).
+			Write("expiry", c.F+300)
 		active = c.F + 300
 
 		return false

--- a/internal/weapons/spear/engulfing/engulfing.go
+++ b/internal/weapons/spear/engulfing/engulfing.go
@@ -36,7 +36,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	val := make([]float64, attributes.EndStatType)
 	char.AddStatMod("engulfing-lightning", -1, attributes.ATKP, func() ([]float64, bool) {
 		er := char.Stat(attributes.ER)
-		c.Log.NewEvent("engulfing lightning snapshot", glog.LogWeaponEvent, char.Index, "er", er)
+		c.Log.NewEvent("engulfing lightning snapshot", glog.LogWeaponEvent, char.Index).
+			Write("er", er)
 		bonus := atk * er
 		if bonus > max {
 			bonus = max

--- a/internal/weapons/sword/amenoma/amenoma.go
+++ b/internal/weapons/sword/amenoma/amenoma.go
@@ -51,7 +51,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		}
 		seeds[index] = c.F + 30*60
 
-		c.Log.NewEvent("amenoma proc'd", glog.LogWeaponEvent, char.Index, "index", index, "seeds", seeds)
+		c.Log.NewEvent("amenoma proc'd", glog.LogWeaponEvent, char.Index).
+			Write("index", index).
+			Write("seeds", seeds)
 
 		icd = c.F + 300 //5 seconds
 

--- a/internal/weapons/sword/cinnabar/cinnnabar.go
+++ b/internal/weapons/sword/cinnabar/cinnnabar.go
@@ -49,7 +49,11 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		damageAdd := (atk.Snapshot.BaseDef*(1+atk.Snapshot.Stats[attributes.DEFP]) + atk.Snapshot.Stats[attributes.DEF]) * defPer
 		atk.Info.FlatDmg += damageAdd
 
-		c.Log.NewEvent("Cinnabar Spindle proc dmg add", glog.LogPreDamageMod, char.Index, "damage_added", damageAdd, "lastproc", effectLastProc, "effect_ends_at", effectDurationExpiry, "effect_icd_ends_at", effectICDExpiry)
+		c.Log.NewEvent("Cinnabar Spindle proc dmg add", glog.LogPreDamageMod, char.Index).
+			Write("damage_added", damageAdd).
+			Write("lastproc", effectLastProc).
+			Write("effect_ends_at", effectDurationExpiry).
+			Write("effect_icd_ends_at", effectICDExpiry)
 
 		// TODO: Assumes that the ICD starts after the last duration ends
 		effectICDExpiry = c.F + 6 + 90

--- a/internal/weapons/sword/freedom/freedom.go
+++ b/internal/weapons/sword/freedom/freedom.go
@@ -68,7 +68,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 
 		icd = c.F + 30
 		stacks++
-		c.Log.NewEvent("freedomsworn gained sigil", glog.LogWeaponEvent, char.Index, "sigil", stacks)
+		c.Log.NewEvent("freedomsworn gained sigil", glog.LogWeaponEvent, char.Index).
+			Write("sigil", stacks)
 
 		if stacks == 2 {
 			stacks = 0

--- a/internal/weapons/sword/haran/haran.go
+++ b/internal/weapons/sword/haran/haran.go
@@ -61,7 +61,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			if wavespikeStacks > maxWavespikeStacks {
 				wavespikeStacks = maxWavespikeStacks
 			}
-			c.Log.NewEvent("Haran gained a wavespike stack", glog.LogWeaponEvent, char.Index, "stack", wavespikeStacks)
+			c.Log.NewEvent("Haran gained a wavespike stack", glog.LogWeaponEvent, char.Index).
+				Write("stack", wavespikeStacks)
 			wavespikeICD = c.F + 0.3*60
 		}
 		return false

--- a/internal/weapons/sword/skyward/skyward.go
+++ b/internal/weapons/sword/skyward/skyward.go
@@ -50,7 +50,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		char.AddStatMod("skyward blade", 720, attributes.NoStat, func() ([]float64, bool) {
 			return atkspdBuff, true
 		})
-		c.Log.NewEvent("Skyward Blade activated", glog.LogWeaponEvent, char.Index, "expiring ", dur)
+		c.Log.NewEvent("Skyward Blade activated", glog.LogWeaponEvent, char.Index).
+			Write("expiring ", dur)
 		return false
 	}, fmt.Sprintf("skyward-blade-%v", char.Base.Name))
 

--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -29,7 +29,9 @@ func (p *Player) Attack(ae *combat.AttackEvent, evt glog.Event) (float64, bool) 
 
 func (p *Player) ApplySelfInfusion(ele attributes.Element, dur combat.Durability, f int) {
 
-	p.Core.Log.NewEventBuildMsg(glog.LogPlayerEvent, -1, "self infusion applied: "+ele.String()).Write("durability", dur, "duration", f)
+	p.Core.Log.NewEventBuildMsg(glog.LogPlayerEvent, -1, "self infusion applied: "+ele.String()).
+		Write("durability", dur).
+		Write("duration", f)
 	//we're assuming self infusion isn't subject to 0.8x multiplier
 	//also no real sanity check
 	if ele == attributes.Frozen {
@@ -59,13 +61,13 @@ func (p *Player) ReactWithSelf(atk *combat.AttackEvent) {
 	existing := p.Reactable.ActiveAuraString()
 	applied := atk.Info.Durability
 	p.React(atk)
-	p.Core.Log.NewEvent("self reaction occured", glog.LogElementEvent, atk.Info.ActorIndex,
-		"attack_tag", atk.Info.AttackTag,
-		"applied_ele", atk.Info.Element.String(),
-		"dur", applied,
-		"abil", atk.Info.Abil,
-		"target", 0,
-		"existing", existing,
-		"after", p.Reactable.ActiveAuraString(),
-	)
+	p.Core.Log.NewEvent("self reaction occured", glog.LogElementEvent, atk.Info.ActorIndex).
+		Write("attack_tag", atk.Info.AttackTag).
+		Write("applied_ele", atk.Info.Element.String()).
+		Write("dur", applied).
+		Write("abil", atk.Info.Abil).
+		Write("target", 0).
+		Write("existing", existing).
+		Write("after", p.Reactable.ActiveAuraString())
+
 }

--- a/pkg/core/combat/attack.go
+++ b/pkg/core/combat/attack.go
@@ -89,7 +89,7 @@ func (h *Handler) ApplyAttack(a *AttackEvent) float64 {
 			Write("amp", &amp).
 			Write("abil", cpy.Info.Abil).
 			Write("source_frame", cpy.SourceFrame)
-		evt.WriteOld(cpy.Snapshot.Logs...)
+		evt.WriteBuildMsg(cpy.Snapshot.Logs...)
 
 		if !cpy.Info.SourceIsSim {
 			if cpy.Info.ActorIndex < 0 {

--- a/pkg/core/combat/attack.go
+++ b/pkg/core/combat/attack.go
@@ -54,20 +54,12 @@ func (h *Handler) ApplyAttack(a *AttackEvent) float64 {
 			// TODO: Maybe want to add a separate set of log events for this?
 			//don't log this for target 0
 			if i > 0 {
-				h.log.NewEventBuildMsg(
-					glog.LogDebugEvent,
-					a.Info.ActorIndex,
-					"skipped ",
-					a.Info.Abil,
-					" ",
-					reason,
-				).Write(
-					"attack_tag", a.Info.AttackTag,
-					"applied_ele", a.Info.Element,
-					"dur", a.Info.Durability,
-					"target", i,
-					"shape", a.Pattern.Shape.String(),
-				)
+				h.log.NewEventBuildMsg(glog.LogDebugEvent, a.Info.ActorIndex, "skipped ", a.Info.Abil, " ", reason).
+					Write("attack_tag", a.Info.AttackTag).
+					Write("applied_ele", a.Info.Element).
+					Write("dur", a.Info.Durability).
+					Write("target", i).
+					Write("shape", a.Pattern.Shape.String())
 			}
 			continue
 		}
@@ -88,20 +80,16 @@ func (h *Handler) ApplyAttack(a *AttackEvent) float64 {
 		var dmg float64
 		var crit bool
 
-		evt := h.log.NewEvent(
-			cpy.Info.Abil,
-			glog.LogDamageEvent,
-			cpy.Info.ActorIndex,
-			"target", i,
-			"attack-tag", cpy.Info.AttackTag,
-			"ele", cpy.Info.Element.String(),
-			"damage", &dmg,
-			"crit", &crit,
-			"amp", &amp,
-			"abil", cpy.Info.Abil,
-			"source_frame", cpy.SourceFrame,
-		)
-		evt.Write(cpy.Snapshot.Logs...)
+		evt := h.log.NewEvent(cpy.Info.Abil, glog.LogDamageEvent, cpy.Info.ActorIndex).
+			Write("target", i).
+			Write("attack-tag", cpy.Info.AttackTag).
+			Write("ele", cpy.Info.Element.String()).
+			Write("damage", &dmg).
+			Write("crit", &crit).
+			Write("amp", &amp).
+			Write("abil", cpy.Info.Abil).
+			Write("source_frame", cpy.SourceFrame)
+		evt.WriteOld(cpy.Snapshot.Logs...)
 
 		if !cpy.Info.SourceIsSim {
 			if cpy.Info.ActorIndex < 0 {
@@ -157,7 +145,9 @@ func (h *Handler) ApplyAttack(a *AttackEvent) float64 {
 		if dur > 0 {
 			h.team.CombatByIndex(a.Info.ActorIndex).ApplyHitlag(a.Info.HitlagFactor, int(dur))
 			if h.debug {
-				h.log.NewEvent(fmt.Sprintf("%v applying hitlag: %v", a.Info.Abil, dur), glog.LogHitlagEvent, a.Info.ActorIndex, "duration", dur, "factor", a.Info.HitlagFactor)
+				h.log.NewEvent(fmt.Sprintf("%v applying hitlag: %v", a.Info.Abil, dur), glog.LogHitlagEvent, a.Info.ActorIndex).
+					Write("duration", dur).
+					Write("factor", a.Info.HitlagFactor)
 			}
 		}
 	}

--- a/pkg/core/construct/handler.go
+++ b/pkg/core/construct/handler.go
@@ -32,28 +32,27 @@ func (h *Handler) New(c Construct, refresh bool) {
 		}
 	}
 	if ind > -1 {
-		h.log.NewEventBuildMsg(
-			glog.LogConstructEvent,
-			-1,
-			"construct replaced - new: ", c.Type().String(),
-		).Write(
-			"key", h.constructs[ind].Key(),
-			"prev type", h.constructs[ind].Type(),
-			"next type", c.Type(),
-		)
+		h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct replaced - new: ", c.Type().String()).
+			Write("key", h.constructs[ind].Key()).
+			Write("prev type", h.constructs[ind].Type()).
+			Write("next type", c.Type())
 		h.constructs[ind].OnDestruct()
 		h.constructs[ind] = c
 
 	} else {
 		//add this one to the end
 		h.constructs = append(h.constructs, c)
-		h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct created: ", c.Type().String()).Write("key", c.Key(), "type", c.Type())
+		h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct created: ", c.Type().String()).
+			Write("key", c.Key()).
+			Write("type", c.Type())
 	}
 
 	//if length > 3, then destruct the beginning ones
 	for i := 0; i < len(h.constructs)-3; i++ {
 		h.constructs[i].OnDestruct()
-		h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct destroyed: "+h.constructs[i].Type().String()).Write("key", h.constructs[i].Key(), "type", h.constructs[i].Type())
+		h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct destroyed: "+h.constructs[i].Type().String()).
+			Write("key", h.constructs[i].Key()).
+			Write("type", h.constructs[i].Type())
 		h.constructs[i] = nil
 	}
 
@@ -80,13 +79,9 @@ func (h *Handler) NewNoLimitCons(c Construct, refresh bool) {
 		if ind > -1 {
 			//destroy the existing by setting expiry
 			h.consNoLimit[ind].OnDestruct()
-			h.log.NewEventBuildMsg(
-				glog.LogConstructEvent, -1,
-				"construct destroyed: "+h.consNoLimit[ind].Type().String(),
-			).Write(
-				"key", h.consNoLimit[ind].Key(),
-				"type", h.consNoLimit[ind].Type(),
-			)
+			h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct destroyed: "+h.consNoLimit[ind].Type().String()).
+				Write("key", h.consNoLimit[ind].Key()).
+				Write("type", h.consNoLimit[ind].Type())
 			h.consNoLimit[ind] = nil
 
 		}
@@ -100,13 +95,9 @@ func (h *Handler) Tick() {
 	for _, v := range h.constructs {
 		if v.Expiry() == *h.f {
 			v.OnDestruct()
-			h.log.NewEventBuildMsg(
-				glog.LogConstructEvent, -1,
-				"construct destroyed: "+v.Type().String(),
-			).Write(
-				"key", v.Key(),
-				"type", v.Type(),
-			)
+			h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct destroyed: "+v.Type().String()).
+				Write("key", v.Key()).
+				Write("type", v.Type())
 		} else {
 			h.constructs[n] = v
 			n++
@@ -117,13 +108,9 @@ func (h *Handler) Tick() {
 	for i, v := range h.consNoLimit {
 		if v.Expiry() == *h.f {
 			h.consNoLimit[i].OnDestruct()
-			h.log.NewEventBuildMsg(
-				glog.LogConstructEvent, -1,
-				"construct destroyed: "+v.Type().String(),
-			).Write(
-				"key", v.Key(),
-				"type", v.Type(),
-			)
+			h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct destroyed: "+v.Type().String()).
+				Write("key", v.Key()).
+				Write("type", v.Type())
 		} else {
 			h.consNoLimit[n] = v
 			n++
@@ -213,13 +200,9 @@ func (h *Handler) Destroy(key int) bool {
 		if v.Key() == key {
 			v.OnDestruct()
 			ok = true
-			h.log.NewEventBuildMsg(
-				glog.LogConstructEvent, -1,
-				"construct destroyed: "+v.Type().String(),
-			).Write(
-				"key", v.Key(),
-				"type", v.Type(),
-			)
+			h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct destroyed: "+v.Type().String()).
+				Write("key", v.Key()).
+				Write("type", v.Type())
 		} else {
 			h.constructs[n] = v
 			n++
@@ -234,13 +217,9 @@ func (h *Handler) Destroy(key int) bool {
 		if v.Key() == key {
 			h.consNoLimit[i].OnDestruct()
 			ok = true
-			h.log.NewEventBuildMsg(
-				glog.LogConstructEvent, -1,
-				"construct destroyed: "+v.Type().String(),
-			).Write(
-				"key", v.Key(),
-				"type", v.Type(),
-			)
+			h.log.NewEventBuildMsg(glog.LogConstructEvent, -1, "construct destroyed: "+v.Type().String()).
+				Write("key", v.Key()).
+				Write("type", v.Type())
 		} else {
 			h.consNoLimit[n] = v
 			n++

--- a/pkg/core/energy.go
+++ b/pkg/core/energy.go
@@ -61,7 +61,9 @@ func (c *Core) SetupOnNormalHitEnergy() {
 		//add energy
 		char.AddEnergy("na-ca-on-hit", 1)
 		// Add this log in sim if necessary to see as AddEnergy already generates a log
-		c.Log.NewEvent("random energy on normal", glog.LogDebugEvent, char.Index, "char", atk.Info.ActorIndex, "chance", current[atk.Info.ActorIndex][char.Weapon.Class])
+		c.Log.NewEvent("random energy on normal", glog.LogDebugEvent, char.Index).
+			Write("char", atk.Info.ActorIndex).
+			Write("chance", current[atk.Info.ActorIndex][char.Weapon.Class])
 		//set icd
 		icd = c.F + 12
 		current[atk.Info.ActorIndex][char.Weapon.Class] = 0

--- a/pkg/core/glog/log.go
+++ b/pkg/core/glog/log.go
@@ -2,16 +2,18 @@ package glog
 
 // Event describes one event to be logged
 type Event interface {
-	LogSource() Source                    //returns the type of this log event i.e. character, sim, damage, etc...
-	StartFrame() int                      //returns the frame on which this event was started
-	Src() int                             //returns the index of the character that triggered this event. -1 if it's not a character
-	Write(keyAndVal ...interface{}) Event //write additional keyAndVal pairs to the event
+	LogSource() Source                       //returns the type of this log event i.e. character, sim, damage, etc...
+	StartFrame() int                         //returns the frame on which this event was started
+	Src() int                                //returns the index of the character that triggered this event. -1 if it's not a character
+	WriteOld(keyAndVal ...interface{}) Event //write additional keyAndVal pairs to the event
+	Write(key string, val interface{}) Event //write additional keyAndVal pairs to the event
 	SetEnded(f int) Event
 }
 
 // Logger records LogEvents
 type Logger interface {
-	NewEvent(msg string, typ Source, srcChar int, keysAndValues ...interface{}) Event
+	// NewEvent(msg string, typ Source, srcChar int, keysAndValues ...interface{}) Event
+	NewEvent(msg string, typ Source, srcChar int) Event
 	NewEventBuildMsg(typ Source, srcChar int, msg ...string) Event
 	Dump() ([]byte, error) //print out all the logged events in array of JSON strings in the ordered they were added
 }

--- a/pkg/core/glog/log.go
+++ b/pkg/core/glog/log.go
@@ -2,11 +2,11 @@ package glog
 
 // Event describes one event to be logged
 type Event interface {
-	LogSource() Source                       //returns the type of this log event i.e. character, sim, damage, etc...
-	StartFrame() int                         //returns the frame on which this event was started
-	Src() int                                //returns the index of the character that triggered this event. -1 if it's not a character
-	WriteOld(keyAndVal ...interface{}) Event //write additional keyAndVal pairs to the event
-	Write(key string, val interface{}) Event //write additional keyAndVal pairs to the event
+	LogSource() Source                            //returns the type of this log event i.e. character, sim, damage, etc...
+	StartFrame() int                              //returns the frame on which this event was started
+	Src() int                                     //returns the index of the character that triggered this event. -1 if it's not a character
+	WriteBuildMsg(keyAndVal ...interface{}) Event //write additional keyAndVal pairs to the event
+	Write(key string, val interface{}) Event      //write additional keyAndVal pairs to the event
 	SetEnded(f int) Event
 }
 

--- a/pkg/core/glog/logger.go
+++ b/pkg/core/glog/logger.go
@@ -30,7 +30,11 @@ type LogEvent struct {
 //easyjson:json
 type EventArr []*LogEvent
 
-func (e *LogEvent) Write(keysAndValues ...interface{}) Event {
+func (e *LogEvent) Write(key string, value interface{}) Event {
+	return e
+}
+
+func (e *LogEvent) WriteOld(keysAndValues ...interface{}) Event {
 	//should be even number
 	var key string
 	var ok bool
@@ -102,7 +106,7 @@ func (c *Ctrl) NewEventBuildMsg(typ Source, srcChar int, msg ...string) Event {
 	return c.NewEvent(sb.String(), typ, srcChar)
 }
 
-func (c *Ctrl) NewEvent(msg string, typ Source, srcChar int, keysAndValues ...interface{}) Event {
+func (c *Ctrl) NewEvent(msg string, typ Source, srcChar int) Event {
 	e := &LogEvent{
 		Msg:      msg,
 		F:        *c.f,
@@ -115,8 +119,5 @@ func (c *Ctrl) NewEvent(msg string, typ Source, srcChar int, keysAndValues ...in
 	// c.events = append(c.events, e)
 	c.events[c.count] = e
 	c.count++
-	if keysAndValues != nil {
-		e.Write(keysAndValues...)
-	}
 	return e
 }

--- a/pkg/core/glog/logger.go
+++ b/pkg/core/glog/logger.go
@@ -31,10 +31,14 @@ type LogEvent struct {
 type EventArr []*LogEvent
 
 func (e *LogEvent) Write(key string, value interface{}) Event {
+	e.Logs[key] = value
+	e.Ordering[key] = e.counter
+	e.counter++
+
 	return e
 }
 
-func (e *LogEvent) WriteOld(keysAndValues ...interface{}) Event {
+func (e *LogEvent) WriteBuildMsg(keysAndValues ...interface{}) Event {
 	//should be even number
 	var key string
 	var ok bool

--- a/pkg/core/glog/logger_test.go
+++ b/pkg/core/glog/logger_test.go
@@ -22,7 +22,7 @@ func TestEventWriteKeyOnlyPanic(t *testing.T) {
 	}()
 
 	//this should panic
-	e.Write("keyonly")
+	e.WriteOld("keyonly")
 
 }
 
@@ -42,7 +42,7 @@ func TestEventWriteNonStringKeyPanic(t *testing.T) {
 	}()
 
 	//this should panic
-	e.Write(1)
+	e.WriteOld(1)
 
 }
 
@@ -57,8 +57,10 @@ func TestEventWriteKeyVal(t *testing.T) {
 	}
 
 	//this should be ok no panic
-	e.Write("stuff", 1, "goes", true, "here", "two")
-
+	// e.Write("stuff", 1, "goes", true, "here", "two")
+	e.Write("stuff", 1).
+		Write("goes", true).
+		Write("here", "two")
 }
 
 func BenchmarkEasyJSONSerialization(b *testing.B) {
@@ -77,7 +79,12 @@ func BenchmarkEasyJSONSerialization(b *testing.B) {
 			Logs:     map[string]interface{}{},
 			Ordering: make(map[string]int),
 		}
-		e.Write("a", 1, "b", true, "c", "stuff", "e", 123, "f", "boo", "g", 111)
+		e.Write("a", 1).
+			Write("b", true).
+			Write("c", "stuff").
+			Write("e", 123).
+			Write("f", "boo").
+			Write("g", 111)
 		testdata = append(testdata, e)
 	}
 

--- a/pkg/core/glog/logger_test.go
+++ b/pkg/core/glog/logger_test.go
@@ -22,7 +22,7 @@ func TestEventWriteKeyOnlyPanic(t *testing.T) {
 	}()
 
 	//this should panic
-	e.WriteOld("keyonly")
+	e.WriteBuildMsg("keyonly")
 
 }
 
@@ -42,7 +42,7 @@ func TestEventWriteNonStringKeyPanic(t *testing.T) {
 	}()
 
 	//this should panic
-	e.WriteOld(1)
+	e.WriteBuildMsg(1)
 
 }
 

--- a/pkg/core/glog/nil.go
+++ b/pkg/core/glog/nil.go
@@ -3,11 +3,12 @@ package glog
 // NilLogEvent implements LogEvent and is used when no logger is needed
 type NilLogEvent struct{}
 
-func (n *NilLogEvent) LogSource() Source                    { return LogSimEvent }
-func (n *NilLogEvent) StartFrame() int                      { return -1 }
-func (n *NilLogEvent) Src() int                             { return 0 }
-func (n *NilLogEvent) Write(keyAndVal ...interface{}) Event { return n }
-func (n *NilLogEvent) SetEnded(f int) Event                 { return n }
+func (n *NilLogEvent) LogSource() Source                       { return LogSimEvent }
+func (n *NilLogEvent) StartFrame() int                         { return -1 }
+func (n *NilLogEvent) Src() int                                { return 0 }
+func (n *NilLogEvent) WriteOld(keyAndVal ...interface{}) Event { return n }
+func (n *NilLogEvent) Write(key string, val interface{}) Event { return n }
+func (n *NilLogEvent) SetEnded(f int) Event                    { return n }
 
 // NilLogger implements Logger and is used when no logger is needed
 type NilLogger struct{}
@@ -16,6 +17,7 @@ func (n *NilLogger) Dump() ([]byte, error) { return []byte{}, nil }
 func (n *NilLogger) NewEventBuildMsg(typ Source, srcChar int, msg ...string) Event {
 	return &NilLogEvent{}
 }
-func (n *NilLogger) NewEvent(msg string, typ Source, srcChar int, keysAndValues ...interface{}) Event {
+
+func (n *NilLogger) NewEvent(msg string, typ Source, srcChar int) Event {
 	return &NilLogEvent{}
 }

--- a/pkg/core/glog/nil.go
+++ b/pkg/core/glog/nil.go
@@ -3,12 +3,12 @@ package glog
 // NilLogEvent implements LogEvent and is used when no logger is needed
 type NilLogEvent struct{}
 
-func (n *NilLogEvent) LogSource() Source                       { return LogSimEvent }
-func (n *NilLogEvent) StartFrame() int                         { return -1 }
-func (n *NilLogEvent) Src() int                                { return 0 }
-func (n *NilLogEvent) WriteOld(keyAndVal ...interface{}) Event { return n }
-func (n *NilLogEvent) Write(key string, val interface{}) Event { return n }
-func (n *NilLogEvent) SetEnded(f int) Event                    { return n }
+func (n *NilLogEvent) LogSource() Source                            { return LogSimEvent }
+func (n *NilLogEvent) StartFrame() int                              { return -1 }
+func (n *NilLogEvent) Src() int                                     { return 0 }
+func (n *NilLogEvent) WriteBuildMsg(keyAndVal ...interface{}) Event { return n }
+func (n *NilLogEvent) Write(key string, val interface{}) Event      { return n }
+func (n *NilLogEvent) SetEnded(f int) Event                         { return n }
 
 // NilLogger implements Logger and is used when no logger is needed
 type NilLogger struct{}

--- a/pkg/core/player/animation/animation.go
+++ b/pkg/core/player/animation/animation.go
@@ -90,16 +90,11 @@ func (h *AnimationHandler) SetActionUsed(char int, act action.Action, evt *actio
 	h.lastAct = act
 	if h.debug {
 		l := h.log.NewEvent(fmt.Sprintf("%v started", act.String()), glog.LogHitlagEvent, char)
-		l.Write(
-			"AnimationLength", evt.AnimationLength,
-			"CanQueueAfter", evt.CanQueueAfter,
-			"State", evt.State.String(),
-		)
+		l.Write("AnimationLength", evt.AnimationLength).
+			Write("CanQueueAfter", evt.CanQueueAfter).
+			Write("State", evt.State.String())
 		for i, v := range evt.CachedFrames {
-			l.Write(
-				action.Action(i).String(),
-				v,
-			)
+			l.Write(action.Action(i).String(), v)
 		}
 	}
 }

--- a/pkg/core/player/character/basestat.go
+++ b/pkg/core/player/character/basestat.go
@@ -87,12 +87,12 @@ func (c *CharWrapper) UpdateBaseStats() error {
 	c.log.NewEvent(
 		"stat calc done for "+c.Base.Name,
 		glog.LogCharacterEvent, c.Index,
-		"char_base", c.Base,
-		"weap_base", c.Weapon,
-		"spec_char", spec,
-		"spec_weap", specw,
-		"final_stats", c.BaseStats,
-	)
+	).
+		Write("char_base", c.Base).
+		Write("weap_base", c.Weapon).
+		Write("spec_char", spec).
+		Write("spec_weap", specw).
+		Write("final_stats", c.BaseStats)
 
 	return nil
 }

--- a/pkg/core/player/character/cooldown.go
+++ b/pkg/core/player/character/cooldown.go
@@ -23,10 +23,11 @@ func (c *CharWrapper) CDReduction(a action.Action, dur int) int {
 				"applying cooldown modifier",
 				glog.LogActionEvent,
 				c.Index,
-				"key", v.Key,
-				"modifier", amt,
-				"expiry", v.Expiry,
-			)
+			).
+				Write("key", v.Key).
+				Write("modifier", amt).
+				Write("expiry", v.Expiry)
+
 			cd += amt
 			c.cooldownMods[n] = v
 			n++

--- a/pkg/core/player/character/energy.go
+++ b/pkg/core/player/character/energy.go
@@ -27,12 +27,12 @@ func (c *CharWrapper) AddEnergy(src string, e float64) {
 	}
 
 	c.events.Emit(event.OnEnergyChange, c, preEnergy, e, src)
-	c.log.NewEvent("adding energy", glog.LogEnergyEvent, c.Index,
-		"rec'd", e,
-		"post_recovery", c.Energy,
-		"source", src,
-		"max_energy", c.EnergyMax,
-	)
+	c.log.NewEvent("adding energy", glog.LogEnergyEvent, c.Index).
+		Write("rec'd", e).
+		Write("post_recovery", c.Energy).
+		Write("source", src).
+		Write("max_energy", c.EnergyMax)
+
 }
 
 func (c *CharWrapper) ReceiveParticle(p Particle, isActive bool, partyCount int) {
@@ -70,15 +70,16 @@ func (c *CharWrapper) ReceiveParticle(p Particle, isActive bool, partyCount int)
 		"particle",
 		glog.LogEnergyEvent,
 		c.Index,
-		"source", p.Source,
-		"count", p.Num,
-		"ele", p.Ele,
-		"ER", er,
-		"is_active", isActive,
-		"party_count", partyCount,
-		"pre_recovery", pre,
-		"amt", amt,
-		"post_recovery", c.Energy,
-		"max_energy", c.EnergyMax,
-	)
+	).
+		Write("source", p.Source).
+		Write("count", p.Num).
+		Write("ele", p.Ele).
+		Write("ER", er).
+		Write("is_active", isActive).
+		Write("party_count", partyCount).
+		Write("pre_recovery", pre).
+		Write("amt", amt).
+		Write("post_recovery", c.Energy).
+		Write("max_energy", c.EnergyMax)
+
 }

--- a/pkg/core/player/character/mods.go
+++ b/pkg/core/player/character/mods.go
@@ -25,7 +25,8 @@ func deleteMod[K mod](c *CharWrapper, slice *[]K, key string) {
 	for _, v := range *slice {
 		if v.Key() == key {
 			v.Event().SetEnded(*c.f)
-			c.log.NewEvent("mod deleted", glog.LogStatusEvent, c.Index, "key", key)
+			c.log.NewEvent("mod deleted", glog.LogStatusEvent, c.Index).
+				Write("key", key)
 		} else {
 			(*slice)[n] = v
 			n++
@@ -40,12 +41,10 @@ func addMod[K mod](c *CharWrapper, slice *[]K, mod K) {
 
 	//if does not exist, make new and add
 	if ind == -1 {
-		evt := c.log.NewEvent(
-			"mod added", glog.LogStatusEvent, c.Index,
-			"overwrite", false,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt := c.log.NewEvent("mod added", glog.LogStatusEvent, c.Index).
+			Write("overwrite", false).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 		evt.SetEnded(mod.Expiry())
 		mod.SetEvent(evt)
 		//BUG: i think this needs to be *K here. otherwise delete wont work?
@@ -56,21 +55,17 @@ func addMod[K mod](c *CharWrapper, slice *[]K, mod K) {
 	//otherwise check not expired
 	var evt glog.Event
 	if (*slice)[ind].Expiry() > *c.f || (*slice)[ind].Expiry() == -1 {
-		evt = c.log.NewEvent(
-			"mod refreshed", glog.LogStatusEvent, c.Index,
-			"overwrite", true,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt = c.log.NewEvent("mod refreshed", glog.LogStatusEvent, c.Index).
+			Write("overwrite", true).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 
 	} else {
 		//if expired overide the event
-		evt = c.log.NewEvent(
-			"mod added", glog.LogStatusEvent, c.Index,
-			"overwrite", false,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt = c.log.NewEvent("mod added", glog.LogStatusEvent, c.Index).
+			Write("overwrite", false).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 	}
 	mod.SetEvent(evt)
 	evt.SetEnded(mod.Expiry())

--- a/pkg/core/player/exec.go
+++ b/pkg/core/player/exec.go
@@ -57,7 +57,9 @@ func (p *Handler) Exec(t action.Action, k keys.Char, param map[string]int) error
 	case action.ActionCharge: //require special calc for stam
 		amt, ok := stamCheck(t, param)
 		if !ok {
-			p.log.NewEvent("insufficient stam: charge attack", glog.LogWarnings, -1, "have", p.Stam, "cost", amt)
+			p.log.NewEvent("insufficient stam: charge attack", glog.LogWarnings, -1).
+				Write("have", p.Stam).
+				Write("cost", amt)
 			return ErrActionNotReady
 		}
 		//use stam
@@ -69,7 +71,9 @@ func (p *Handler) Exec(t action.Action, k keys.Char, param map[string]int) error
 		//dash handles it in the action itself
 		amt, ok := stamCheck(t, param)
 		if !ok {
-			p.log.NewEvent("insufficient stam: dash", glog.LogWarnings, -1, "have", p.Stam, "cost", amt)
+			p.log.NewEvent("insufficient stam: dash", glog.LogWarnings, -1).
+				Write("have", p.Stam).
+				Write("cost", amt)
 			return ErrActionNotReady
 		}
 		p.useAbility(t, param, char.Dash) //TODO: make sure characters are consuming stam in dashes
@@ -160,8 +164,6 @@ func (p *Handler) useAbility(
 		glog.LogActionEvent,
 		p.active,
 		"executed ", t.String(),
-	).Write(
-		"action", t.String(),
-	)
+	).Write("action", t.String())
 
 }

--- a/pkg/core/player/heal.go
+++ b/pkg/core/player/heal.go
@@ -46,12 +46,12 @@ func (h *Handler) HealIndex(info *HealInfo, index int) {
 	prevhp := c.Base.HP
 	c.ModifyHP(heal)
 
-	h.log.NewEvent(info.Message, glog.LogHealEvent, index,
-		"previous", prevhp,
-		"amount", hp,
-		"bonus", bonus,
-		"current", c.Base.HP,
-		"max_hp", c.MaxHP())
+	h.log.NewEvent(info.Message, glog.LogHealEvent, index).
+		Write("previous", prevhp).
+		Write("amount", hp).
+		Write("bonus", bonus).
+		Write("current", c.Base.HP).
+		Write("max_hp", c.MaxHP())
 
 	h.events.Emit(event.OnHeal, info.Caller, index, heal)
 }
@@ -68,11 +68,11 @@ func (h *Handler) Drain(di DrainInfo) {
 	prevhp := c.HPCurrent
 	c.ModifyHP(-di.Amount)
 
-	h.log.NewEvent(di.Abil, glog.LogHurtEvent, di.ActorIndex,
-		"previous", prevhp,
-		"amount", di.Amount,
-		"current", c.HPCurrent,
-		"max_hp", c.MaxHP())
+	h.log.NewEvent(di.Abil, glog.LogHurtEvent, di.ActorIndex).
+		Write("previous", prevhp).
+		Write("amount", di.Amount).
+		Write("current", c.HPCurrent).
+		Write("max_hp", c.MaxHP())
 
 	h.events.Emit(event.OnCharacterHurt, di.Amount)
 }

--- a/pkg/core/player/player.go
+++ b/pkg/core/player/player.go
@@ -90,14 +90,9 @@ func (h *Handler) swap(to keys.Char) func() {
 	return func() {
 		prev := h.active
 		h.active = h.charPos[to]
-		h.log.NewEventBuildMsg(
-			glog.LogActionEvent,
-			h.active,
-			"executed swap",
-		).Write(
-			"action", "swap",
-			"target", to.String(),
-		)
+		h.log.NewEventBuildMsg(glog.LogActionEvent, h.active, "executed swap").
+			Write("action", "swap").
+			Write("target", to.String())
 		h.SwapCD = SwapCDFrames
 		h.ResetAllNormalCounter()
 		h.events.Emit(event.OnCharacterSwap, prev, h.active)
@@ -197,7 +192,8 @@ func (h *Handler) InitializeTeam() error {
 		if h.chars[i].HPCurrent == -1 {
 			h.chars[i].HPCurrent = h.chars[i].MaxHP()
 		}
-		h.log.NewEvent("starting hp set", glog.LogCharacterEvent, i, "hp", h.chars[i].HPCurrent)
+		h.log.NewEvent("starting hp set", glog.LogCharacterEvent, i).
+			Write("hp", h.chars[i].HPCurrent)
 	}
 	return nil
 }

--- a/pkg/core/player/shield/bonus.go
+++ b/pkg/core/player/shield/bonus.go
@@ -64,12 +64,10 @@ func (h *Handler) AddShieldBonusMod(key string, dur int, f ShieldBonusModFunc) {
 
 	//if does not exist, make new and add
 	if ind == -1 {
-		mod.Event = h.log.NewEvent(
-			"shield bonus added", glog.LogStatusEvent, -1,
-			"overwrite", false,
-			"key", mod.Key,
-			"expiry", mod.Expiry,
-		)
+		mod.Event = h.log.NewEvent("shield bonus added", glog.LogStatusEvent, -1).
+			Write("overwrite", false).
+			Write("key", mod.Key).
+			Write("expiry", mod.Expiry)
 		mod.Event.SetEnded(mod.Expiry)
 		h.shieldBonusMods = append(h.shieldBonusMods, mod)
 		return
@@ -79,19 +77,18 @@ func (h *Handler) AddShieldBonusMod(key string, dur int, f ShieldBonusModFunc) {
 	if h.shieldBonusMods[ind].Expiry > *h.f || h.shieldBonusMods[ind].Expiry == -1 {
 		h.log.NewEvent(
 			"shield bonus refreshed", glog.LogStatusEvent, -1,
-			"overwrite", true,
-			"key", mod.Key,
-			"expiry", mod.Expiry,
-		)
+		).
+			Write("overwrite", true).
+			Write("key", mod.Key).
+			Write("expiry", mod.Expiry)
+
 		mod.Event = h.shieldBonusMods[ind].Event
 	} else {
 		//if expired overide the event
-		mod.Event = h.log.NewEvent(
-			"shield bonus added", glog.LogStatusEvent, -1,
-			"overwrite", false,
-			"key", mod.Key,
-			"expiry", mod.Expiry,
-		)
+		mod.Event = h.log.NewEvent("shield bonus added", glog.LogStatusEvent, -1).
+			Write("overwrite", false).
+			Write("key", mod.Key).
+			Write("expiry", mod.Expiry)
 	}
 	mod.Event.SetEnded(mod.Expiry)
 	h.shieldBonusMods[ind] = mod

--- a/pkg/core/player/shield/handler.go
+++ b/pkg/core/player/shield/handler.go
@@ -57,12 +57,22 @@ func (s *Handler) Add(shd Shield) {
 		}
 	}
 	if ind > -1 {
-		s.log.NewEvent("shield overridden", glog.LogShieldEvent, -1, "overwrite", true, "name", shd.Desc(), "hp", shd.CurrentHP(), "ele", shd.Element(), "expiry", shd.Expiry())
+		s.log.NewEvent("shield overridden", glog.LogShieldEvent, -1).
+			Write("overwrite", true).
+			Write("name", shd.Desc()).
+			Write("hp", shd.CurrentHP()).
+			Write("ele", shd.Element()).
+			Write("expiry", shd.Expiry())
 		s.shields[ind].OnOverwrite()
 		s.shields[ind] = shd
 	} else {
 		s.shields = append(s.shields, shd)
-		s.log.NewEvent("shield added", glog.LogShieldEvent, -1, "overwrite", false, "name", shd.Desc(), "hp", shd.CurrentHP(), "ele", shd.Element(), "expiry", shd.Expiry())
+		s.log.NewEvent("shield added", glog.LogShieldEvent, -1).
+			Write("overwrite", false).
+			Write("name", shd.Desc()).
+			Write("hp", shd.CurrentHP()).
+			Write("ele", shd.Element()).
+			Write("expiry", shd.Expiry())
 	}
 	s.events.Emit(event.OnShielded, shd)
 }
@@ -91,7 +101,9 @@ func (s *Handler) Tick() {
 	for _, v := range s.shields {
 		if v.Expiry() == *s.f {
 			v.OnExpire()
-			s.log.NewEvent("shield expired", glog.LogShieldEvent, -1, "name", v.Desc(), "hp", v.CurrentHP())
+			s.log.NewEvent("shield expired", glog.LogShieldEvent, -1).
+				Write("name", v.Desc()).
+				Write("hp", v.CurrentHP())
 		} else {
 			s.shields[n] = v
 			n++

--- a/pkg/core/player/stam.go
+++ b/pkg/core/player/stam.go
@@ -64,12 +64,10 @@ func (h *Handler) AddStamPercentMod(key string, dur int, f StamPercentModFunc) {
 
 	//if does not exist, make new and add
 	if ind == -1 {
-		mod.Event = h.log.NewEvent(
-			"stam mod added", glog.LogStatusEvent, -1,
-			"overwrite", false,
-			"key", mod.Key,
-			"expiry", mod.Expiry,
-		)
+		mod.Event = h.log.NewEvent("stam mod added", glog.LogStatusEvent, -1).
+			Write("overwrite", false).
+			Write("key", mod.Key).
+			Write("expiry", mod.Expiry)
 		mod.Event.SetEnded(mod.Expiry)
 		h.stamPercentMods = append(h.stamPercentMods, mod)
 		return
@@ -79,19 +77,18 @@ func (h *Handler) AddStamPercentMod(key string, dur int, f StamPercentModFunc) {
 	if h.stamPercentMods[ind].Expiry > *h.f || h.stamPercentMods[ind].Expiry == -1 {
 		h.log.NewEvent(
 			"stam mod refreshed", glog.LogStatusEvent, -1,
-			"overwrite", true,
-			"key", mod.Key,
-			"expiry", mod.Expiry,
-		)
+		).
+			Write("overwrite", true).
+			Write("key", mod.Key).
+			Write("expiry", mod.Expiry)
+
 		mod.Event = h.stamPercentMods[ind].Event
 	} else {
 		//if expired overide the event
-		mod.Event = h.log.NewEvent(
-			"stam mod added", glog.LogStatusEvent, -1,
-			"overwrite", false,
-			"key", mod.Key,
-			"expiry", mod.Expiry,
-		)
+		mod.Event = h.log.NewEvent("stam mod added", glog.LogStatusEvent, -1).
+			Write("overwrite", false).
+			Write("key", mod.Key).
+			Write("expiry", mod.Expiry)
 	}
 	mod.Event.SetEnded(mod.Expiry)
 	h.stamPercentMods[ind] = mod

--- a/pkg/core/status/status.go
+++ b/pkg/core/status/status.go
@@ -42,12 +42,16 @@ func (t *Handler) Add(key string, dur int) {
 		a.expiry = *t.f + dur
 		a.evt.SetEnded(a.expiry)
 		t.status[key] = a
-		t.log.NewEvent("status refreshed", glog.LogStatusEvent, -1, "key", key, "expiry", *t.f+dur)
+		t.log.NewEvent("status refreshed", glog.LogStatusEvent, -1).
+			Write("key", key).
+			Write("expiry", *t.f+dur)
 		return
 	}
 
 	//otherwise create a new event
-	a.evt = t.log.NewEvent("status added", glog.LogStatusEvent, -1, "key", key, "expiry", *t.f+dur)
+	a.evt = t.log.NewEvent("status added", glog.LogStatusEvent, -1).
+		Write("key", key).
+		Write("expiry", *t.f+dur)
 	a.expiry = *t.f + dur
 	a.evt.SetEnded(a.expiry)
 
@@ -65,7 +69,9 @@ func (t *Handler) Extend(key string, dur int) {
 	a.expiry += dur
 	a.evt.SetEnded(a.expiry)
 	t.status[key] = a
-	t.log.NewEvent("status refreshed", glog.LogStatusEvent, -1, "key", key, "expiry", a.expiry)
+	t.log.NewEvent("status refreshed", glog.LogStatusEvent, -1).
+		Write("key", key).
+		Write("expiry", a.expiry)
 
 }
 
@@ -74,7 +80,8 @@ func (t *Handler) Delete(key string) {
 	a, ok := t.status[key]
 	if ok && a.expiry > *t.f {
 		a.evt.SetEnded(*t.f)
-		t.log.NewEvent("status deleted", glog.LogStatusEvent, -1, "key", key)
+		t.log.NewEvent("status deleted", glog.LogStatusEvent, -1).
+			Write("key", key)
 	}
 	delete(t.status, key)
 }

--- a/pkg/enemy/attack.go
+++ b/pkg/enemy/attack.go
@@ -31,14 +31,15 @@ func (e *Enemy) Attack(atk *combat.AttackEvent, evt glog.Event) (float64, bool) 
 					"application",
 					glog.LogElementEvent,
 					atk.Info.ActorIndex,
-					"attack_tag", atk.Info.AttackTag,
-					"applied_ele", atk.Info.Element.String(),
-					"dur", applied,
-					"abil", atk.Info.Abil,
-					"target", e.TargetIndex,
-					"existing", existing,
-					"after", e.Reactable.ActiveAuraString(),
-				)
+				).
+					Write("attack_tag", atk.Info.AttackTag).
+					Write("applied_ele", atk.Info.Element.String()).
+					Write("dur", applied).
+					Write("abil", atk.Info.Abil).
+					Write("target", e.TargetIndex).
+					Write("existing", existing).
+					Write("after", e.Reactable.ActiveAuraString())
+
 			}
 		}
 	}

--- a/pkg/enemy/damage.go
+++ b/pkg/enemy/damage.go
@@ -110,53 +110,54 @@ func (t *Enemy) calc(atk *combat.AttackEvent, evt glog.Event) (float64, bool) {
 			atk.Info.Abil,
 			glog.LogCalc,
 			atk.Info.ActorIndex,
-			"src_frame", atk.SourceFrame,
-			"damage_grp_mult", x,
-			"damage", damage,
-			"abil", atk.Info.Abil,
-			"talent", atk.Info.Mult,
-			"base_atk", atk.Snapshot.BaseAtk,
-			"flat_atk", atk.Snapshot.Stats[attributes.ATK],
-			"atk_per", atk.Snapshot.Stats[attributes.ATKP],
-			"use_def", atk.Info.UseDef,
-			"base_def", atk.Snapshot.BaseDef,
-			"flat_def", atk.Snapshot.Stats[attributes.DEF],
-			"def_per", atk.Snapshot.Stats[attributes.DEFP],
-			"base_hp", atk.Snapshot.BaseHP,
-			"flat_hp", atk.Snapshot.Stats[attributes.HP],
-			"hp_per", atk.Snapshot.Stats[attributes.HPP],
-			"total_hp", totalhp,
-			"flat_dmg", atk.Info.FlatDmg,
-			"total_atk_def", a,
-			"base_dmg", base,
-			"ele", st,
-			"ele_per", elePer,
-			"bonus_dmg", dmgBonus,
-			"def_adj", defadj,
-			"target_lvl", t.Level,
-			"char_lvl", atk.Snapshot.CharLvl,
-			"def_mod", defmod,
-			"res", res,
-			"res_mod", resmod,
-			"cr", atk.Snapshot.Stats[attributes.CR],
-			"cd", atk.Snapshot.Stats[attributes.CD],
-			"pre_crit_dmg", precritdmg,
-			"dmg_if_crit", precritdmg*(1+atk.Snapshot.Stats[attributes.CD]),
-			"avg_crit_dmg", (1-atk.Snapshot.Stats[attributes.CR])*precritdmg+atk.Snapshot.Stats[attributes.CR]*precritdmg*(1+atk.Snapshot.Stats[attributes.CD]),
-			"is_crit", isCrit,
-			"pre_amp_dmg", preampdmg,
-			"reaction_type", atk.Info.AmpType,
-			"melt_vape", atk.Info.Amped,
-			"react_mult", atk.Info.AmpMult,
-			"em", em,
-			"em_bonus", emBonus,
-			"react_bonus", reactBonus,
-			"amp_mult_total", (atk.Info.AmpMult * (1 + emBonus + reactBonus)),
-			"pre_crit_dmg_react", precritdmg*(atk.Info.AmpMult*(1+emBonus+reactBonus)),
-			"dmg_if_crit_react", precritdmg*(1+atk.Snapshot.Stats[attributes.CD])*(atk.Info.AmpMult*(1+emBonus+reactBonus)),
-			"avg_crit_dmg_react", ((1-atk.Snapshot.Stats[attributes.CR])*precritdmg+atk.Snapshot.Stats[attributes.CR]*precritdmg*(1+atk.Snapshot.Stats[attributes.CD]))*(atk.Info.AmpMult*(1+emBonus+reactBonus)),
-			"target", t.TargetIndex,
-		)
+		).
+			Write("src_frame", atk.SourceFrame).
+			Write("damage_grp_mult", x).
+			Write("damage", damage).
+			Write("abil", atk.Info.Abil).
+			Write("talent", atk.Info.Mult).
+			Write("base_atk", atk.Snapshot.BaseAtk).
+			Write("flat_atk", atk.Snapshot.Stats[attributes.ATK]).
+			Write("atk_per", atk.Snapshot.Stats[attributes.ATKP]).
+			Write("use_def", atk.Info.UseDef).
+			Write("base_def", atk.Snapshot.BaseDef).
+			Write("flat_def", atk.Snapshot.Stats[attributes.DEF]).
+			Write("def_per", atk.Snapshot.Stats[attributes.DEFP]).
+			Write("base_hp", atk.Snapshot.BaseHP).
+			Write("flat_hp", atk.Snapshot.Stats[attributes.HP]).
+			Write("hp_per", atk.Snapshot.Stats[attributes.HPP]).
+			Write("total_hp", totalhp).
+			Write("flat_dmg", atk.Info.FlatDmg).
+			Write("total_atk_def", a).
+			Write("base_dmg", base).
+			Write("ele", st).
+			Write("ele_per", elePer).
+			Write("bonus_dmg", dmgBonus).
+			Write("def_adj", defadj).
+			Write("target_lvl", t.Level).
+			Write("char_lvl", atk.Snapshot.CharLvl).
+			Write("def_mod", defmod).
+			Write("res", res).
+			Write("res_mod", resmod).
+			Write("cr", atk.Snapshot.Stats[attributes.CR]).
+			Write("cd", atk.Snapshot.Stats[attributes.CD]).
+			Write("pre_crit_dmg", precritdmg).
+			Write("dmg_if_crit", precritdmg*(1+atk.Snapshot.Stats[attributes.CD])).
+			Write("avg_crit_dmg", (1-atk.Snapshot.Stats[attributes.CR])*precritdmg+atk.Snapshot.Stats[attributes.CR]*precritdmg*(1+atk.Snapshot.Stats[attributes.CD])).
+			Write("is_crit", isCrit).
+			Write("pre_amp_dmg", preampdmg).
+			Write("reaction_type", atk.Info.AmpType).
+			Write("melt_vape", atk.Info.Amped).
+			Write("react_mult", atk.Info.AmpMult).
+			Write("em", em).
+			Write("em_bonus", emBonus).
+			Write("react_bonus", reactBonus).
+			Write("amp_mult_total", (atk.Info.AmpMult*(1+emBonus+reactBonus))).
+			Write("pre_crit_dmg_react", precritdmg*(atk.Info.AmpMult*(1+emBonus+reactBonus))).
+			Write("dmg_if_crit_react", precritdmg*(1+atk.Snapshot.Stats[attributes.CD])*(atk.Info.AmpMult*(1+emBonus+reactBonus))).
+			Write("avg_crit_dmg_react", ((1-atk.Snapshot.Stats[attributes.CR])*precritdmg+atk.Snapshot.Stats[attributes.CR]*precritdmg*(1+atk.Snapshot.Stats[attributes.CD]))*(atk.Info.AmpMult*(1+emBonus+reactBonus))).
+			Write("target", t.TargetIndex)
+
 	}
 
 	return damage, isCrit

--- a/pkg/enemy/icd.go
+++ b/pkg/enemy/icd.go
@@ -27,7 +27,13 @@ func (t *Enemy) WillApplyEle(tag combat.ICDTag, grp combat.ICDGroup, char int) b
 		t.icdTagCounter[char][tag] = 0
 	}
 
-	t.Core.Log.NewEvent("ele icd check", glog.LogICDEvent, char, "grp", grp, "target", t.TargetIndex, "tag", tag, "counter", val, "val", combat.ICDGroupEleApplicationSequence[grp][val], "group on timer", x)
+	t.Core.Log.NewEvent("ele icd check", glog.LogICDEvent, char).
+		Write("grp", grp).
+		Write("target", t.TargetIndex).
+		Write("tag", tag).
+		Write("counter", val).
+		Write("val", combat.ICDGroupEleApplicationSequence[grp][val]).
+		Write("group on timer", x)
 	//true if group seq is 1
 	return combat.ICDGroupEleApplicationSequence[grp][val] == 1
 }
@@ -57,9 +63,14 @@ func (t *Enemy) ResetDamageCounterAfterDelay(tag combat.ICDTag, grp combat.ICDGr
 		//set the counter back to 0
 		t.icdDamageTagCounter[char][tag] = 0
 		t.icdDamageTagOnTimer[char][tag] = false
-		t.Core.Log.NewEvent("damage counter reset", glog.LogICDEvent, char, "tag", tag, "grp", grp)
+		t.Core.Log.NewEvent("damage counter reset", glog.LogICDEvent, char).
+			Write("tag", tag).
+			Write("grp", grp)
 	}, combat.ICDGroupResetTimer[grp]-1)
-	t.Core.Log.NewEvent("damage reset timer set", glog.LogICDEvent, char, "tag", tag, "grp", grp, "reset", t.Core.F+combat.ICDGroupResetTimer[grp]-1)
+	t.Core.Log.NewEvent("damage reset timer set", glog.LogICDEvent, char).
+		Write("tag", tag).
+		Write("grp", grp).
+		Write("reset", t.Core.F+combat.ICDGroupResetTimer[grp]-1)
 }
 
 func (t *Enemy) ResetTagCounterAfterDelay(tag combat.ICDTag, grp combat.ICDGroup, char int) {
@@ -67,7 +78,12 @@ func (t *Enemy) ResetTagCounterAfterDelay(tag combat.ICDTag, grp combat.ICDGroup
 		//set the counter back to 0
 		t.icdTagCounter[char][tag] = 0
 		t.icdTagOnTimer[char][tag] = false
-		t.Core.Log.NewEvent("ele app counter reset", glog.LogICDEvent, char, "tag", tag, "grp", grp)
+		t.Core.Log.NewEvent("ele app counter reset", glog.LogICDEvent, char).
+			Write("tag", tag).
+			Write("grp", grp)
 	}, combat.ICDGroupResetTimer[grp]-1)
-	t.Core.Log.NewEvent("ele app reset timer set", glog.LogICDEvent, char, "tag", tag, "grp", grp, "reset", t.Core.F+combat.ICDGroupResetTimer[grp]-1)
+	t.Core.Log.NewEvent("ele app reset timer set", glog.LogICDEvent, char).
+		Write("tag", tag).
+		Write("grp", grp).
+		Write("reset", t.Core.F+combat.ICDGroupResetTimer[grp]-1)
 }

--- a/pkg/enemy/mods.go
+++ b/pkg/enemy/mods.go
@@ -27,7 +27,8 @@ func deleteMod[K mod](c *Enemy, slice *[]K, key string) {
 	for _, v := range *slice {
 		if v.Key() == key {
 			v.Event().SetEnded(c.Core.F)
-			c.Core.Log.NewEvent("enemy mod deleted", glog.LogStatusEvent, -1, "key", key)
+			c.Core.Log.NewEvent("enemy mod deleted", glog.LogStatusEvent, -1).
+				Write("key", key)
 		} else {
 			(*slice)[n] = v
 			n++
@@ -41,12 +42,10 @@ func addMod[K mod](c *Enemy, slice *[]K, mod K) {
 
 	//if does not exist, make new and add
 	if ind == -1 {
-		evt := c.Core.Log.NewEvent(
-			"enemy mod added", glog.LogStatusEvent, -1,
-			"overwrite", false,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt := c.Core.Log.NewEvent("enemy mod added", glog.LogStatusEvent, -1).
+			Write("overwrite", false).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 		evt.SetEnded(mod.Expiry())
 		mod.SetEvent(evt)
 		*slice = append(*slice, mod)
@@ -56,21 +55,17 @@ func addMod[K mod](c *Enemy, slice *[]K, mod K) {
 	//otherwise check not expired
 	var evt glog.Event
 	if (*slice)[ind].Expiry() > c.Core.F || (*slice)[ind].Expiry() == -1 {
-		evt = c.Core.Log.NewEvent(
-			"enemy mod refreshed", glog.LogStatusEvent, -1,
-			"overwrite", true,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt = c.Core.Log.NewEvent("enemy mod refreshed", glog.LogStatusEvent, -1).
+			Write("overwrite", true).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 
 	} else {
 		//if expired overide the event
-		evt = c.Core.Log.NewEvent(
-			"enemy mod added", glog.LogStatusEvent, -1,
-			"overwrite", false,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt = c.Core.Log.NewEvent("enemy mod added", glog.LogStatusEvent, -1).
+			Write("overwrite", false).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 	}
 	mod.SetEvent(evt)
 	evt.SetEnded(mod.Expiry())

--- a/pkg/modifier/modifier.go
+++ b/pkg/modifier/modifier.go
@@ -34,7 +34,8 @@ func Delete[K Mod](f int, log glog.Logger, slice *[]K, key string) {
 	for _, v := range *slice {
 		if v.Key() == key {
 			v.Event().SetEnded(f)
-			log.NewEvent("enemy mod deleted", glog.LogStatusEvent, -1, "key", key)
+			log.NewEvent("enemy mod deleted", glog.LogStatusEvent, -1).
+				Write("key", key)
 		} else {
 			(*slice)[n] = v
 			n++
@@ -48,12 +49,10 @@ func Add[K Mod](f int, log glog.Logger, slice *[]K, mod K) {
 
 	//if does not exist, make new and add
 	if ind == -1 {
-		evt := log.NewEvent(
-			"enemy mod added", glog.LogStatusEvent, -1,
-			"overwrite", false,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt := log.NewEvent("enemy mod added", glog.LogStatusEvent, -1).
+			Write("overwrite", false).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 		evt.SetEnded(mod.Expiry())
 		mod.SetEvent(evt)
 		*slice = append(*slice, mod)
@@ -63,21 +62,17 @@ func Add[K Mod](f int, log glog.Logger, slice *[]K, mod K) {
 	//otherwise check not expired
 	var evt glog.Event
 	if (*slice)[ind].Expiry() > f || (*slice)[ind].Expiry() == -1 {
-		evt = log.NewEvent(
-			"enemy mod refreshed", glog.LogStatusEvent, -1,
-			"overwrite", true,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt = log.NewEvent("enemy mod refreshed", glog.LogStatusEvent, -1).
+			Write("overwrite", true).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 
 	} else {
 		//if expired overide the event
-		evt = log.NewEvent(
-			"enemy mod added", glog.LogStatusEvent, -1,
-			"overwrite", false,
-			"key", mod.Key(),
-			"expiry", mod.Expiry(),
-		)
+		evt = log.NewEvent("enemy mod added", glog.LogStatusEvent, -1).
+			Write("overwrite", false).
+			Write("key", mod.Key()).
+			Write("expiry", mod.Expiry())
 	}
 	mod.SetEvent(evt)
 	evt.SetEnded(mod.Expiry())

--- a/pkg/reactable/electrocharged.go
+++ b/pkg/reactable/electrocharged.go
@@ -118,11 +118,12 @@ func (r *Reactable) waneEC() {
 	r.core.Log.NewEvent("ec wane",
 		glog.LogElementEvent,
 		-1,
-		"aura", "ec",
-		"target", r.self.Index(),
-		"hydro", r.Durability[attributes.Hydro],
-		"electro", r.Durability[attributes.Electro],
-	)
+	).
+		Write("aura", "ec").
+		Write("target", r.self.Index()).
+		Write("hydro", r.Durability[attributes.Hydro]).
+		Write("electro", r.Durability[attributes.Electro])
+
 	//ec is gone
 	r.checkEC()
 }
@@ -134,11 +135,12 @@ func (r *Reactable) checkEC() {
 		r.core.Log.NewEvent("ec expired",
 			glog.LogElementEvent,
 			-1,
-			"aura", "ec",
-			"target", r.self.Index(),
-			"hydro", r.Durability[attributes.Hydro],
-			"electro", r.Durability[attributes.Electro],
-		)
+		).
+			Write("aura", "ec").
+			Write("target", r.self.Index()).
+			Write("hydro", r.Durability[attributes.Hydro]).
+			Write("electro", r.Durability[attributes.Electro])
+
 	}
 }
 

--- a/pkg/simulation/data.go
+++ b/pkg/simulation/data.go
@@ -30,7 +30,8 @@ func (s *Simulation) initDetailLog() {
 	s.C.Events.Subscribe(event.OnTargetAdded, func(args ...interface{}) bool {
 		t := args[0].(combat.Target)
 
-		s.C.Log.NewEvent("Target Added", glog.LogDebugEvent, -1, "target_type", t.Type())
+		s.C.Log.NewEvent("Target Added", glog.LogDebugEvent, -1).
+			Write("target_type", t.Type())
 		s.stats.ElementUptime = append(s.stats.ElementUptime, make(map[attributes.Element]int))
 
 		return false

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -95,7 +95,8 @@ func (s *Simulation) queueAndExec() error {
 			if s.queue.Action == action.ActionWait {
 				//wipe the action here, set skip
 				s.skip = s.queue.Param["f"]
-				s.C.Log.NewEvent("executed wait", glog.LogActionEvent, s.C.Player.Active(), "f", s.queue.Param["f"])
+				s.C.Log.NewEvent("executed wait", glog.LogActionEvent, s.C.Player.Active()).
+					Write("f", s.queue.Param["f"])
 				s.queue = nil
 				return nil
 			} else {

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -79,7 +79,9 @@ func (s *Simulation) randEnergy() {
 	//calculate next
 	next := int(s.C.Rand.Float64()*s.cfg.Energy.Mean/5 + s.cfg.Energy.Mean)
 	// next := int(-math.Log(1-s.C.Rand.Float64()) / s.cfg.Energy.Lambda)
-	s.C.Log.NewEventBuildMsg(glog.LogEnergyEvent, -1, "rand energy queued - ", fmt.Sprintf("next %v", s.C.F+next)).Write("settings", s.cfg.Energy, "first", next)
+	s.C.Log.NewEventBuildMsg(glog.LogEnergyEvent, -1, "rand energy queued - ", fmt.Sprintf("next %v", s.C.F+next)).
+		Write("settings", s.cfg.Energy).
+		Write("first", next)
 	s.C.Tasks.Add(s.randEnergy, next)
 }
 
@@ -97,7 +99,9 @@ func (s *Simulation) SetupRandEnergyDrop() {
 	s.cfg.Energy.Mean = s.cfg.Energy.Every * 60
 	next := int(s.C.Rand.Float64()*s.cfg.Energy.Mean/5 + s.cfg.Energy.Mean)
 	// next := int(-math.Log(1-s.C.Rand.Float64()) / s.cfg.Energy.Lambda)
-	s.C.Log.NewEventBuildMsg(glog.LogEnergyEvent, -1, "rand energy started - ", fmt.Sprintf("next %v", s.C.F+next)).Write("settings", s.cfg.Energy, "first", next)
+	s.C.Log.NewEventBuildMsg(glog.LogEnergyEvent, -1, "rand energy started - ", fmt.Sprintf("next %v", s.C.F+next)).
+		Write("settings", s.cfg.Energy).
+		Write("first", next)
 	//start the first round
 	s.C.Tasks.Add(s.randEnergy, next)
 }


### PR DESCRIPTION
The current implementation of `Log.NewEvent()` accepts a variadic parameter which causes a lot of unnecessary allocations.

I've changed all the calls to `Log.NewEvent()` to only pass the first three parameters and instead make chain calls to `Write()` for each additional (key, value) pair.

I also updated the AST walking script to work recursively and automatically format the code without needing to run `gofmt -w .`. If you want I can also push those changes.