### PR TITLE
fix jean c4

### DIFF
--- a/internal/characters/jean/burst.go
+++ b/internal/characters/jean/burst.go
@@ -64,10 +64,6 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// handle In/Out damage on field expiry
 	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 600+burstStart)
 
-	if c.Base.Cons >= 4 {
-		c.c4()
-	}
-
 	//heal on cast
 	hpplus := snap.Stats[attributes.Heal]
 	atk := snap.BaseAtk*(1+snap.Stats[attributes.ATKP]) + snap.Stats[attributes.ATK]
@@ -97,9 +93,10 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 25,
 	}
 
-	//duration is ~10.6s, first tick start at frame 100, + 60 each
+	// duration is ~10.6s, first tick starts at frame 100, + 60 each
 	for i := 100; i <= 600+burstStart; i += 60 {
 		c.Core.Tasks.Add(func() {
+			// heal
 			// c.Core.Log.NewEvent("jean q healing", glog.LogCharacterEvent, c.Index, "+heal", hpplus, "atk", atk, "heal amount", healDot)
 			c.Core.Player.Heal(player.HealInfo{
 				Caller:  c.Index,
@@ -109,6 +106,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				Bonus:   hpplus,
 			})
 
+			// self swirl
 			ae := combat.AttackEvent{
 				Info:        selfSwirl,
 				Pattern:     combat.NewDefSingleTarget(0, combat.TargettablePlayer),
@@ -116,6 +114,11 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			}
 			c.Core.Log.NewEvent("jean self swirling", glog.LogCharacterEvent, c.Index)
 			self.ReactWithSelf(&ae)
+
+			// C4
+			if c.Base.Cons >= 4 {
+				c.c4()
+			}
 		}, i)
 	}
 

--- a/internal/characters/jean/cons.go
+++ b/internal/characters/jean/cons.go
@@ -46,15 +46,15 @@ func (c *char) c2() {
 // C4:
 // Within the Field created by Dandelion Breeze, all opponents have their Anemo RES decreased by 40%.
 func (c *char) c4() {
-	//add debuff to all target for ??? duration
+	// gets called at the same time as heal ticks (every 1s)
+	// add debuff to all targets for 1.2 s
 	for _, t := range c.Core.Combat.Targets() {
 		e, ok := t.(*enemy.Enemy)
 		if !ok {
 			continue
 		}
-		//10 seconds + animation
 		e.AddResistMod(enemy.ResistMod{
-			Base:  modifier.NewBaseWithHitlag("jean-c4", 600+burstStart),
+			Base:  modifier.NewBaseWithHitlag("jean-c4", 72), // 1.2s
 			Ele:   attributes.Anemo,
 			Value: -0.4,
 		})


### PR DESCRIPTION
Jean C4 should not apply for the entire Q duration. It should instead apply at the same rate as the healing ticks/self swirls with a duration of 1.2s per tick.