### PR TITLE
fix weapon hitlag

### DIFF
--- a/internal/weapons/bow/alley/alley.go
+++ b/internal/weapons/bow/alley/alley.go
@@ -91,7 +91,7 @@ func (w *Weapon) decStack(c *character.CharWrapper, src int) func() {
 			if w.stacks < 0 {
 				w.stacks = 0
 			}
-			w.core.Log.NewEvent("Alley lost stack", glog.LogArtifactEvent, w.char.Index).
+			w.core.Log.NewEvent("Alley lost stack", glog.LogWeaponEvent, w.char.Index).
 				Write("stacks:", w.stacks).
 				Write("last_swap", w.lastActiveChange).
 				Write("source", src)
@@ -104,7 +104,7 @@ func (w *Weapon) incStack(c *character.CharWrapper, src int) func() {
 	return func() {
 		if !w.active && w.stacks < 10 && src == w.lastActiveChange {
 			w.stacks++
-			w.core.Log.NewEvent("Alley gained stack", glog.LogArtifactEvent, w.char.Index).
+			w.core.Log.NewEvent("Alley gained stack", glog.LogWeaponEvent, w.char.Index).
 				Write("stacks:", w.stacks).
 				Write("last_swap", w.lastActiveChange).
 				Write("source", src)

--- a/internal/weapons/bow/aqua/aqua.go
+++ b/internal/weapons/bow/aqua/aqua.go
@@ -32,7 +32,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	m[attributes.DmgP] = 0.15 + float64(r)*0.05
 
 	char.AddStatMod(character.StatMod{
-		Base:         modifier.NewBase("aquasimulacra", -1),
+		Base:         modifier.NewBase("aquasimulacra-hp", -1),
 		AffectedStat: attributes.NoStat,
 		Amount: func() ([]float64, bool) {
 			return v, true
@@ -40,7 +40,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	})
 
 	char.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("aquasimulacra", -1),
+		Base: modifier.NewBase("aquasimulacra-dmg", -1),
 		Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 			//TODO: need range check here
 			return m, true

--- a/internal/weapons/bow/mitternachtswaltz/mitternachtswaltz.go
+++ b/internal/weapons/bow/mitternachtswaltz/mitternachtswaltz.go
@@ -52,7 +52,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 
 		if atk.Info.AttackTag == combat.AttackTagNormal {
 			char.AddAttackMod(character.AttackMod{
-				Base: modifier.NewBase("mitternachtswaltz-ele", 300),
+				Base: modifier.NewBaseWithHitlag("mitternachtswaltz-ele", 300),
 				Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 					if (atk.Info.AttackTag == combat.AttackTagElementalArt) || (atk.Info.AttackTag == combat.AttackTagElementalArtHold) {
 						m[attributes.DmgP] = buffAmount
@@ -65,7 +65,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 
 		if (atk.Info.AttackTag == combat.AttackTagElementalArt) || (atk.Info.AttackTag == combat.AttackTagElementalArtHold) {
 			char.AddAttackMod(character.AttackMod{
-				Base: modifier.NewBase("mitternachtswaltz-na", 300),
+				Base: modifier.NewBaseWithHitlag("mitternachtswaltz-na", 300),
 				Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 					if atk.Info.AttackTag == combat.AttackTagNormal {
 						m[attributes.DmgP] = buffAmount

--- a/internal/weapons/bow/polarstar/polarstar.go
+++ b/internal/weapons/bow/polarstar/polarstar.go
@@ -37,27 +37,28 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	stack := .075 + float64(r)*.025
 	max := .06 + float64(r)*.02
 
-	normal := 0
-	charged := 0
-	skill := 0
-	burst := 0
+	const normalKey = "polar-star-normal"
+	const chargedKey = "polar-star-charged"
+	const skillKey = "polar-star-skill"
+	const burstKey = "polar-star-burst"
+	stackDuration := 720 // 12s * 60
 
 	mATK := make([]float64, attributes.EndStatType)
 	char.AddStatMod(character.StatMod{
-		Base:         modifier.NewBase("polar-star", -1),
+		Base:         modifier.NewBase("polar-star-atk", -1),
 		AffectedStat: attributes.NoStat,
 		Amount: func() ([]float64, bool) {
 			count := 0
-			if normal > c.F {
+			if char.StatusIsActive(normalKey) {
 				count++
 			}
-			if charged > c.F {
+			if char.StatusIsActive(chargedKey) {
 				count++
 			}
-			if skill > c.F {
+			if char.StatusIsActive(skillKey) {
 				count++
 			}
-			if burst > c.F {
+			if char.StatusIsActive(burstKey) {
 				count++
 			}
 
@@ -80,16 +81,15 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 
-		cd := c.F + 60*12
 		switch atk.Info.AttackTag {
 		case combat.AttackTagNormal:
-			normal = cd
+			char.AddStatus(normalKey, stackDuration, true)
 		case combat.AttackTagExtra:
-			charged = cd
+			char.AddStatus(chargedKey, stackDuration, true)
 		case combat.AttackTagElementalArt, combat.AttackTagElementalArtHold:
-			skill = cd
+			char.AddStatus(skillKey, stackDuration, true)
 		case combat.AttackTagElementalBurst:
-			burst = cd
+			char.AddStatus(burstKey, stackDuration, true)
 		}
 
 		return false
@@ -98,7 +98,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	mDmg := make([]float64, attributes.EndStatType)
 	mDmg[attributes.DmgP] = dmg
 	char.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("polar-star", -1),
+		Base: modifier.NewBase("polar-star-dmg", -1),
 		Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 			switch atk.Info.AttackTag {
 			case combat.AttackTagElementalArt, combat.AttackTagElementalArtHold, combat.AttackTagElementalBurst:

--- a/internal/weapons/bow/prototype/prototype.go
+++ b/internal/weapons/bow/prototype/prototype.go
@@ -40,7 +40,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("prototype-crescent", 60*10),
+			Base:         modifier.NewBaseWithHitlag("prototype-crescent", 60*10),
 			AffectedStat: attributes.NoStat,
 			Amount: func() ([]float64, bool) {
 				return m, true

--- a/internal/weapons/bow/skyward/skyward.go
+++ b/internal/weapons/bow/skyward/skyward.go
@@ -42,9 +42,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	})
 
 	//procs
-	cd := 270 - 30*r
 	prob := 0.5 + 0.1*float64(r)
-	icd := 0
+	const icdKey = "skyward-harp-icd"
+	cd := 270 - 30*r
 
 	c.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
 		atk := args[1].(*combat.AttackEvent)
@@ -57,7 +57,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 
-		if icd > c.F {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
 		if c.Rand.Float64() > prob {
@@ -76,7 +76,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		}
 		c.QueueAttack(ai, combat.NewCircleHit(trg, 2, true, combat.TargettableEnemy), 0, 1)
 
-		icd = c.F + cd
+		char.AddStatus(icdKey, cd, true)
 
 		return false
 	}, fmt.Sprintf("skyward-harp-%v", char.Base.Key.String()))

--- a/internal/weapons/bow/thundering/thundering.go
+++ b/internal/weapons/bow/thundering/thundering.go
@@ -33,8 +33,10 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	stack := 0.09 + float64(r)*0.03
 	max := 0.3 + float64(r)*0.1
 
-	normal := 0
-	skill := 0
+	const normalKey = "thundering-pulse-normal"
+	normalDuration := 300 // 5s * 60
+	const skillKey = "thundering-pulse-skill"
+	skillDuration := 600 // 10s * 60
 
 	key := fmt.Sprintf("thundering-pulse-%v", char.Base.Key.String())
 
@@ -46,7 +48,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if atk.Info.AttackTag != combat.AttackTagNormal {
 			return false
 		}
-		normal = c.F + 300
+		char.AddStatus(normalKey, normalDuration, true)
 		return false
 	}, key)
 
@@ -54,12 +56,12 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if c.Player.Active() != char.Index {
 			return false
 		}
-		skill = c.F + 600
+		char.AddStatus(skillKey, skillDuration, true)
 		return false
 	}, key)
 
 	char.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("thundering", -1),
+		Base: modifier.NewBase("thundering-pulse", -1),
 		Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 			m[attributes.DmgP] = 0
 			if atk.Info.AttackTag != combat.AttackTagNormal {
@@ -69,10 +71,10 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			if char.Energy < char.EnergyMax {
 				count++
 			}
-			if normal > c.F {
+			if char.StatusIsActive(normalKey) {
 				count++
 			}
-			if skill > c.F {
+			if char.StatusIsActive(skillKey) {
 				count++
 			}
 			dmg := float64(count) * stack

--- a/internal/weapons/bow/twilight/twilight.go
+++ b/internal/weapons/bow/twilight/twilight.go
@@ -51,22 +51,23 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		},
 	})
 
-	icd := 0
+	const icdKey = "twilight-icd"
+	icd := 420
 	c.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
 		atk := args[1].(*combat.AttackEvent)
 		if atk.Info.ActorIndex != char.Index {
 			return false
 		}
 
-		if icd > c.F {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
-		icd = c.F + 420
+		char.AddStatus(icdKey, icd, true)
 		cycle++
 		cycle = cycle % 3
 		c.Log.NewEvent("fading twillight cycle changed", glog.LogWeaponEvent, char.Index).
 			Write("cycle", cycle).
-			Write("next cycle", icd)
+			Write("next cycle (without hitlag)", c.F+icd)
 
 		return false
 	}, fmt.Sprintf("fadingtwilight-%v", char.Base.Key.String()))

--- a/internal/weapons/bow/viridescent/viridescent.go
+++ b/internal/weapons/bow/viridescent/viridescent.go
@@ -31,8 +31,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	w := &Weapon{}
 	r := p.Refine
 
+	const icdKey = "viridescent-hunt-icd"
 	cd := 900 - r*60
-	icd := 0
 	mult := 0.3 + float64(r)*0.1
 
 	c.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
@@ -50,7 +50,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 
-		if icd > c.F {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
 
@@ -73,7 +73,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			c.QueueAttack(ai, combat.NewCircleHit(trg, 3, false, combat.TargettableEnemy), 0, i+1)
 		}
 
-		icd = c.F + cd
+		char.AddStatus(icdKey, cd, true)
 
 		return false
 	}, fmt.Sprintf("veridescent-%v", char.Base.Key.String()))

--- a/internal/weapons/bow/windblume/windblume.go
+++ b/internal/weapons/bow/windblume/windblume.go
@@ -35,7 +35,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("windblume", 360),
+			Base:         modifier.NewBaseWithHitlag("windblume", 360),
 			AffectedStat: attributes.NoStat,
 			Amount: func() ([]float64, bool) {
 				return m, true

--- a/internal/weapons/catalyst/dodoco/dodoco.go
+++ b/internal/weapons/catalyst/dodoco/dodoco.go
@@ -44,7 +44,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		switch atk.Info.AttackTag {
 		case combat.AttackTagNormal:
 			char.AddAttackMod(character.AttackMod{
-				Base: modifier.NewBase("dodoco-ca", 360),
+				Base: modifier.NewBaseWithHitlag("dodoco-ca", 360),
 				Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 					if atk.Info.AttackTag != combat.AttackTagExtra {
 						return nil, false
@@ -54,7 +54,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			})
 		case combat.AttackTagExtra:
 			char.AddStatMod(character.StatMod{
-				Base:         modifier.NewBase("dodoco atk", 360),
+				Base:         modifier.NewBaseWithHitlag("dodoco-atk", 360),
 				AffectedStat: attributes.NoStat,
 				Amount: func() ([]float64, bool) {
 					return n, true

--- a/internal/weapons/catalyst/frostbearer/frostbearer.go
+++ b/internal/weapons/catalyst/frostbearer/frostbearer.go
@@ -32,7 +32,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	atkc := 1.6 + float64(r)*0.4
 	prob := 0.5 + float64(r)*0.1
 
-	icd := 0
+	const icdKey = "frostbearer-icd"
+	icd := 600
 
 	c.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
 		ae := args[1].(*combat.AttackEvent)
@@ -43,14 +44,14 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if ae.Info.ActorIndex != char.Index {
 			return false
 		}
-		if c.F > icd {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
 		if ae.Info.AttackTag != combat.AttackTagNormal && ae.Info.AttackTag != combat.AttackTagExtra {
 			return false
 		}
 		if c.Rand.Float64() < prob {
-			icd = c.F + 600
+			char.AddStatus(icdKey, icd, true)
 
 			ai := combat.AttackInfo{
 				ActorIndex: char.Index,

--- a/internal/weapons/catalyst/hakushin/hakushin.go
+++ b/internal/weapons/catalyst/hakushin/hakushin.go
@@ -54,7 +54,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 				}
 				this := char
 				char.AddStatMod(character.StatMod{
-					Base:         modifier.NewBase("hakushin-passive", 6*60),
+					Base:         modifier.NewBaseWithHitlag("hakushin-passive", 6*60),
 					AffectedStat: attributes.NoStat,
 					Amount: func() ([]float64, bool) {
 						m[attributes.PyroP] = 0
@@ -71,7 +71,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			}
 			c.Log.NewEvent("hakushin proc'd", glog.LogWeaponEvent, char.Index).
 				Write("trigger", key).
-				Write("expiring", c.F+6*60)
+				Write("expiring (without hitlag)", c.F+6*60)
 			return false
 		}
 	}

--- a/internal/weapons/catalyst/kagura/kagura.go
+++ b/internal/weapons/catalyst/kagura/kagura.go
@@ -35,18 +35,19 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	key := fmt.Sprintf("kaguradance-%v", char.Base.Key.String())
 	dmg := 0.12 + 0.03*float64(r-1)
 	val := make([]float64, attributes.EndStatType)
-	lastActiveUntil := -1
+	const stackKey = "kaguras-verity-stacks"
+	stackDuration := 960 // 16s * 60
 
 	//TODO: this used to be on postskill. make sure nothing broke here
 	c.Events.Subscribe(event.OnSkill, func(args ...interface{}) bool {
 		if c.Player.Active() != char.Index {
 			return false
 		}
-		if c.F > lastActiveUntil {
+		if !char.StatusIsActive(stackKey) {
 			//reset stacks back to 0
 			stacks = 0
 		}
-		lastActiveUntil = c.F + 960 //16 * 60
+		char.AddStatus(stackKey, stackDuration, true)
 		if stacks < 3 {
 			stacks++
 		}
@@ -73,7 +74,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		}
 		//add mod for duration, override last
 		char.AddAttackMod(character.AttackMod{
-			Base: modifier.NewBase("kagurasverity", 960),
+			Base: modifier.NewBaseWithHitlag("kaguras-verity", stackDuration),
 			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 				if atk.Info.ActorIndex != char.Index {
 					return nil, false

--- a/internal/weapons/catalyst/mappa/mappa.go
+++ b/internal/weapons/catalyst/mappa/mappa.go
@@ -28,7 +28,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	r := p.Refine
 
 	stacks := 0
-	dur := 0
+	const stackKey = "mappa-mare-stacks"
+	stackDuration := 600 // 10s * 60
 
 	addStack := func(args ...interface{}) bool {
 		atk := args[1].(*combat.AttackEvent)
@@ -39,17 +40,18 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 
-		if c.F > dur {
+		if !char.StatusIsActive(stackKey) {
 			stacks = 1
-			dur = c.F + 600
+			char.AddStatus(stackKey, stackDuration, true)
 			c.Log.NewEvent("mappa proc'd", glog.LogWeaponEvent, char.Index).
 				Write("stacks", stacks).
-				Write("expiry", dur)
+				Write("expiry (without hitlag)", c.F+stackDuration)
 		} else if stacks < 2 {
 			stacks++
+			char.AddStatus(stackKey, stackDuration, true)
 			c.Log.NewEvent("mappa proc'd", glog.LogWeaponEvent, char.Index).
 				Write("stacks", stacks).
-				Write("expiry", dur)
+				Write("expiry (without hitlag)", c.F+stackDuration)
 		}
 		return false
 	}
@@ -64,7 +66,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		Base:         modifier.NewBase("mappa", -1),
 		AffectedStat: attributes.NoStat,
 		Amount: func() ([]float64, bool) {
-			if c.F > dur {
+			if !char.StatusIsActive(stackKey) {
 				return nil, false
 			}
 

--- a/internal/weapons/catalyst/moonglow/moonglow.go
+++ b/internal/weapons/catalyst/moonglow/moonglow.go
@@ -58,12 +58,16 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		return false
 	}, fmt.Sprintf("moonglow-nabuff-%v", char.Base.Key.String()))
 
-	icd, dur := -1, -1
+	const buffKey = "moonglow-postburst"
+	buffDuration := 720 // 12s * 60
+	const icdKey = "moonglow-energy-icd"
+	icd := 6 // 0.1s * 60
+
 	c.Events.Subscribe(event.OnBurst, func(args ...interface{}) bool {
 		if c.Player.Active() != char.Index {
 			return false
 		}
-		dur = c.F + 720
+		char.AddStatus(buffKey, buffDuration, true)
 		return false
 	}, fmt.Sprintf("moonglow-onburst-%v", char.Base.Key.String()))
 
@@ -75,12 +79,12 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if atk.Info.AttackTag != combat.AttackTagNormal {
 			return false
 		}
-		if dur < c.F || icd > c.F {
+		if !char.StatusIsActive(buffKey) || char.StatusIsActive(icdKey) {
 			return false
 		}
 
 		char.AddEnergy("moonglow", 0.6)
-		icd = c.F + 6
+		char.AddStatus(icdKey, icd, true)
 
 		return false
 	}, fmt.Sprintf("moonglow-energy-%v", char.Base.Key.String()))

--- a/internal/weapons/catalyst/oathsworneye/oathsworneye.go
+++ b/internal/weapons/catalyst/oathsworneye/oathsworneye.go
@@ -34,7 +34,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("oathsworn", 10*60),
+			Base:         modifier.NewBaseWithHitlag("oathsworn", 10*60),
 			AffectedStat: attributes.NoStat,
 			Amount: func() ([]float64, bool) {
 				return val, true

--- a/internal/weapons/catalyst/perception/perception.go
+++ b/internal/weapons/catalyst/perception/perception.go
@@ -71,19 +71,19 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	w := &Weapon{}
 	r := p.Refine
 
-	dmg := 2.1 * float64(r) * 0.3
+	const icdKey = "perception-icd"
 	cd := (13 - r) * 60
-	icd := 0
+	dmg := 2.1 * float64(r) * 0.3
 
 	c.Events.Subscribe(event.OnAttackWillLand, func(args ...interface{}) bool {
 		ae := args[1].(*combat.AttackEvent)
 		if ae.Info.ActorIndex != char.Index {
 			return false
 		}
-		if icd > c.F {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
-		icd = c.F + cd
+		char.AddStatus(icdKey, cd, true)
 
 		ai := combat.AttackInfo{
 			ActorIndex: char.Index,

--- a/internal/weapons/catalyst/prayer/prayer.go
+++ b/internal/weapons/catalyst/prayer/prayer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/core/player/weapon"
@@ -19,6 +20,8 @@ func init() {
 type Weapon struct {
 	Index  int
 	stacks int
+	char   *character.CharWrapper
+	c      *core.Core
 	buff   []float64
 	dmg    float64
 }
@@ -31,6 +34,8 @@ func (w *Weapon) stackCheck(char *character.CharWrapper, c *core.Core) func() {
 			if w.stacks < 4 {
 				w.stacks++
 				w.updateBuff()
+				w.c.Log.NewEvent("lostprayer gained stack", glog.LogWeaponEvent, w.char.Index).
+					Write("stacks", w.stacks)
 			}
 		}
 		char.QueueCharTask(w.stackCheck(char, c), 240)
@@ -51,7 +56,10 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	//Increases Movement SPD by 10%. When in battle, gain an 8% Elemental DMG
 	//Bonus every 4s. Max 4 stacks. Lasts until the character falls or leaves
 	//combat.
-	w := &Weapon{}
+	w := &Weapon{
+		char: char,
+		c:    c,
+	}
 	r := p.Refine
 	w.dmg = 0.04 + float64(r)*0.02
 	w.buff = make([]float64, attributes.EndStatType)

--- a/internal/weapons/catalyst/prayer/prayer.go
+++ b/internal/weapons/catalyst/prayer/prayer.go
@@ -33,7 +33,7 @@ func (w *Weapon) stackCheck(char *character.CharWrapper, c *core.Core) func() {
 				w.updateBuff()
 			}
 		}
-		c.Tasks.Add(w.stackCheck(char, c), 240)
+		char.QueueCharTask(w.stackCheck(char, c), 240)
 	}
 }
 func (w *Weapon) updateBuff() {
@@ -62,7 +62,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	}
 	w.updateBuff()
 
-	c.Tasks.Add(w.stackCheck(char, c), 240)
+	char.QueueCharTask(w.stackCheck(char, c), 240)
 
 	c.Events.Subscribe(event.OnCharacterSwap, func(args ...interface{}) bool {
 		if c.Player.Active() != char.Index {

--- a/internal/weapons/catalyst/prototype/prototype.go
+++ b/internal/weapons/catalyst/prototype/prototype.go
@@ -34,20 +34,28 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 
+		// task for self energy gain
 		for i := 120; i <= 360; i += 120 {
-			c.Tasks.Add(func() {
+			char.QueueCharTask(func() {
 				char.AddEnergy("prototype-amber", e)
-				c.Player.Heal(player.HealInfo{
-					Caller:  char.Index,
-					Target:  -1,
-					Type:    player.HealTypePercent,
-					Message: "Prototype Amber",
-					Src:     e / 100.0,
-					Bonus:   char.Stat(attributes.Heal),
-				})
 			}, i)
 		}
-
+		// task for party heal
+		for _, x := range c.Player.Chars() {
+			this := x
+			for i := 120; i <= 360; i += 120 {
+				this.QueueCharTask(func() {
+					c.Player.Heal(player.HealInfo{
+						Caller:  char.Index,
+						Target:  this.Index,
+						Type:    player.HealTypePercent,
+						Message: "Prototype Amber",
+						Src:     e / 100.0,
+						Bonus:   char.Stat(attributes.Heal),
+					})
+				}, i)
+			}
+		}
 		return false
 	}, fmt.Sprintf("prototype-amber-%v", char.Base.Key.String()))
 

--- a/internal/weapons/catalyst/skyward/skyward.go
+++ b/internal/weapons/catalyst/skyward/skyward.go
@@ -32,7 +32,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	dmg := 0.09 + float64(r)*0.03
 	atk := 1.2 + float64(r)*0.4
 
-	icd := 0
+	const icdKey = "skyward-atlas-icd"
+	icd := 1800 // 30s * 60
 
 	c.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
 		ae := args[1].(*combat.AttackEvent)
@@ -42,7 +43,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if ae.Info.AttackTag != combat.AttackTagNormal {
 			return false
 		}
-		if icd > c.F {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
 		if c.Rand.Float64() < 0.5 {
@@ -63,9 +64,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		for i := 0; i < 6; i++ {
 			c.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(trg, 0.1, false, combat.TargettableEnemy), i*150)
 		}
-		icd = c.F + 1800
+		char.AddStatus(icdKey, icd, true)
 		return false
-	}, fmt.Sprintf("skyward-atlast-%v", char.Base.Key.String()))
+	}, fmt.Sprintf("skyward-atlas-%v", char.Base.Key.String()))
 
 	//permanent stat buff
 	m := make([]float64, attributes.EndStatType)
@@ -77,7 +78,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	m[attributes.GeoP] = dmg
 	m[attributes.DendroP] = dmg
 	char.AddStatMod(character.StatMod{
-		Base:         modifier.NewBase("skyward-atlast", -1),
+		Base:         modifier.NewBase("skyward-atlas", -1),
 		AffectedStat: attributes.NoStat,
 		Amount: func() ([]float64, bool) {
 			return m, true

--- a/internal/weapons/catalyst/solar/solar.go
+++ b/internal/weapons/catalyst/solar/solar.go
@@ -39,7 +39,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		switch atk.Info.AttackTag {
 		case combat.AttackTagElementalArt, combat.AttackTagElementalArtHold, combat.AttackTagElementalBurst:
 			char.AddAttackMod(character.AttackMod{
-				Base: modifier.NewBase("solar-na-buff", 6*60),
+				Base: modifier.NewBaseWithHitlag("solar-na-buff", 6*60),
 				Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 					switch atk.Info.AttackTag {
 					case combat.AttackTagNormal:
@@ -51,7 +51,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 
 		case combat.AttackTagNormal:
 			char.AddAttackMod(character.AttackMod{
-				Base: modifier.NewBase("solar-skill-burst-buff", 6*60),
+				Base: modifier.NewBaseWithHitlag("solar-skill-burst-buff", 6*60),
 				Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 					switch atk.Info.AttackTag {
 					case combat.AttackTagElementalArt, combat.AttackTagElementalArtHold, combat.AttackTagElementalBurst:

--- a/internal/weapons/catalyst/thrilling/thrilling.go
+++ b/internal/weapons/catalyst/thrilling/thrilling.go
@@ -30,9 +30,10 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	w := &Weapon{}
 	r := p.Refine
 
-	cd := -1
+	const icdKey = "ttds-icd"
+	icd := 1200 // 20s * 60
 	isActive := false
-	key := fmt.Sprintf("thrilling-%v", char.Base.Key.String())
+	key := fmt.Sprintf("ttds-%v", char.Base.Key.String())
 
 	c.Events.Subscribe(event.OnInitialize, func(args ...interface{}) bool {
 		isActive = c.Player.Active() == char.Index
@@ -50,14 +51,13 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 
 		if isActive && c.Player.Active() != char.Index {
 			isActive = false
-			if c.F < cd {
+			if char.StatusIsActive(icdKey) {
 				return false
 			}
-
-			cd = c.F + 60*20
+			char.AddStatus(icdKey, icd, true)
 			active := c.Player.ActiveChar()
 			active.AddStatMod(character.StatMod{
-				Base:         modifier.NewBase("thrilling tales", 600),
+				Base:         modifier.NewBaseWithHitlag("ttds", 600),
 				AffectedStat: attributes.NoStat,
 				Amount: func() ([]float64, bool) {
 					return m, true
@@ -65,7 +65,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			})
 
 			c.Log.NewEvent("ttds activated", glog.LogWeaponEvent, c.Player.Active()).
-				Write("expiry", c.F+600)
+				Write("expiry (without hitlag)", c.F+600)
 		}
 
 		return false

--- a/internal/weapons/catalyst/widsith/widsith.go
+++ b/internal/weapons/catalyst/widsith/widsith.go
@@ -44,7 +44,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	mDmg[attributes.GeoP] = dmg
 	mDmg[attributes.DendroP] = dmg
 
-	icd := -1
+	const icdKey = "widsith-icd"
+	icd := 1800 // 30s * 60
 	state := -1
 	stats := []string{"em", "dmg%", "atk%"}
 	buff := [][]float64{mEM, mDmg, mATK}
@@ -56,16 +57,16 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 
-		if c.F < icd {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
-		icd = c.F + 60*30
+		char.AddStatus(icdKey, icd, true)
 
 		state = c.Rand.Intn(3)
 
 		expiry := c.F + 60*10
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("widsith", 600),
+			Base:         modifier.NewBaseWithHitlag("widsith", 600),
 			AffectedStat: attributes.NoStat,
 			Amount: func() ([]float64, bool) {
 				//sanity check; should never happen
@@ -77,7 +78,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		})
 		c.Log.NewEvent("widsith proc'd", glog.LogWeaponEvent, char.Index).
 			Write("stat", stats[state]).
-			Write("expiring", expiry)
+			Write("expiring (without hitlag)", expiry)
 
 		return false
 	}, fmt.Sprintf("width-%v", char.Base.Key.String()))

--- a/internal/weapons/catalyst/wine/wine.go
+++ b/internal/weapons/catalyst/wine/wine.go
@@ -42,7 +42,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("wineandsong", 60*5),
+			Base:         modifier.NewBaseWithHitlag("wineandsong", 60*5),
 			AffectedStat: attributes.NoStat,
 			Amount: func() ([]float64, bool) {
 				return m, true

--- a/internal/weapons/claymore/pines/pines.go
+++ b/internal/weapons/claymore/pines/pines.go
@@ -79,7 +79,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			char.AddStatus(cdKey, 1200, true)
 			for _, char := range c.Player.Chars() {
 				char.AddStatMod(character.StatMod{
-					Base:         modifier.NewBase("pines-proc", 720),
+					Base:         modifier.NewBaseWithHitlag("pines-proc", 720),
 					AffectedStat: attributes.NoStat,
 					Amount: func() ([]float64, bool) {
 						return val, true

--- a/internal/weapons/claymore/spine/spine.go
+++ b/internal/weapons/claymore/spine/spine.go
@@ -37,7 +37,7 @@ func (w *Weapon) stackCheck() func() {
 				w.updateBuff()
 			}
 		}
-		w.c.Tasks.Add(w.stackCheck(), 240) //check again in 4s
+		w.char.QueueCharTask(w.stackCheck(), 240) //check again in 4s
 	}
 }
 func (w *Weapon) updateBuff() {
@@ -75,19 +75,20 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	w.updateBuff()
 
 	//start ticker to check for stack increase
-	c.Tasks.Add(w.stackCheck(), 240)
+	char.QueueCharTask(w.stackCheck(), 240)
 
 	//add event hook to check for dmg, subject to 1s icd
 	//TODO: taking 3% more damage not implemented
-	icd := -1
+	const icdKey = "spine-dmgtaken-icd"
+	icd := 60
 	c.Events.Subscribe(event.OnCharacterHurt, func(args ...interface{}) bool {
 		if c.Player.Active() != char.Index {
 			return false
 		}
-		if icd > c.F {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
-		icd = c.F + 60
+		char.AddStatus(icdKey, icd, true)
 		if w.stacks > 0 {
 			w.stacks--
 			w.updateBuff()

--- a/internal/weapons/spear/crescent/crescent.go
+++ b/internal/weapons/spear/crescent/crescent.go
@@ -29,15 +29,16 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	r := p.Refine
 
 	atk := .15 + float64(r)*.05
-	active := 0
+	const buffKey = "crescent-pike-buff"
+	buffDuration := 300 // 5s * 60
 
 	c.Events.Subscribe(event.OnParticleReceived, func(args ...interface{}) bool {
 		if c.Player.Active() != char.Index {
 			return false
 		}
 		c.Log.NewEvent("crescent pike active", glog.LogWeaponEvent, char.Index).
-			Write("expiry", c.F+300)
-		active = c.F + 300
+			Write("expiry (without hitlag)", c.F+300)
+		char.AddStatus(buffKey, buffDuration, true)
 
 		return false
 	}, fmt.Sprintf("cp-%v", char.Base.Key.String()))
@@ -50,8 +51,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if ae.Info.AttackTag != combat.AttackTagNormal && ae.Info.AttackTag != combat.AttackTagExtra {
 			return false
 		}
-		if c.F < active {
-			//TODO: does this proc trigger any hitlag? probably not?
+		if char.StatusIsActive(buffKey) {
 			ai := combat.AttackInfo{
 				ActorIndex: char.Index,
 				Abil:       "Crescent Pike Proc",

--- a/internal/weapons/spear/dragonspine/dragonspine.go
+++ b/internal/weapons/spear/dragonspine/dragonspine.go
@@ -32,7 +32,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	atkc := 1.6 + float64(r)*0.4
 	prob := 0.5 + float64(r)*0.1
 
-	icd := 0
+	const icdKey = "dragonspine-spear-icd"
+	icd := 600 // 10s *60
 
 	c.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
 		t, ok := args[0].(*enemy.Enemy)
@@ -43,15 +44,14 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if ae.Info.ActorIndex != char.Index {
 			return false
 		}
-		if c.F > icd {
+		if char.StatusIsActive(icdKey) {
 			return false
 		}
 		if ae.Info.AttackTag != combat.AttackTagNormal && ae.Info.AttackTag != combat.AttackTagExtra {
 			return false
 		}
 		if c.Rand.Float64() < prob {
-			icd = c.F + 600
-			//TODO: not sure if this proc triggers hitlag
+			char.AddStatus(icdKey, icd, true)
 			ai := combat.AttackInfo{
 				ActorIndex: char.Index,
 				Abil:       "Dragonspine Proc",

--- a/internal/weapons/spear/prototype/prototype.go
+++ b/internal/weapons/spear/prototype/prototype.go
@@ -48,7 +48,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			w.buff[attributes.ATKP] = atkbonus * float64(w.stacks)
 		}
 		char.AddAttackMod(character.AttackMod{
-			Base: modifier.NewBase(buffKey, 720),
+			Base: modifier.NewBaseWithHitlag(buffKey, 720),
 			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
 				if atk.Info.AttackTag != combat.AttackTagNormal && atk.Info.AttackTag != combat.AttackTagExtra {
 					return nil, false

--- a/internal/weapons/sword/amenoma/amenoma.go
+++ b/internal/weapons/sword/amenoma/amenoma.go
@@ -76,7 +76,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			return false
 		}
 		//regen energy after 2 seconds
-		c.Tasks.Add(func() {
+		char.QueueCharTask(func() {
 			char.AddEnergy("amenoma", refund*float64(count))
 		}, 120+60) //added 1 extra sec for burst animation but who knows if this is true
 

--- a/internal/weapons/sword/cinnabar/cinnnabar.go
+++ b/internal/weapons/sword/cinnabar/cinnnabar.go
@@ -54,9 +54,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		if !char.StatusIsActive(durationKey) {
 			//TODO: we're assuming icd starts after the effect
 			char.QueueCharTask(func() {
-				char.AddStatus(icdKey, 90, true) //icd lasts for 1.5s
+				char.AddStatus(icdKey, 90, false) //icd lasts for 1.5s
 			}, 6) //icd starts 6 frames after
-			char.AddStatus(durationKey, 6, true)
+			char.AddStatus(durationKey, 6, false)
 		}
 		damageAdd := (atk.Snapshot.BaseDef*(1+atk.Snapshot.Stats[attributes.DEFP]) + atk.Snapshot.Stats[attributes.DEF]) * defPer
 		atk.Info.FlatDmg += damageAdd

--- a/internal/weapons/sword/ironsting/ironsting.go
+++ b/internal/weapons/sword/ironsting/ironsting.go
@@ -60,7 +60,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		}
 		//refresh mod
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("ironsting", 360),
+			Base:         modifier.NewBaseWithHitlag("ironsting", 360),
 			AffectedStat: attributes.NoStat,
 			Amount: func() ([]float64, bool) {
 				return w.buff, true


### PR DESCRIPTION
also fixes a bug for aquasimulacra, polarstar and predator where mods were overwriting each other due to changes to mod logic in rewrite + some minor changes

missing (maybe I missed something else?):
- ~~alley hunter 4s/1s decrease timer~~
- ~~lost prayer stack gain timer~~
- ~~prototype amber heal timer~~
- wine and song stam percent mod
- ~~serpent spine stack gain & dmgtaken timer~~
- ~~calamity queller 20s duration and per 1s increase timer~~
- amenoma kageuchi 30s duration timer
- ~~amenoma kageuchi 2s post burst timer~~
