### PR TITLE
add missing damagemode check where target hp is accessed

### DIFF
--- a/internal/characters/ayato/cons.go
+++ b/internal/characters/ayato/cons.go
@@ -10,17 +10,19 @@ import (
 )
 
 func (c *char) c1() {
-	m := make([]float64, attributes.EndStatType)
-	m[attributes.DmgP] = 0.4
-	c.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("ayato-c1", -1),
-		Amount: func(a *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-			if a.Info.AttackTag != combat.AttackTagNormal || t.HP()/t.MaxHP() > 0.5 {
-				return nil, false
-			}
-			return m, true
-		},
-	})
+	if c.Core.Combat.DamageMode {
+		m := make([]float64, attributes.EndStatType)
+		m[attributes.DmgP] = 0.4
+		c.AddAttackMod(character.AttackMod{
+			Base: modifier.NewBase("ayato-c1", -1),
+			Amount: func(a *combat.AttackEvent, t combat.Target) ([]float64, bool) {
+				if a.Info.AttackTag != combat.AttackTagNormal || t.HP()/t.MaxHP() > 0.5 {
+					return nil, false
+				}
+				return m, true
+			},
+		})
+	}
 }
 
 func (c *char) c2() {

--- a/internal/characters/chongyun/cons.go
+++ b/internal/characters/chongyun/cons.go
@@ -39,18 +39,20 @@ func (c *char) c4() {
 }
 
 func (c *char) c6() {
-	m := make([]float64, attributes.EndStatType)
-	m[attributes.DmgP] = 0.15
-	c.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("chongyun-c6", -1),
-		Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-			if atk.Info.AttackTag != combat.AttackTagElementalBurst {
+	if c.Core.Combat.DamageMode {
+		m := make([]float64, attributes.EndStatType)
+		m[attributes.DmgP] = 0.15
+		c.AddAttackMod(character.AttackMod{
+			Base: modifier.NewBase("chongyun-c6", -1),
+			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
+				if atk.Info.AttackTag != combat.AttackTagElementalBurst {
+					return nil, false
+				}
+				if t.HP()/t.MaxHP() < c.HPCurrent/c.MaxHP() {
+					return m, true
+				}
 				return nil, false
-			}
-			if t.HP()/t.MaxHP() < c.HPCurrent/c.MaxHP() {
-				return m, true
-			}
-			return nil, false
-		},
-	})
+			},
+		})
+	}
 }

--- a/internal/characters/diluc/cons.go
+++ b/internal/characters/diluc/cons.go
@@ -9,17 +9,19 @@ import (
 )
 
 func (c *char) c1() {
-	m := make([]float64, attributes.EndStatType)
-	m[attributes.DmgP] = 0.15
-	c.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("diluc-c1", -1),
-		Amount: func(_ *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-			if t.HP()/t.MaxHP() > 0.5 {
-				return m, true
-			}
-			return nil, false
-		},
-	})
+	if c.Core.Combat.DamageMode {
+		m := make([]float64, attributes.EndStatType)
+		m[attributes.DmgP] = 0.15
+		c.AddAttackMod(character.AttackMod{
+			Base: modifier.NewBase("diluc-c1", -1),
+			Amount: func(_ *combat.AttackEvent, t combat.Target) ([]float64, bool) {
+				if t.HP()/t.MaxHP() > 0.5 {
+					return m, true
+				}
+				return nil, false
+			},
+		})
+	}
 }
 
 const (

--- a/internal/characters/eula/cons.go
+++ b/internal/characters/eula/cons.go
@@ -8,21 +8,23 @@ import (
 )
 
 func (c *char) c4() {
-	m := make([]float64, attributes.EndStatType)
-	m[attributes.DmgP] = 0.25
-	c.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("eula-c4", -1),
-		Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-			if atk.Info.Abil != "Glacial Illumination (Lightfall)" {
-				return nil, false
-			}
-			if !c.Core.Combat.DamageMode {
-				return nil, false
-			}
-			if t.HP()/t.MaxHP() >= 0.5 {
-				return nil, false
-			}
-			return m, true
-		},
-	})
+	if c.Core.Combat.DamageMode {
+		m := make([]float64, attributes.EndStatType)
+		m[attributes.DmgP] = 0.25
+		c.AddAttackMod(character.AttackMod{
+			Base: modifier.NewBase("eula-c4", -1),
+			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
+				if atk.Info.Abil != "Glacial Illumination (Lightfall)" {
+					return nil, false
+				}
+				if !c.Core.Combat.DamageMode {
+					return nil, false
+				}
+				if t.HP()/t.MaxHP() >= 0.5 {
+					return nil, false
+				}
+				return m, true
+			},
+		})
+	}
 }

--- a/internal/characters/razor/cons.go
+++ b/internal/characters/razor/cons.go
@@ -32,18 +32,20 @@ func (c *char) c1() {
 
 // Increases CRIT Rate against opponents with less than 30% HP by 10%.
 func (c *char) c2() {
-	c.c2bonus = make([]float64, attributes.EndStatType)
-	c.c2bonus[attributes.CR] = 0.1
+	if c.Core.Combat.DamageMode {
+		c.c2bonus = make([]float64, attributes.EndStatType)
+		c.c2bonus[attributes.CR] = 0.1
 
-	c.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("razor-c2", -1),
-		Amount: func(_ *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-			if t.HP()/t.MaxHP() < 0.3 {
-				return c.c2bonus, true
-			}
-			return nil, false
-		},
-	})
+		c.AddAttackMod(character.AttackMod{
+			Base: modifier.NewBase("razor-c2", -1),
+			Amount: func(_ *combat.AttackEvent, t combat.Target) ([]float64, bool) {
+				if t.HP()/t.MaxHP() < 0.3 {
+					return c.c2bonus, true
+				}
+				return nil, false
+			},
+		})
+	}
 }
 
 // When casting Claw and Thunder (Press), opponents hit will have their DEF decreased by 15% for 7s.

--- a/internal/characters/yanfei/cons.go
+++ b/internal/characters/yanfei/cons.go
@@ -11,20 +11,22 @@ import (
 // Hook for C2:
 // Increases Yan Fei's Charged Attack CRIT Rate by 20% against enemies below 50% HP.
 func (c *char) c2() {
-	m := make([]float64, attributes.EndStatType)
-	c.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBase("yanfei-c2", -1),
-		Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-			if atk.Info.AttackTag != combat.AttackTagExtra {
-				return nil, false
-			}
-			if t.HP()/t.MaxHP() >= .5 {
-				return nil, false
-			}
-			m[attributes.CR] = 0.20
-			return m, true
-		},
-	})
+	if c.Core.Combat.DamageMode {
+		m := make([]float64, attributes.EndStatType)
+		c.AddAttackMod(character.AttackMod{
+			Base: modifier.NewBase("yanfei-c2", -1),
+			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
+				if atk.Info.AttackTag != combat.AttackTagExtra {
+					return nil, false
+				}
+				if t.HP()/t.MaxHP() >= .5 {
+					return nil, false
+				}
+				m[attributes.CR] = 0.20
+				return m, true
+			},
+		})
+	}
 }
 
 // Handles C4 shield creation


### PR DESCRIPTION
only looking at char code here because artifacts/weapons are considered in #764/#762

without this check you'd get a float division of 0 by 0 which is NaN (doesn't crash the sim, but this shouldn't be a thing)