### PR TITLE
fix hutao bb second tick hitlag

### DIFF
--- a/internal/characters/hutao/skill.go
+++ b/internal/characters/hutao/skill.go
@@ -146,6 +146,6 @@ func (c *char) bbtickfunc(src int, trg *enemy.Enemy) func() {
 				Write("src", src)
 		}
 		//queue up next instance
-		c.Core.Tasks.Add(c.bbtickfunc(src, trg), 240)
+		trg.QueueEnemyTask(c.bbtickfunc(src, trg), 240)
 	}
 }


### PR DESCRIPTION
second tick used a different queue method than first tick, so when the second tick happens wasn't affected by hitlag