### PR TITLE
fix ReceiveParticle on Jean C2 / Venti C4

### DIFF
--- a/internal/characters/jean/burst.go
+++ b/internal/characters/jean/burst.go
@@ -8,8 +8,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player"
-	"github.com/genshinsim/gcsim/pkg/enemy"
-	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
 var burstFrames []int
@@ -62,19 +60,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	c.Core.Status.Add("jeanq", 600+burstStart)
 
 	if c.Base.Cons >= 4 {
-		//add debuff to all target for ??? duration
-		for _, t := range c.Core.Combat.Targets() {
-			e, ok := t.(*enemy.Enemy)
-			if !ok {
-				continue
-			}
-			//10 seconds + animation
-			e.AddResistMod(enemy.ResistMod{
-				Base:  modifier.NewBaseWithHitlag("jeanc4", 600+burstStart),
-				Ele:   attributes.Anemo,
-				Value: -0.4,
-			})
-		}
+		c.c4()
 	}
 
 	//heal on cast

--- a/internal/characters/jean/cons.go
+++ b/internal/characters/jean/cons.go
@@ -1,0 +1,69 @@
+﻿package jean
+
+import (
+	"github.com/genshinsim/gcsim/pkg/core/attributes"
+	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
+	"github.com/genshinsim/gcsim/pkg/core/player/character"
+	"github.com/genshinsim/gcsim/pkg/enemy"
+	"github.com/genshinsim/gcsim/pkg/modifier"
+)
+
+// C1:
+// Increases the pulling speed of Gale Blade after holding for more than 1s, and increases the DMG dealt by 40%.
+func (c *char) c1(snap *combat.Snapshot) {
+	//add 40% dmg
+	snap.Stats[attributes.DmgP] += .4
+	c.Core.Log.NewEvent("jean c1 adding 40% dmg", glog.LogCharacterEvent, c.Index).
+		Write("final dmg%", snap.Stats[attributes.DmgP])
+}
+
+// C2:
+// When Jean picks up an Elemental Orb/Particle, all party members have their Movement SPD and ATK SPD increased by 15% for 15s.
+func (c *char) c2() {
+	c.c2buff = make([]float64, attributes.EndStatType)
+	c.c2buff[attributes.AtkSpd] = 0.15
+	c.Core.Events.Subscribe(event.OnParticleReceived, func(args ...interface{}) bool {
+		// only trigger if Jean catches the particle
+		if c.Core.Player.Active() != c.Index {
+			return false
+		}
+		// apply C2 to all characters
+		for _, this := range c.Core.Player.Chars() {
+			this.AddStatMod(character.StatMod{
+				Base:         modifier.NewBaseWithHitlag("jean-c2", 900),
+				AffectedStat: attributes.AtkSpd,
+				Amount: func() ([]float64, bool) {
+					return c.c2buff, true
+				},
+			})
+		}
+		return false
+	}, "jean-c2")
+}
+
+// C4:
+// Within the Field created by Dandelion Breeze, all opponents have their Anemo RES decreased by 40%.
+func (c *char) c4() {
+	//add debuff to all target for ??? duration
+	for _, t := range c.Core.Combat.Targets() {
+		e, ok := t.(*enemy.Enemy)
+		if !ok {
+			continue
+		}
+		//10 seconds + animation
+		e.AddResistMod(enemy.ResistMod{
+			Base:  modifier.NewBaseWithHitlag("jean-c4", 600+burstStart),
+			Ele:   attributes.Anemo,
+			Value: -0.4,
+		})
+	}
+}
+
+// C6:
+// Incoming DMG is decreased by 35% within the Field created by Dandelion Breeze.
+// Upon leaving the Dandelion Field, this effect lasts for 3 attacks or 10s.
+func (c *char) c6() {
+	c.Core.Log.NewEvent("jean-c6 not implemented", glog.LogCharacterEvent, c.Index)
+}

