### PR TITLE
Fix double close channel error

### DIFF
--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -89,7 +89,6 @@ func RunWithConfig(cfg string, simcfg *ast.ActionList, opts Options) (result.Sum
 			count--
 		case err := <-errCh:
 			//error encountered
-			close(pool.StopCh)
 			return result.Summary{}, err
 		}
 	}


### PR DESCRIPTION
This prevents the following config from returning a call stack failure:
```
options debug=true iteration=1000 duration=104 workers=30 swap_delay=12;

diona char lvl=90/90 cons=6 talent=9,9,9;
diona add weapon="favbow" refine=3 lvl=90/90;
diona add set="noblesseoblige" count=4;
diona add stats hp=4780 atk=311 er=0.518 cryo%=0.466 cr=0.311; #main
diona add stats def%=0.124 def=39.36 hp=507.88 hp%=0.0992 atk=33.08 atk%=0.3968 er=0.3306 em=39.64 cr=0.3972 cd=0.1324;

ayato char lvl=90/90 cons=0 talent=9,9,9; 
ayato add weapon="favsword" refine=3 lvl=90/90;
ayato add set="blizzardstrayer" count=5;
ayato add stats hp=4780 atk=311 atk%=0.466 hydro%=0.466 cd=0.622; #main
ayato add stats def%=0.124 def=39.36 hp=507.88 hp%=0.0992 atk=33.08 atk%=0.1984 er=0.551 em=39.64 cr=0.3972 cd=0.1324;

venti char lvl=90/90 cons=0 talent=9,9,9; 
venti add weapon="favbow" refine=3 lvl=90/90;
venti add set="viridescentvenerer" count=5;
venti add stats hp=4780 atk=311 em=374 cr=0.311; #main
venti add stats def%=0.124 def=39.36 hp=507.88 hp%=0.0992 atk=33.08 atk%=0.5952 er=0.1102 em=118.92 cr=0.1655 cd=0.331;

ganyu char lvl=90/90 cons=0 talent=9,9,9; 
ganyu add weapon="prototypecrescent" refine=5 lvl=90/90;
ganyu add set="blizzardstrayer" count=5;
ganyu add stats hp=4780 atk=311 atk%=0.466 cryo%=0.466 cd=0.622 ; #main
ganyu add stats def%=0.124 def=39.36 hp=507.88 hp%=0.0992 atk=33.08 atk%=0.1984 er=0.1102 em=39.64 cr=0.3972 cd=0.662;

target lvl=100 pyro=0.1 dendro=0.1 hydro=0.1 electro=0.1 geo=0.1 anemo=0.1 physical=.1 cryo=.1;

energy every=10 amount=1;
active ganyu;


while 1 {
ganyu aim[weakspot=1];
diona burst;
venti skill, burst;
ayato burst[radius=2];
ganyu skill, burst[radius=2];
venti skill, attack;
ayato skill, attack:14;
diona skill[hold=1];
ganyu aim[weakpoint=1];
}
```