### PR TITLE
fix char hitlag & some char issues

### DIFF
--- a/internal/characters/albedo/attack.go
+++ b/internal/characters/albedo/attack.go
@@ -11,7 +11,7 @@ import (
 
 var attackFrames [][]int
 var attackHitmarks = []int{12, 18, 29, 39, 54}
-var attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06, 0.09, 0.012}
+var attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
 
 const normalHitNum = 5
 

--- a/internal/characters/aloy/skill.go
+++ b/internal/characters/aloy/skill.go
@@ -71,6 +71,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Durability:         25,
 		Mult:               skillBomblets[c.TalentLvlSkill()],
 		CanBeDefenseHalted: true,
+		IsDeployable:       true,
 	}
 
 	// Queue up bomblets

--- a/internal/characters/ayaka/attack.go
+++ b/internal/characters/ayaka/attack.go
@@ -12,6 +12,8 @@ import (
 var attackFrames [][]int
 var attackHitmarks = [][]int{{8}, {10}, {16}, {8, 15, 22}, {27}}
 var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0, 0.03}, {0}}
+var attackHitlagFactor = [][]float64{{0.01}, {0.01}, {0.01}, {0, 0, 0.05}, {0.01}}
+var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false, true}, {false}}
 
 const normalHitNum = 5
 
@@ -44,9 +46,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			ICDGroup:           combat.ICDGroupDefault,
 			Element:            attributes.Physical,
 			Durability:         25,
-			HitlagFactor:       0.01,
+			HitlagFactor:       attackHitlagFactor[c.NormalCounter][i],
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
-			CanBeDefenseHalted: true,
+			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 			Mult:               mult[c.TalentLvlAttack()],
 		}
 		c.QueueCharTask(func() {

--- a/internal/characters/ayato/attack.go
+++ b/internal/characters/ayato/attack.go
@@ -12,6 +12,7 @@ import (
 var attackFrames [][]int
 var attackHitmarks = [][]int{{12}, {18}, {20}, {22, 25}, {41}}
 var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0}, {0.08}}
+var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false}, {true}}
 var shunsuikenFrames []int
 
 const normalHitNum = 5
@@ -52,7 +53,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			Mult:               mult[c.TalentLvlAttack()],
 			HitlagFactor:       0.01,
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
-			CanBeDefenseHalted: true,
+			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
@@ -88,7 +89,7 @@ func (c *char) SoukaiKanka(p map[string]int) action.ActionInfo {
 		Mult:               shunsuiken[c.NormalCounter][c.TalentLvlSkill()],
 		HitlagFactor:       0.01,
 		HitlagHaltFrames:   0.03 * 60,
-		CanBeDefenseHalted: true,
+		CanBeDefenseHalted: false,
 	}
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, shunsuikenHitmark, c.generateParticles, c.skillStacks)
 

