### PR TITLE
Fixes build.sh for Mac

### DIFF
--- a/cmd/gcsim/build.sh
+++ b/cmd/gcsim/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # notice how we avoid spaces in $now to avoid quotation hell in go build command
-now=$(date --utc +%FT%T%Z)
+now=$(date -u +%FT%T%Z)
 go build -ldflags "-X main.sha1ver=`git rev-parse HEAD` -X main.buildTime=$now"


### PR DESCRIPTION
Mac's version of `date` only has `-u`, not `--utc`. I tested on a Debian 10 machine and verified that `-u` and `--utc` give the same output on Linux.