### PR TITLE
fix albedo e icd hitlag

### DIFF
--- a/internal/characters/albedo/skill.go
+++ b/internal/characters/albedo/skill.go
@@ -84,7 +84,8 @@ func (c *char) skillHook() {
 			return false
 		}
 
-		c.AddStatus(skillICDKey, 120, true) //proc every 2 s
+		// this ICD is most likely tied to the construct, so it's not hitlag extendable
+		c.AddStatus(skillICDKey, 120, false) // proc every 2s
 
 		snap := c.skillSnapshot
 


### PR DESCRIPTION
The Albedo E proc ICD is most likely tied to the construct, so it shouldn't even be hitlag extendable by Albedo.