### PR TITLE
partially fix kazuha c2 and c6

### DIFF
--- a/internal/characters/kazuha/burst.go
+++ b/internal/characters/kazuha/burst.go
@@ -83,16 +83,17 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		if c.Base.Cons >= 2 {
 			c.Core.Tasks.Add(c.c2, 30) // start checking in 0.5s
 		}
+		// C6:
+		// TODO: when does the infusion kick in?
+		// -> For now, assume that it starts on Initial Hit hitlag end.
+		if c.Base.Cons >= 6 {
+			c.c6()
+		}
 	}, burstHitmark+1)
 
 	//reset skill cd
 	if c.Base.Cons >= 1 {
 		c.ResetActionCooldown(action.ActionSkill)
-	}
-
-	if c.Base.Cons >= 6 {
-		// TODO: when does the infusion kick in?
-		c.c6()
 	}
 
 	c.SetCD(action.ActionBurst, 15*60)

--- a/internal/characters/kazuha/burst.go
+++ b/internal/characters/kazuha/burst.go
@@ -5,8 +5,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/player/character"
-	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
 var burstFrames []int
@@ -16,6 +14,8 @@ const (
 	burstAnimation = 92
 	burstFirstTick = 140
 )
+
+const burstStatus = "kazuha-q"
 
 func init() {
 	burstFrames = frames.InitAbilSlice(burstAnimation)
@@ -58,13 +58,13 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.Core.Tasks.Add(c.absorbCheckQ(c.Core.F, 0, int(310/18)), 10)
 
-	//from kisa's count: ticks starts at 147, + 117 gap each roughly; 5 ticks total
-	//updated to 140 based on koli's count: https://docs.google.com/spreadsheets/d/1uEbP13O548-w_nGxFPGsf5jqj1qGD3pqFZ_AiV4w3ww/edit#gid=775340159
-
 	// make sure that this task gets executed:
-	// - after q initial hit hitlag happened
+	// - inside Q hitlag
 	// - before kazuha can get affected by any more hitlag
 	c.QueueCharTask(func() {
+		// queue up ticks
+		// from kisa's count: ticks starts at 147, + 117 gap each roughly; 5 ticks total
+		// updated to 140 based on koli's count: https://docs.google.com/spreadsheets/d/1uEbP13O548-w_nGxFPGsf5jqj1qGD3pqFZ_AiV4w3ww/edit#gid=775340159
 		for i := 0; i < 5; i++ {
 			c.Core.Tasks.Add(func() {
 				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0)
@@ -72,37 +72,18 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 					aiAbsorb.Element = c.qInfuse
 					c.Core.QueueAttackWithSnap(aiAbsorb, snapAbsorb, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0)
 				}
-			}, (burstFirstTick-(burstHitmark+5))+117*i)
+			}, (burstFirstTick-(burstHitmark+1))+117*i)
 		}
-
-		//add em to kazuha even if off-field
-		//add em to all char, but only activate if char is active
-		//The Autumn Whirlwind field created by Kazuha Slash has the following effects:
-		//• Increases Kaedehara Kazuha's own Elemental Mastery by 200 for its duration.
-		//• Increases the Elemental Mastery of characters within the field by 200.
-		//The Elemental Mastery-increasing effects of this Constellation do not stack.
+		// C2:
+		// TODO: Not sure when it lasts from and until
+		// -> For now, assume that it lasts from Initial Hit hitlag end to the last Q tick.
+		// TODO: Does it apply to Kazuha's initial hit?
+		// -> For now, assume that it doesn't.
+		c.Core.Status.Add(burstStatus, (burstFirstTick-(burstHitmark+1))+117*4)
 		if c.Base.Cons >= 2 {
-			// TODO: Lasts while Q field is on stage is ambiguous.
-			// Does it apply to Kazuha's initial hit?
-			// Not sure when it lasts from and until
-			// For consistency with how it was previously done, assume that it lasts from button press to the last tick
-			for _, char := range c.Core.Player.Chars() {
-				this := char
-				//use non hitlag since it's from the field?
-				char.AddStatMod(character.StatMod{
-					Base:         modifier.NewBase("kazuha-c2", (burstFirstTick-(burstHitmark+5))+117*5),
-					AffectedStat: attributes.EM,
-					Amount: func() ([]float64, bool) {
-						switch this.Index {
-						case c.Core.Player.Active(), c.Index:
-							return c.c2buff, true
-						}
-						return nil, false
-					},
-				})
-			}
+			c.Core.Tasks.Add(c.c2, 30) // start checking in 0.5s
 		}