--- a/internal/characters/jean/jean.go
+++ b/internal/characters/jean/jean.go
@@ -3,13 +3,9 @@ package jean
 import (
 	tmpl "github.com/genshinsim/gcsim/internal/template/character"
 	"github.com/genshinsim/gcsim/pkg/core"
-	"github.com/genshinsim/gcsim/pkg/core/attributes"
-	"github.com/genshinsim/gcsim/pkg/core/event"
-	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/core/player/character/profile"
-	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
 func init() {
@@ -36,31 +32,11 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 }
 
 func (c *char) Init() error {
-	// C2:
-	// When Jean picks up an Elemental Orb/Particle, all party members have their Movement SPD and ATK SPD increased by 15% for 15s.
 	if c.Base.Cons >= 2 {
-		c.c2buff = make([]float64, attributes.EndStatType)
-		c.c2buff[attributes.AtkSpd] = 0.15
-		c.Core.Events.Subscribe(event.OnParticleReceived, func(args ...interface{}) bool {
-			// only trigger if Jean catches the particle
-			if c.Core.Player.Active() != c.Index {
-				return false
-			}
-			// apply C2 to all characters
-			for _, this := range c.Core.Player.Chars() {
-				this.AddStatMod(character.StatMod{
-					Base:         modifier.NewBaseWithHitlag("jean-c2", 900),
-					AffectedStat: attributes.AtkSpd,
-					Amount: func() ([]float64, bool) {
-						return c.c2buff, true
-					},
-				})
-			}
-			return false
-		}, "jean-c2")
+		c.c2()
 	}
 	if c.Base.Cons >= 6 {
-		c.Core.Log.NewEvent("jean c6 not implemented", glog.LogCharacterEvent, c.Index)
+		c.c6()
 	}
 	return nil
 }

--- a/internal/characters/jean/jean.go
+++ b/internal/characters/jean/jean.go
@@ -4,6 +4,7 @@ import (
 	tmpl "github.com/genshinsim/gcsim/internal/template/character"
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
+	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
@@ -35,31 +36,31 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 }
 
 func (c *char) Init() error {
+	// C2:
+	// When Jean picks up an Elemental Orb/Particle, all party members have their Movement SPD and ATK SPD increased by 15% for 15s.
 	if c.Base.Cons >= 2 {
 		c.c2buff = make([]float64, attributes.EndStatType)
 		c.c2buff[attributes.AtkSpd] = 0.15
+		c.Core.Events.Subscribe(event.OnParticleReceived, func(args ...interface{}) bool {
+			// only trigger if Jean catches the particle
+			if c.Core.Player.Active() != c.Index {
+				return false
+			}
+			// apply C2 to all characters
+			for _, this := range c.Core.Player.Chars() {
+				this.AddStatMod(character.StatMod{
+					Base:         modifier.NewBaseWithHitlag("jean-c2", 900),
+					AffectedStat: attributes.AtkSpd,
+					Amount: func() ([]float64, bool) {
+						return c.c2buff, true
+					},
+				})
+			}
+			return false
+		}, "jean-c2")
 	}
 	if c.Base.Cons >= 6 {
 		c.Core.Log.NewEvent("jean c6 not implemented", glog.LogCharacterEvent, c.Index)
 	}
 	return nil
-}
-
-func (c *char) ReceiveParticle(p character.Particle, isActive bool, partyCount int) {
-	c.Character.ReceiveParticle(p, isActive, partyCount)
-	if c.Base.Cons >= 2 {
-		//only pop this if jean is active
-		if !isActive {
-			return
-		}
-		for _, active := range c.Core.Player.Chars() {
-			active.AddStatMod(character.StatMod{
-				Base:         modifier.NewBaseWithHitlag("jean-c2", 900),
-				AffectedStat: attributes.AtkSpd,
-				Amount: func() ([]float64, bool) {
-					return c.c2buff, true
-				},
-			})
-		}
-	}
 }

--- a/internal/characters/jean/skill.go
+++ b/internal/characters/jean/skill.go
@@ -5,7 +5,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/glog"
 )
 
 var skillFrames []int
@@ -40,10 +39,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 	snap := c.Snapshot(&ai)
 	if c.Base.Cons >= 1 && p["hold"] >= 60 {
-		//add 40% dmg
-		snap.Stats[attributes.DmgP] += .4
-		c.Core.Log.NewEvent("jean c1 adding 40% dmg", glog.LogCharacterEvent, c.Index).
-			Write("final dmg%", snap.Stats[attributes.DmgP])
+		c.c1(&snap)
 	}
 
 	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), hitmark)

--- a/internal/characters/venti/aimed.go
+++ b/internal/characters/venti/aimed.go
@@ -42,10 +42,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), .1, false, combat.TargettableEnemy), aimedHitmark, aimedHitmark+travel)
 	if c.Base.Cons >= 1 {
-		ai.Abil = "Aim (Charged) C1"
-		ai.Mult = ai.Mult / 3.0
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), .1, false, combat.TargettableEnemy), aimedHitmark, aimedHitmark+travel)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), .1, false, combat.TargettableEnemy), aimedHitmark, aimedHitmark+travel)
+		c.c1(ai, travel)
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/venti/cons.go
+++ b/internal/characters/venti/cons.go
@@ -3,13 +3,25 @@ package venti
 import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/enemy"
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
-// TODO: the airborne part isn't implemented
+// C1:
+// Fires 2 additional arrows per Aimed Shot, each dealing 33% of the original arrow's DMG.
+func (c *char) c1(ai combat.AttackInfo, travel int) {
+	ai.Abil = "Aim (Charged) C1"
+	ai.Mult = ai.Mult / 3.0
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), .1, false, combat.TargettableEnemy), aimedHitmark, aimedHitmark+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), .1, false, combat.TargettableEnemy), aimedHitmark, aimedHitmark+travel)
+}
+
+// C2:
 // Skyward Sonnet decreases opponents' Anemo RES and Physical RES by 12% for 10s.
 // Opponents launched by Skyward Sonnet suffer an additional 12% Anemo RES and Physical RES decrease while airborne.
