### PR TITLE
Includes pre_recovery field in AddEnergy log entry

### DIFF
--- a/pkg/core/player/character/energy.go
+++ b/pkg/core/player/character/energy.go
@@ -29,6 +29,7 @@ func (c *CharWrapper) AddEnergy(src string, e float64) {
 	c.events.Emit(event.OnEnergyChange, c, preEnergy, e, src)
 	c.log.NewEvent("adding energy", glog.LogEnergyEvent, c.Index).
 		Write("rec'd", e).
+		Write("pre_recovery", preEnergy).
 		Write("post_recovery", c.Energy).
 		Write("source", src).
 		Write("max_energy", c.EnergyMax)


### PR DESCRIPTION
Not sure if there's a particular reason why `pre_recovery` field is not included in the `energy` event emitted from `AddEnergy`, but if there isn't, here's a patch to add it. This makes it more consistent to the `energy` events emitted elsewhere.

Tested locally by inspecting the output data.

First time contributing here, so let me know if I missed anything. Thanks!