--- a/internal/characters/ayato/burst.go
+++ b/internal/characters/ayato/burst.go
@@ -85,7 +85,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		c.Core.Tasks.Add(func() {
 			active := c.Core.Player.ActiveChar()
 			active.AddAttackMod(character.AttackMod{
-				Base: modifier.NewBase("ayato-burst", 90),
+				Base: modifier.NewBaseWithHitlag("ayato-burst", 90),
 				Amount: func(a *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 					return m, a.Info.AttackTag == combat.AttackTagNormal
 				},
@@ -98,7 +98,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		m[attributes.AtkSpd] = 0.15
 		for _, char := range c.Core.Player.Chars() {
 			char.AddStatMod(character.StatMod{
-				Base:         modifier.NewBase("ayato-c4", 15*60),
+				Base:         modifier.NewBaseWithHitlag("ayato-c4", 15*60),
 				AffectedStat: attributes.AtkSpd,
 				Amount: func() ([]float64, bool) {
 					return m, true

--- a/internal/characters/beidou/attack.go
+++ b/internal/characters/beidou/attack.go
@@ -11,7 +11,7 @@ import (
 
 var attackFrames [][]int
 var attackHitmarks = []int{23, 22, 45, 25, 43}
-var attackHitlagHaltFrame = []float64{.09, .12, .12, .09, .12}
+var attackHitlagHaltFrame = []float64{.09, .12, .09, .09, .12}
 
 const normalHitNum = 5
 

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -41,12 +41,12 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Mult:               burstonhit[c.TalentLvlBurst()],
 		HitlagFactor:       0.01,
 		HitlagHaltFrames:   0.1 * 60,
-		CanBeDefenseHalted: true,
+		CanBeDefenseHalted: false,
 	}
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), burstHitmark, burstHitmark)
 
-	//TODO: this implementation will only extend her burst if she's on field; need to check if correct
-	c.AddStatus(burstKey, 900, true)
+	// beidou burst is not hitlag extendable
+	c.AddStatus(burstKey, 900, false)
 
 	procAI := combat.AttackInfo{
 		ActorIndex: c.Index,

--- a/internal/characters/chongyun/skill.go
+++ b/internal/characters/chongyun/skill.go
@@ -40,7 +40,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:               skill[c.TalentLvlSkill()],
 		HitlagFactor:       0.01,
 		HitlagHaltFrames:   0.09 * 60,
-		CanBeDefenseHalted: true,
+		CanBeDefenseHalted: false,
 	}
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), 0, skillHitmark)
 

--- a/internal/characters/chongyun/skill.go
+++ b/internal/characters/chongyun/skill.go
@@ -174,7 +174,7 @@ func (c *char) infuse(active *character.CharWrapper) {
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.AtkSpd] = 0.08
 	active.AddStatMod(character.StatMod{
-		Base:         modifier.NewBase("chongyun-field", 126),
+		Base:         modifier.NewBaseWithHitlag("chongyun-field", 126),
 		AffectedStat: attributes.NoStat,
 		Amount: func() ([]float64, bool) {
 			return m, true

--- a/internal/characters/raiden/attack.go
+++ b/internal/characters/raiden/attack.go
@@ -14,6 +14,10 @@ const normalHitNum = 5
 var attackFrames [][]int
 var attackHitmarks = [][]int{{14}, {9}, {14}, {14, 27}, {34}}
 
+// same between polearm and burst attacks so just use these arrays for both
+var attackHitlagHaltFrame = [][]float64{{0.02}, {0.02}, {0.02}, {0, 0}, {0.02}}
+var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false}, {true}}
+
 func init() {
 	// NA cancels (polearm)
 	attackFrames = make([][]int, normalHitNum)
@@ -39,20 +43,19 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		return c.swordAttack(p)
 	}
 
-	ai := combat.AttackInfo{
-		ActorIndex:         c.Index,
-		Abil:               fmt.Sprintf("Normal %v", c.NormalCounter),
-		AttackTag:          combat.AttackTagNormal,
-		ICDTag:             combat.ICDTagNormalAttack,
-		ICDGroup:           combat.ICDGroupDefault,
-		Element:            attributes.Physical,
-		Durability:         25,
-		HitlagHaltFrames:   0.02 * 60, //all raiden normals have 0.02s hitlag
-		HitlagFactor:       0.01,
-		CanBeDefenseHalted: true,
-	}
-
 	for i, mult := range attack[c.NormalCounter] {
+		ai := combat.AttackInfo{
+			ActorIndex:         c.Index,
+			Abil:               fmt.Sprintf("Normal %v", c.NormalCounter),
+			AttackTag:          combat.AttackTagNormal,
+			ICDTag:             combat.ICDTagNormalAttack,
+			ICDGroup:           combat.ICDGroupDefault,
+			Element:            attributes.Physical,
+			Durability:         25,
+			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
+			HitlagFactor:       0.01,
+			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
+		}
 		ax := ai
 		ax.Mult = mult[c.TalentLvlAttack()]
 		c.QueueCharTask(func() {
@@ -95,20 +98,19 @@ func init() {
 }
 
 func (c *char) swordAttack(p map[string]int) action.ActionInfo {
-	ai := combat.AttackInfo{
-		ActorIndex:         c.Index,
-		Abil:               fmt.Sprintf("Musou Isshin %v", c.NormalCounter),
-		AttackTag:          combat.AttackTagElementalBurst,
-		ICDTag:             combat.ICDTagNormalAttack,
-		ICDGroup:           combat.ICDGroupDefault,
-		Element:            attributes.Electro,
-		Durability:         25,
-		HitlagHaltFrames:   0.02 * 60, //all raiden normals have 0.2s hitlag
-		HitlagFactor:       0.01,
-		CanBeDefenseHalted: true,
-	}
-
 	for i, mult := range attackB[c.NormalCounter] {
+		ai := combat.AttackInfo{
+			ActorIndex:         c.Index,
+			Abil:               fmt.Sprintf("Musou Isshin %v", c.NormalCounter),
+			AttackTag:          combat.AttackTagElementalBurst,
+			ICDTag:             combat.ICDTagNormalAttack,
+			ICDGroup:           combat.ICDGroupDefault,
+			Element:            attributes.Electro,
+			Durability:         25,
+			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
+			HitlagFactor:       0.01,
+			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
+		}
 		// Sword hits are dynamic - group snapshots with damage proc
 		ax := ai
 		ax.Mult = mult[c.TalentLvlBurst()]

--- a/internal/characters/raiden/charge.go
+++ b/internal/characters/raiden/charge.go
@@ -25,16 +25,17 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	}
 
 	ai := combat.AttackInfo{
-		ActorIndex:       c.Index,
-		Abil:             "Charge Attack",
-		AttackTag:        combat.AttackTagExtra,
-		ICDTag:           combat.ICDTagExtraAttack,
-		ICDGroup:         combat.ICDGroupDefault,
-		Element:          attributes.Physical,
-		Durability:       25,
-		HitlagHaltFrames: 0.02 * 60, //all raiden normals have 0.02s hitlag
-		HitlagFactor:     0.01,
-		Mult:             charge[c.TalentLvlAttack()],
+		ActorIndex:         c.Index,
+		Abil:               "Charge Attack",
+		AttackTag:          combat.AttackTagExtra,
+		ICDTag:             combat.ICDTagExtraAttack,
+		ICDGroup:           combat.ICDGroupDefault,
+		Element:            attributes.Physical,
+		Durability:         25,
+		HitlagHaltFrames:   0.02 * 60,
+		HitlagFactor:       0.01,
+		CanBeDefenseHalted: true,
+		Mult:               charge[c.TalentLvlAttack()],
 	}
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy), chargeHitmark, chargeHitmark)

--- a/internal/characters/raiden/cons.go
+++ b/internal/characters/raiden/cons.go
@@ -20,7 +20,7 @@ func (c *char) c4() {
 			continue
 		}
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("raiden-c4", 600),
+			Base:         modifier.NewBaseWithHitlag("raiden-c4", 600),
 			AffectedStat: attributes.ATKP,
 			Amount: func() ([]float64, bool) {
 				return m, true

--- a/internal/characters/rosaria/charge.go
+++ b/internal/characters/rosaria/charge.go
@@ -32,6 +32,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Mult:               nc[c.TalentLvlAttack()],
 		HitlagFactor:       0.01,
 		CanBeDefenseHalted: true,
+		IsDeployable:       true,
 	}
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), chargeHitmark, chargeHitmark)

--- a/internal/characters/rosaria/skill.go
+++ b/internal/characters/rosaria/skill.go
@@ -79,11 +79,12 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		HitlagFactor:       0.01,
 		CanBeDefenseHalted: true,
 	}
-	//second hit is 14 frames after the first
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), skillHitmark+14, skillHitmark+14)
-
-	// Particles are emitted after the second hit lands
-	c.Core.QueueParticle("rosaria", 3, attributes.Cryo, skillHitmark+14+c.Core.Flags.ParticleDelay)
+	c.QueueCharTask(func() {
+		//second hit is 14 frames after the first (if we exclude hitlag)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), 0, 0)
+		// Particles are emitted after the second hit lands
+		c.Core.QueueParticle("rosaria", 3, attributes.Cryo, c.Core.Flags.ParticleDelay)
+	}, skillHitmark+14)
 
 	c.SetCDWithDelay(action.ActionSkill, 360, 23)
 

--- a/internal/characters/sara/cons.go
+++ b/internal/characters/sara/cons.go
@@ -26,7 +26,7 @@ func (c *char) c1() {
 // The Electro DMG of characters who have had their ATK increased by Tengu Juurai has its Crit DMG increased by 60%.
 func (c *char) c6(char *character.CharWrapper) {
 	char.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("sara-c6", 360),
+		Base: modifier.NewBaseWithHitlag("sara-c6", 360),
 		Amount: func(atk *combat.AttackEvent, _ combat.Target) ([]float64, bool) {
 			if atk.Info.Element != attributes.Electro {
 				return nil, false

--- a/internal/characters/sayu/skill.go
+++ b/internal/characters/sayu/skill.go
@@ -143,18 +143,17 @@ func (c *char) skillHold(p map[string]int, duration int) action.ActionInfo {
 //TODO: is this helper needed?
 func (c *char) createSkillHoldSnapshot() *combat.AttackEvent {
 	ai := combat.AttackInfo{
-		ActorIndex:         c.Index,
-		Abil:               "Yoohoo Art: Fuuin Dash (Hold Tick)",
-		AttackTag:          combat.AttackTagElementalArtHold,
-		ICDTag:             combat.ICDTagElementalArtAnemo,
-		ICDGroup:           combat.ICDGroupDefault,
-		Element:            attributes.Anemo,
-		Durability:         25,
-		Mult:               skillPress[c.TalentLvlSkill()],
-		HitlagHaltFrames:   0.01 * 60,
-		HitlagFactor:       0.05,
-		CanBeDefenseHalted: true,
-		IsDeployable:       true,
+		ActorIndex:       c.Index,
+		Abil:             "Yoohoo Art: Fuuin Dash (Hold Tick)",
+		AttackTag:        combat.AttackTagElementalArtHold,
+		ICDTag:           combat.ICDTagElementalArtAnemo,
+		ICDGroup:         combat.ICDGroupDefault,
+		Element:          attributes.Anemo,
+		Durability:       25,
+		Mult:             skillPress[c.TalentLvlSkill()],
+		HitlagHaltFrames: 0.01 * 60,
+		HitlagFactor:     0.05,
+		IsDeployable:     true,
 	}
 	snap := c.Snapshot(&ai)
 

--- a/internal/characters/shenhe/charge.go
+++ b/internal/characters/shenhe/charge.go
@@ -31,6 +31,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Mult:               charged[c.TalentLvlAttack()],
 		HitlagFactor:       0.01,
 		CanBeDefenseHalted: true,
+		IsDeployable:       true,
 	}
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), chargeHitmark, chargeHitmark)

--- a/internal/characters/sucrose/cons.go
+++ b/internal/characters/sucrose/cons.go
@@ -31,10 +31,9 @@ func (c *char) c6() {
 	stat := attributes.EleToDmgP(c.qInfused)
 	c.c6buff[stat] = .20
 
-	//TODO: assuming this here is on a deployable therefore not affected by hitlag?
 	for _, char := range c.Core.Player.Chars() {
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("sucrose-c6", 60*10),
+			Base:         modifier.NewBaseWithHitlag("sucrose-c6", 60*10),
 			AffectedStat: stat,
 			Amount: func() ([]float64, bool) {
 				return c.c6buff, true

--- a/internal/characters/thoma/asc.go
+++ b/internal/characters/thoma/asc.go
@@ -9,7 +9,7 @@ func (c *char) a1() {
 		if c.Tags["shielded"] == 0 {
 			return 0, false
 		}
-		if c.Core.Status.Duration("thoma-a1") <= 0 {
+		if !c.StatusIsActive("thoma-a1") {
 			return 0, false
 		}
 		return float64(c.a1Stack) * 0.05, true

--- a/internal/characters/thoma/attack.go
+++ b/internal/characters/thoma/attack.go
@@ -12,7 +12,7 @@ import (
 var attackFrames [][]int
 var attackHitmarks = [][]int{{11}, {38}, {27, 40}, {25}}
 var attackHitlagHaltFrame = [][]float64{{0.06}, {0.09}, {0, 0}, {0}}
-var attackDefHalt = [][]bool{{true}, {true}, {false, false}, {true}}
+var attackDefHalt = [][]bool{{true}, {true}, {false, false}, {false}}
 
 const normalHitNum = 4
 

--- a/internal/characters/thoma/charge.go
+++ b/internal/characters/thoma/charge.go
@@ -31,6 +31,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Mult:               charged[c.TalentLvlAttack()],
 		HitlagFactor:       0.01,
 		CanBeDefenseHalted: true,
+		IsDeployable:       true,
 	}
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), chargeHitmark, chargeHitmark)

--- a/internal/characters/thoma/shield.go
+++ b/internal/characters/thoma/shield.go
@@ -9,10 +9,10 @@ import (
 )
 
 func (c *char) genShield(src string, shieldamt float64) {
-	if c.Core.F > c.a1icd && c.a1Stack < 5 {
+	if !c.StatusIsActive("thoma-a1-icd") && c.a1Stack < 5 {
 		c.a1Stack++
-		c.a1icd = c.Core.F + 0.3*60
-		c.Core.Status.Add("thoma-a1", 6*60)
+		c.AddStatus("thoma-a1-icd", 18, true) // 0.3s * 60
+		c.AddStatus("thoma-a1", 360, true)    // 6s * 60
 	}
 	if c.Core.Player.Shields.Get(shield.ShieldThomaSkill) != nil {
 		maxHP := c.maxShieldHP()

--- a/internal/characters/thoma/thoma.go
+++ b/internal/characters/thoma/thoma.go
@@ -16,7 +16,6 @@ func init() {
 type char struct {
 	*tmpl.Character
 	a1Stack int
-	a1icd   int
 	c6buff  []float64
 }
 
@@ -33,7 +32,6 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ character.CharacterProfil
 	c.CharZone = character.ZoneInazuma
 
 	c.a1Stack = 0
-	c.a1icd = 0
 
 	w.Character = &c
 

--- a/internal/characters/xiangling/charge.go
+++ b/internal/characters/xiangling/charge.go
@@ -22,14 +22,17 @@ func init() {
 
 func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	ai := combat.AttackInfo{
-		ActorIndex: c.Index,
-		Abil:       "Charge",
-		AttackTag:  combat.AttackTagExtra,
-		ICDTag:     combat.ICDTagExtraAttack,
-		ICDGroup:   combat.ICDGroupPole,
-		Element:    attributes.Physical,
-		Durability: 25,
-		Mult:       nc[c.TalentLvlAttack()],
+		ActorIndex:         c.Index,
+		Abil:               "Charge",
+		AttackTag:          combat.AttackTagExtra,
+		ICDTag:             combat.ICDTagExtraAttack,
+		ICDGroup:           combat.ICDGroupPole,
+		Element:            attributes.Physical,
+		Durability:         25,
+		HitlagFactor:       0.01,
+		CanBeDefenseHalted: true,
+		IsDeployable:       true,
+		Mult:               nc[c.TalentLvlAttack()],
 	}
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), chargeHitmark, chargeHitmark)

--- a/internal/characters/xiao/xiao.go
+++ b/internal/characters/xiao/xiao.go
@@ -90,6 +90,11 @@ func (c *char) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 		// Also handle burst CA ICD change to share with Normal
 		switch a.AttackTag {
 		case combat.AttackTagNormal:
+			// QN1-1 has different hitlag from N1-1
+			if a.Abil == "Normal 0" {
+				//this also overwrites N1-2 HitlagHaltFrames but they have the same value so it's fine
+				a.HitlagHaltFrames = 0.01 * 60
+			}
 		case combat.AttackTagExtra:
 			// Q-CA has different hitlag from CA
 			a.ICDTag = combat.ICDTagNormalAttack

--- a/internal/characters/xiao/xiao.go
+++ b/internal/characters/xiao/xiao.go
@@ -70,7 +70,7 @@ func (c *char) Init() error {
 func (c *char) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 	ds := c.Character.Snapshot(a)
 
-	if c.Core.Status.Duration("xiaoburst") > 0 {
+	if c.StatusIsActive("xiaoburst") {
 		// Calculate and add A1 damage bonus - applies to all damage
 		// Fraction dropped in int conversion in go - acts like floor
 		stacks := 1 + int((c.Core.F-c.qStarted)/180)
@@ -91,6 +91,7 @@ func (c *char) Snapshot(a *combat.AttackInfo) combat.Snapshot {
 		switch a.AttackTag {
 		case combat.AttackTagNormal:
 		case combat.AttackTagExtra:
+			// Q-CA has different hitlag from CA
 			a.ICDTag = combat.ICDTagNormalAttack
 			a.HitlagHaltFrames = 0.04 * 60
 		case combat.AttackTagPlunge:

--- a/internal/characters/xinyan/burst.go
+++ b/internal/characters/xinyan/burst.go
@@ -40,6 +40,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	for i := 0; i < 7; i++ {
 		f := 63 + i*17
 		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), f, f)
+		if i == 0 {
+			ai.CanBeDefenseHalted = false // only the first DoT has hitlag
+		}
 	}
 
 	if c.Base.Cons >= 2 {

--- a/internal/characters/xinyan/cons.go
+++ b/internal/characters/xinyan/cons.go
@@ -33,7 +33,7 @@ func (c *char) c1() {
 		}
 
 		c.AddAttackMod(character.AttackMod{
-			Base: modifier.NewBase("xinyan-c1", 5*60),
+			Base: modifier.NewBaseWithHitlag("xinyan-c1", 5*60),
 			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 				return c.c1buff, true
 			},

--- a/internal/characters/yaemiko/cons.go
+++ b/internal/characters/yaemiko/cons.go
@@ -11,7 +11,7 @@ func (c *char) c4() {
 	// TODO: does this trigger for yaemiko too? assuming it does
 	for _, char := range c.Core.Player.Chars() {
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("yaemiko-c4", 5*60),
+			Base:         modifier.NewBaseWithHitlag("yaemiko-c4", 5*60),
 			AffectedStat: attributes.ElectroP,
 			Amount: func() ([]float64, bool) {
 				return c.c4buff, true

--- a/internal/characters/yelan/skill.go
+++ b/internal/characters/yelan/skill.go
@@ -50,10 +50,9 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		}
 	}
 
-	if c.Core.Status.Duration("yelanc4") == 0 {
+	if !c.StatusIsActive("yelanc4") {
 		c.c4count = 0
 		c.Core.Log.NewEvent("c4 stacks set to 0", glog.LogCharacterEvent, c.Index)
-
 	}
 
 	//add a task to loop through targets and mark them
@@ -77,7 +76,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			marked--
 			c.c4count++
 			if c.Base.Cons >= 4 {
-				c.Core.Status.Add("yelanc4", 25*60)
+				c.AddStatus("yelanc4", 25*60, true)
 			}
 		}
 	}, skillHitmark) //TODO: frames for hold e
@@ -132,7 +131,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 				Write("enemies count", c.c4count)
 			for _, char := range c.Core.Player.Chars() {
 				char.AddStatMod(character.StatMod{
-					Base:         modifier.NewBase("yelan-c4", 25*60),
+					Base:         modifier.NewBaseWithHitlag("yelan-c4", 25*60),
 					AffectedStat: attributes.HPP,
 					Amount: func() ([]float64, bool) {
 						return m, true

--- a/internal/characters/yunjin/charge.go
+++ b/internal/characters/yunjin/charge.go
@@ -32,6 +32,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Mult:               charge[c.TalentLvlAttack()],
 		HitlagFactor:       0.01,
 		CanBeDefenseHalted: true,
+		IsDeployable:       true,
 	}
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), chargeHitmark, chargeHitmark)
 

--- a/internal/characters/yunjin/cons.go
+++ b/internal/characters/yunjin/cons.go
@@ -14,7 +14,7 @@ func (c *char) c2() {
 	m[attributes.DmgP] = .15
 	for _, char := range c.Core.Player.Chars() {
 		char.AddAttackMod(character.AttackMod{
-			Base: modifier.NewBase("yunjin-c2", 12*60),
+			Base: modifier.NewBaseWithHitlag("yunjin-c2", 12*60),
 			Amount: func(ae *combat.AttackEvent, _ combat.Target) ([]float64, bool) {
 				if ae.Info.AttackTag == combat.AttackTagNormal {
 					return m, true


### PR DESCRIPTION
also fixes Xiao Q straight up not working (related to switching his Q status to be affected by hitlag and then not adjusting the status check)

chars that are missing hitlag completely:
```
itto
heizou
hutao
kuki
noelle
tartaglia 
traveleranemo
travelerelectro
travelergeo
yoimiya
```

remaining issues (maybe there are more?):
- raiden e buff is hitlag extendable in the sim atm, but the eye itself should also be hitlag extendable (attack icd?)
- Shenhe Q res shred, A1 and C2 are not properly implemented, but once they are they should be hitlag extendable.
- ~~Thoma A1 should be hitlag extendable (a1 icd)~~ 
- ~~Thoma Q should be hitlag extendable just like Xingqiu Q (also adjust the Q proc icd accordingly)~~
- ~~Xiao N1-1 has different hitlag when in Q state~~
- ~~Diluc Q is fucked~~

todo for me:
- Rosaria's hitmark on her second E hit should be delayed by hitlag the first hit (also applies to Rosaria Q, Kazuha Q, Sayu Q, Xinyan Q)