### PR TITLE
fix absorption checks not picking up cryo on pure frozen aura

### DIFF
--- a/internal/characters/heizou/burst.go
+++ b/internal/characters/heizou/burst.go
@@ -96,7 +96,7 @@ func (c *char) irisDmg(t combat.Target) {
 		Durability: 25,
 		Mult:       burstIris[c.TalentLvlBurst()],
 	}
-	auraPriority := []attributes.Element{attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo, attributes.Frozen}
+	auraPriority := []attributes.Element{attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo}
 	for _, ele := range auraPriority {
 		if t.AuraContains(ele) {
 			aiAbs.Element = ele

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -105,6 +105,9 @@ func (r *Reactable) AuraContains(e ...attributes.Element) bool {
 		if r.Durability[v] > ZeroDur {
 			return true
 		}
+		if v == attributes.Cryo && r.Durability[attributes.Frozen] > ZeroDur {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
fixes #638 

Currently nearly all absorption checks (except Heizou Q) don't check for Frozen aura, but they should. This is because you can potentially apply a Frozen aura without underlying Cryo or Hydro, see #638. To fix this, I adjusted the AuraContains method to also check for frozen durability when checking for cryo (srl gave me the code).

also:
- fixes heizou q absorbing frozen instead of cryo on windmuster iris 