+// TODO: the airborne part isn't implemented
 func (c *char) c2(a combat.AttackCB) {
 	if c.Base.Cons < 2 {
 		return
@@ -31,6 +43,29 @@ func (c *char) c2(a combat.AttackCB) {
 	})
 }
 
+// C4:
+// When Venti picks up an Elemental Orb or Particle, he receives a 25% Anemo DMG Bonus for 10s.
+func (c *char) c4() {
+	c.c4bonus = make([]float64, attributes.EndStatType)
+	c.c4bonus[attributes.AnemoP] = 0.25
+	c.Core.Events.Subscribe(event.OnParticleReceived, func(args ...interface{}) bool {
+		// only trigger if Venti catches the particle
+		if c.Core.Player.Active() != c.Index {
+			return false
+		}
+		// apply C4 to Venti
+		c.AddStatMod(character.StatMod{
+			Base:         modifier.NewBaseWithHitlag("venti-c4", 600),
+			AffectedStat: attributes.AnemoP,
+			Amount: func() ([]float64, bool) {
+				return c.c4bonus, true
+			},
+		})
+		return false
+	}, "venti-c4")
+}
+
+// C6:
 // Targets who take DMG from Wind's Grand Ode have their Anemo RES decreased by 20%.
 // If an Elemental Absorption occurred, then their RES towards the corresponding Element is also decreased by 20%.
 func (c *char) c6(ele attributes.Element) func(a combat.AttackCB) {

--- a/internal/characters/venti/venti.go
+++ b/internal/characters/venti/venti.go
@@ -5,6 +5,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/core/player/character/profile"
@@ -41,26 +42,26 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 }
 
 func (c *char) Init() error {
+	// C4:
+	// When Venti picks up an Elemental Orb or Particle, he receives a 25% Anemo DMG Bonus for 10s.
 	if c.Base.Cons >= 4 {
 		c.c4bonus = make([]float64, attributes.EndStatType)
 		c.c4bonus[attributes.AnemoP] = 0.25
+		c.Core.Events.Subscribe(event.OnParticleReceived, func(args ...interface{}) bool {
+			// only trigger if Venti catches the particle
+			if c.Core.Player.Active() != c.Index {
+				return false
+			}
+			// apply C4 to Venti
+			c.AddStatMod(character.StatMod{
+				Base:         modifier.NewBaseWithHitlag("venti-c4", 600),
+				AffectedStat: attributes.AnemoP,
+				Amount: func() ([]float64, bool) {
+					return c.c4bonus, true
+				},
+			})
+			return false
+		}, "venti-c4")
 	}
 	return nil
-}
-
-func (c *char) ReceiveParticle(p character.Particle, isActive bool, partyCount int) {
-	c.Character.ReceiveParticle(p, isActive, partyCount)
-	if c.Base.Cons >= 4 {
-		//only pop this if active
-		if !isActive {
-			return
-		}
-		c.AddStatMod(character.StatMod{
-			Base:         modifier.NewBaseWithHitlag("venti-c4", 600),
-			AffectedStat: attributes.AnemoP,
-			Amount: func() ([]float64, bool) {
-				return c.c4bonus, true
-			},
-		})
-	}
 }

--- a/internal/characters/venti/venti.go
+++ b/internal/characters/venti/venti.go
@@ -5,11 +5,9 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/core/player/character/profile"
-	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
 func init() {
@@ -45,23 +43,7 @@ func (c *char) Init() error {
 	// C4:
 	// When Venti picks up an Elemental Orb or Particle, he receives a 25% Anemo DMG Bonus for 10s.
 	if c.Base.Cons >= 4 {
-		c.c4bonus = make([]float64, attributes.EndStatType)
-		c.c4bonus[attributes.AnemoP] = 0.25
-		c.Core.Events.Subscribe(event.OnParticleReceived, func(args ...interface{}) bool {
-			// only trigger if Venti catches the particle
-			if c.Core.Player.Active() != c.Index {
-				return false
-			}
-			// apply C4 to Venti
-			c.AddStatMod(character.StatMod{
-				Base:         modifier.NewBaseWithHitlag("venti-c4", 600),
-				AffectedStat: attributes.AnemoP,
-				Amount: func() ([]float64, bool) {
-					return c.c4bonus, true
-				},
-			})
-			return false
-		}, "venti-c4")
+		c.c4()
 	}
 	return nil
 }


### PR DESCRIPTION
The ReceiveParticle method can't be overriden unless it is moved under `internal/template/character`, so the custom ReceiveParticle methods in Jean's/Venti's code were never called. The solution is to listen to the OnParticleReceived event instead.
also:
- moves all Jean/Venti constellations to cons.go