### PR TITLE
Support outputting debug log for min/max-DPS runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ internal/characters/replace.txt
 ./cmd/gcsim/tests
 ./cmd/gcsim/*.gz
 ./cmd/gcsim/*.json
+cmd/gcsim/gcsim
 !release-notes.txt
 \.vscode/

--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -33,6 +33,7 @@ type opts struct {
 	// substatOptim bool
 	// verbose      bool
 	// options      string
+	debugMinMax bool
 }
 
 //command line tool; following options are available:
@@ -48,6 +49,7 @@ func main() {
 	flag.BoolVar(&opt.serve, "s", false, "serve file to viewer (local). default false")
 	flag.BoolVar(&opt.nobrowser, "nb", false, "disable opening default browser")
 	flag.BoolVar(&opt.keepserving, "ks", false, "keep serving same file without terminating web server")
+	flag.BoolVar(&opt.debugMinMax, "debugMinMax", false, "Output debug log for the min-DPS and max-DPS runs in addition to a random run.")
 
 	flag.Parse()
 
@@ -72,6 +74,7 @@ func main() {
 		GZIPResult:       opt.gz,
 		Version:          sha1ver,
 		BuildDate:        buildTime,
+		DebugMinMax:      opt.debugMinMax,
 	}
 
 	res, err := simulator.Run(simopt)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -25,6 +25,7 @@ import (
 type Core struct {
 	F     int
 	Flags Flags
+	Seed  int64
 	Rand  *rand.Rand
 	//various functionalities of core
 	Log        glog.Logger    //we use an interface here so that we can pass in a nil logger for all except 1 run
@@ -78,6 +79,7 @@ type CoreOpt struct {
 
 func New(opt CoreOpt) (*Core, error) {
 	c := &Core{}
+	c.Seed = opt.Seed
 	c.Rand = rand.New(rand.NewSource(opt.Seed))
 	c.Flags.Custom = make(map[string]int)
 	if opt.Debug {

--- a/pkg/result/results.go
+++ b/pkg/result/results.go
@@ -46,9 +46,11 @@ type Summary struct {
 	MinSeed int64 `json:"-"`
 	MaxSeed int64 `json:"-"`
 	//put these last so result is kinda readable by human
-	Config string `json:"config_file"`
-	Text   string `json:"text"`
-	Debug  string `json:"debug"`
+	Config         string `json:"config_file"`
+	Text           string `json:"text"`
+	Debug          string `json:"debug"`
+	DebugMinDPSRun string `json:"debugMinDPSRun"`
+	DebugMaxDPSRun string `json:"debugMaxDPSRun"`
 }
 
 type IntResult struct {
@@ -114,7 +116,7 @@ func CollectResult(data []simulation.Result, mode bool, chars []string, detailed
 
 		//dmg
 		if v.Damage < result.Damage.Min {
-			result.DPS.Min = v.Damage
+			result.Damage.Min = v.Damage
 
 		}
 		if v.Damage > result.Damage.Max {

--- a/pkg/result/results.go
+++ b/pkg/result/results.go
@@ -49,8 +49,8 @@ type Summary struct {
 	Config         string `json:"config_file"`
 	Text           string `json:"text"`
 	Debug          string `json:"debug"`
-	DebugMinDPSRun string `json:"debugMinDPSRun"`
-	DebugMaxDPSRun string `json:"debugMaxDPSRun"`
+	DebugMinDPSRun string `json:"debug_min_dps_run"`
+	DebugMaxDPSRun string `json:"debug_max_dps_run"`
 }
 
 type IntResult struct {

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -52,6 +52,8 @@ func (s *Simulation) Run() (Result, error) {
 		stop = s.C.F == f
 	}
 
+	s.stats.Seed = s.C.Seed
+
 	s.stats.Damage = s.C.Combat.TotalDamage
 	s.stats.DPS = s.stats.Damage * 60 / float64(s.C.F+1)
 	s.stats.Duration = f

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -23,6 +23,7 @@ type Options struct {
 	ConfigPath       string // path to the config file to read
 	Version          string
 	BuildDate        string
+	DebugMinMax      bool // whether to additional include debug logs for min/max-DPS runs
 }
 
 var start time.Time
@@ -91,6 +92,22 @@ func RunWithConfig(cfg string, simcfg *ast.ActionList, opts Options) (result.Sum
 		return r, err
 	}
 	r.Debug = debugOut
+
+	// Include debug logs for min/max-DPS runs if requested.
+	if opts.DebugMinMax {
+		minDPSDebugOut, err := GenerateDebugLogWithSeed(simcfg, r.MinSeed)
+		if err != nil {
+			return r, err
+		}
+		r.DebugMinDPSRun = minDPSDebugOut
+
+		maxDPSDebugOut, err := GenerateDebugLogWithSeed(simcfg, r.MaxSeed)
+		if err != nil {
+			return r, err
+		}
+		r.DebugMaxDPSRun = maxDPSDebugOut
+	}
+
 	r.Runtime = time.Since(start)
 	r.Config = cfg
 	r.Version = opts.Version


### PR DESCRIPTION
If the new CLI option `--debugMinMax` is given, will additionally output min/max-DPS runs' debug logs in `debug_min_dps_run` and `debug_max_dps_run` JSON fields in the output.

Tested with doing a sim and tallying up the damage from the 3 debug runs:

```
$ tools/gcsim_tools.py show-damages /tmp/gcsim.out.gz.gz | pc -1 | get_sum
698147

$ tools/gcsim_tools.py show-damages /tmp/gcsim.out.gz.gz --debug-log-flavor debug_min_dps_run | pc -1 | get_sum
423780

$ tools/gcsim_tools.py show-damages /tmp/gcsim.out.gz.gz --debug-log-flavor debug_max_dps_run | pc -1 | get_sum
809334
```