### PR TITLE
fix beidou q icd hitlag

### DIFF
--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -137,7 +137,8 @@ func (c *char) burstProc() {
 			Write("char", ae.Info.ActorIndex).
 			Write("attack tag", ae.Info.AttackTag)
 
-		c.AddStatus(burstICDKey, 60, true)
+		// this ICD is most likely tied to the deployable, so it's not hitlag extendable
+		c.AddStatus(burstICDKey, 60, false)
 		return false
 	}, "beidou-burst")
 }


### PR DESCRIPTION
The Beidou Q proc ICD is most likely tied to the deployable, so it shouldn't even be hitlag extendable by Beidou.