-	}, burstHitmark+5)
+	}, burstHitmark+1)
 
 	//reset skill cd
 	if c.Base.Cons >= 1 {

--- a/internal/characters/kazuha/burst.go
+++ b/internal/characters/kazuha/burst.go
@@ -81,7 +81,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		// -> For now, assume that it doesn't.
 		c.Core.Status.Add(burstStatus, (burstFirstTick-(burstHitmark+1))+117*4)
 		if c.Base.Cons >= 2 {
-			c.Core.Tasks.Add(c.c2, 30) // start checking in 0.5s
+			c.qFieldSrc = c.Core.F
+			c.Core.Tasks.Add(c.c2(c.Core.F), 30) // start checking in 0.5s
 		}
 		// C6:
 		// TODO: when does the infusion kick in?

--- a/internal/characters/kazuha/cons.go
+++ b/internal/characters/kazuha/cons.go
@@ -66,10 +66,6 @@ func (c *char) c6() {
 	c.AddAttackMod(character.AttackMod{
 		Base: modifier.NewBaseWithHitlag("kazuha-c6-dmgup", 60*5), // 5s
 		Amount: func(atk *combat.AttackEvent, _ combat.Target) ([]float64, bool) {
-			// skip if not active
-			if c.Core.Player.Active() != c.Index {
-				return nil, false
-			}
 			// skip if not normal/charged/plunge
 			if atk.Info.AttackTag != combat.AttackTagNormal &&
 				atk.Info.AttackTag != combat.AttackTagExtra &&

--- a/internal/characters/kazuha/cons.go
+++ b/internal/characters/kazuha/cons.go
@@ -3,12 +3,54 @@ package kazuha
 import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
+	"github.com/genshinsim/gcsim/pkg/core/player/character"
+	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
-//After using Chihayaburu or Kazuha Slash, Kaedehara Kazuha gains an Anemo
-//Infusion for 5s. Additionally, each point of Elemental Mastery will
-//increase the DMG dealt by Kaedehara Kazuha's Normal, Charged, and Plunging
-//Attacks by 0.2%.
+// C2:
+// The Autumn Whirlwind field created by Kazuha Slash has the following effects:
+// - Increases Kaedehara Kazuha's own Elemental Mastery by 200 for its duration.
+// - Increases the Elemental Mastery of characters within the field by 200.
+// The Elemental Mastery-increasing effects of this Constellation do not stack.
+func (c *char) c2() {
+	// don't tick if Q isn't up anymore
+	if c.Core.Status.Duration(burstStatus) == 0 {
+		return
+	}
+
+	c.Core.Log.NewEvent("kazuha-c2 ticking", glog.LogCharacterEvent, -1)
+
+	// apply C2 buff to active char for 1s
+	active := c.Core.Player.ActiveChar()
+	active.AddStatMod(character.StatMod{
+		Base:         modifier.NewBaseWithHitlag("kazuha-c2", 60), // 1s
+		AffectedStat: attributes.EM,
+		Amount: func() ([]float64, bool) {
+			return c.c2buff, true
+		},
+	})
+
+	// apply C2 buff to Kazuha (even if off-field) for 1s
+	if active.Base.Key != c.Base.Key {
+		c.AddStatMod(character.StatMod{
+			Base:         modifier.NewBaseWithHitlag("kazuha-c2", 60), // 1s
+			AffectedStat: attributes.EM,
+			Amount: func() ([]float64, bool) {
+				return c.c2buff, true
+			},
+		})
+	}
+
+	// check again in 0.5s
+	c.Core.Tasks.Add(c.c2, 30)
+}
+
+// C6
+// After using Chihayaburu or Kazuha Slash, Kaedehara Kazuha gains an Anemo
+// Infusion for 5s. Additionally, each point of Elemental Mastery will
+// increase the DMG dealt by Kaedehara Kazuha's Normal, Charged, and Plunging
+// Attacks by 0.2%.
 func (c *char) c6() {
 	c.AddStatus(c6BuffKey, 60*5, true)
 	c.Core.Player.AddWeaponInfuse(

--- a/internal/characters/kazuha/cons.go
+++ b/internal/characters/kazuha/cons.go
@@ -52,7 +52,7 @@ func (c *char) c2() {
 // increase the DMG dealt by Kaedehara Kazuha's Normal, Charged, and Plunging
 // Attacks by 0.2%.
 func (c *char) c6() {
-	c.AddStatus(c6BuffKey, 60*5, true)
+	// add anemo infusion
 	c.Core.Player.AddWeaponInfuse(
 		c.Index,
 		"kazuha-c6-infusion",
@@ -61,4 +61,24 @@ func (c *char) c6() {
 		true,
 		combat.AttackTagNormal, combat.AttackTagExtra, combat.AttackTagPlunge,
 	)
+	// add em based buff
+	m := make([]float64, attributes.EndStatType)
+	c.AddAttackMod(character.AttackMod{
+		Base: modifier.NewBaseWithHitlag("kazuha-c6-dmgup", 60*5), // 5s
+		Amount: func(atk *combat.AttackEvent, _ combat.Target) ([]float64, bool) {
+			// skip if not active
+			if c.Core.Player.Active() != c.Index {
+				return nil, false
+			}
+			// skip if not normal/charged/plunge
+			if atk.Info.AttackTag != combat.AttackTagNormal &&
+				atk.Info.AttackTag != combat.AttackTagExtra &&
+				atk.Info.AttackTag != combat.AttackTagPlunge {
+				return nil, false
+			}
+			// apply buff
+			m[attributes.DmgP] = 0.002 * c.Stat(attributes.EM)
+			return m, true
+		},
+	})
 }

--- a/internal/characters/kazuha/kazuha.go
+++ b/internal/characters/kazuha/kazuha.go
@@ -18,6 +18,7 @@ type char struct {
 	*tmpl.Character
 	a1Ele               attributes.Element
 	qInfuse             attributes.Element
+	qFieldSrc           int
 	infuseCheckLocation combat.AttackPattern
 	c2buff              []float64
 }

--- a/internal/characters/kazuha/kazuha.go
+++ b/internal/characters/kazuha/kazuha.go
@@ -5,7 +5,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/core/player/character/profile"
@@ -39,8 +38,6 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	return nil
 }
 
-const c6BuffKey = "kazuha-c6"
-
 func (c *char) Init() error {
 	c.a4()
 	if c.Base.Cons >= 2 {
@@ -48,22 +45,4 @@ func (c *char) Init() error {
 		c.c2buff[attributes.EM] = 200
 	}
 	return nil
-}
-
-func (c *char) Snapshot(ai *combat.AttackInfo) combat.Snapshot {
-	ds := c.Character.Snapshot(ai)
-
-	if c.Base.Cons < 6 {
-		return ds
-	}
-	if !c.StatusIsActive(c6BuffKey) {
-		return ds
-	}
-
-	//add 0.2% dmg for every EM
-	ds.Stats[attributes.DmgP] += 0.002 * ds.Stats[attributes.EM]
-	c.Core.Log.NewEvent("c6 adding dmg", glog.LogCharacterEvent, c.Index).
-		Write("em", ds.Stats[attributes.EM]).
-		Write("final", ds.Stats[attributes.DmgP])
-	return ds
 }

--- a/internal/characters/kazuha/skill.go
+++ b/internal/characters/kazuha/skill.go
@@ -67,7 +67,10 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 	}
 	if c.Base.Cons >= 6 {
 		// TODO: when does the infusion kick in?
-		c.c6()
+		// -> For now, assume that it starts on hitmark.
+		c.Core.Tasks.Add(func() {
+			c.c6()
+		}, skillPressHitmark)
 	}
 
 	c.SetCDWithDelay(action.ActionSkill, cd, skillPressCDStart)
@@ -103,7 +106,11 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 		cd = 486
 	}
 	if c.Base.Cons >= 6 {
-		c.c6()
+		// TODO: when does the infusion kick in?
+		// -> For now, assume that it starts on hitmark.
+		c.Core.Tasks.Add(func() {
+			c.c6()
+		}, skillHoldHitmark)
 	}
 
 	c.SetCDWithDelay(action.ActionSkill, cd, skillHoldCDStart)


### PR DESCRIPTION
This PR is for improving the implementation of Kazuha's C2 and C6. Even though there are still some uncertainties, I believe this PR will make things more accurate when compared to before. However, this change spams the status log in debug with kazuha-c2 getting refreshed every 0.5s.

Kazuha C6 dmg up part didn't check for normal/charged/plunge and used a custom snapshot function, when it should be dynamic (fixes #605).

for sure:
- C2 ticks every 0.5s to apply the C2 buff to active char and Kazuha for 1s

unsure:
- Q field starts and ends when? assumption: starts on Initial Hit hitlag end and lasts until the last tick (needed for C2)
- C6 starts when? assumption: on E hitmark / Q Initial Hit hitlag end

TODO:
- [ ] update docs after merge