### PR TITLE
fix transient blossom icd reset timing

### DIFF
--- a/internal/characters/albedo/albedo.go
+++ b/internal/characters/albedo/albedo.go
@@ -190,9 +190,6 @@ func (c *char) Skill(p map[string]int) (int, int) {
 	c.skillAttackInfo = ai
 	c.skillSnapshot = c.Snapshot(&c.skillAttackInfo)
 
-	// Reset ICD
-	c.icdSkill = c.Core.F - 1
-
 	//create a construct
 	// Construct is not fully formed until after the hit lands (exact timing unknown)
 	c.AddTask(func() {
@@ -201,6 +198,10 @@ func (c *char) Skill(p map[string]int) (int, int) {
 		c.lastConstruct = c.Core.F
 
 		c.Tags["elevator"] = 1
+
+		// Reset ICD after construct is created
+		c.icdSkill = c.Core.F - 1
+
 	}, "albedo-create-construct", f)
 
 	c.SetCD(core.ActionSkill, 240)


### PR DESCRIPTION
correction to the transient blossom icd reset timing, where the timing is now after the construct has been created, as opposed what used to be when the skill was used. source: https://discord.com/channels/763583452762734592/763610791839924224/1001895536552595536

this issue used to give rise to bugs like what happens in here (https://gcsim.app/viewer/share/heOJY9AJNuV7PON6x3psV) at the 25.92s mark.