### PR TITLE
fix fischl oz conditional breaking & oz spawn from q

### DIFF
--- a/internal/characters/fischl/asc.go
+++ b/internal/characters/fischl/asc.go
@@ -16,7 +16,7 @@ func (c *char) a4() {
 		if ae.Info.ActorIndex != c.Core.Player.Active() {
 			return false
 		}
-		//do nothing if oz not on field
+		// do nothing if oz not on field
 		if c.ozActiveUntil < c.Core.F {
 			return false
 		}

--- a/internal/characters/fischl/burst.go
+++ b/internal/characters/fischl/burst.go
@@ -75,8 +75,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		if done {
 			return
 		}
-		// c.Core.Tasks.Add can't handle tasks with 0 delay, so delay by 1f
-		c.queueOz("Burst", 1)
+		c.queueOz("Burst", 0)
 		done = true
 	}
 

--- a/internal/characters/fischl/burst.go
+++ b/internal/characters/fischl/burst.go
@@ -20,13 +20,6 @@ func init() {
 }
 
 func (c *char) Burst(p map[string]int) action.ActionInfo {
-	//set on field oz to be this one
-	//TODO: Oz should spawn and snapshot when the burst animation is cancelled
-	//for now, the common burst->swap combo (24 frames) is used.
-	c.Core.Tasks.Add(func() {
-		c.queueOz("Burst")
-	}, 24)
-
 	//initial damage; part of the burst tag
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -73,10 +66,25 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	c.ConsumeEnergy(6)
 	c.SetCD(action.ActionBurst, 15*60)
 
+	// set oz to active at the start of the action
+	c.ozActive = true
+	// spawn oz at the end of animation
+	// need bool for checking that CanQueueAfter and OnRemoved don't both spawn oz
+	done := false
+	burstOzSpawn := func() {
+		if done {
+			return
+		}
+		// c.Core.Tasks.Add can't handle tasks with 0 delay, so delay by 1f
+		c.queueOz("Burst", 1)
+		done = true
+	}
+
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(burstFrames),
 		AnimationLength: burstFrames[action.InvalidAction],
 		CanQueueAfter:   burstFrames[action.ActionSwap], // earliest cancel
 		State:           action.BurstState,
+		OnRemoved:       func(next action.AnimationState) { burstOzSpawn() },
 	}
 }

--- a/internal/characters/fischl/fischl.go
+++ b/internal/characters/fischl/fischl.go
@@ -17,8 +17,9 @@ type char struct {
 	*tmpl.Character
 	//field use for calculating oz damage
 	ozSnapshot    combat.AttackEvent
-	ozSource      int //keep tracks of source of oz aka resets
-	ozActiveUntil int
+	ozSource      int  // keep tracks of source of oz aka resets
+	ozActive      bool // purely used for gscl conditional purposes
+	ozActiveUntil int  // used for oz ticks, a4, c1 and c6
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
@@ -29,6 +30,7 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.NormalHitNum = normalHitNum
 
 	c.ozSource = -1
+	c.ozActive = false
 	c.ozActiveUntil = -1
 
 	w.Character = &c
@@ -47,10 +49,7 @@ func (c *char) Init() error {
 func (c *char) Condition(fields []string) (any, error) {
 	switch fields[0] {
 	case "oz":
-		if c.ozActiveUntil <= c.Core.F {
-			return false, nil
-		}
-		return (c.ozActiveUntil - c.Core.F), nil
+		return c.ozActive, nil
 	case "oz-source":
 		return c.ozSource, nil
 	default:

--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func (c *char) Skill(p map[string]int) action.ActionInfo {
-	//always trigger electro no ICD on initial summon
+	// always trigger electro no ICD on initial summon
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Oz (Summon)",
@@ -38,29 +38,17 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	if c.Base.Cons >= 2 {
 		ai.Mult += 2
 	}
-	//hitmark is 5 frames after oz spawns
+	// hitmark is 5 frames after oz spawns
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), skillOzSpawn, skillOzSpawn+5)
-
-	c.Core.Tasks.Add(func() {
-		// activate status at CanQueueAfter because adding the status later than that breaks things
-		// if you do E -> D then everything's fine, but any other cancel breaks the conditional
-		// example:
-		// "fischl skill" followed by a ".status.fischloz == 0" check
-		dur := 600 + skillOzSpawn - skillFrames[action.ActionDash]
-		if c.Base.Cons == 6 {
-			dur += 120
-		}
-		c.Core.Status.Add("fischloz", dur)
-	}, skillFrames[action.ActionDash])
-
-	//set on field oz to be this one
-	c.Core.Tasks.Add(func() {
-		c.queueOz("Skill")
-	}, skillOzSpawn)
 
 	// CD Delay is 18 frames, but things break if Delay > CanQueueAfter
 	// so we add 18 to the duration instead. this probably mess up CDR stuff
 	c.SetCD(action.ActionSkill, 25*60+18) //18 frames until CD starts
+
+	// set oz to active at the start of the action
+	c.ozActive = true
+	// set on field oz to be this one
+	c.queueOz("Skill", skillOzSpawn)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(skillFrames),
@@ -70,43 +58,48 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 }
 
-func (c *char) queueOz(src string) {
+func (c *char) queueOz(src string, ozSpawn int) {
+	// calculate oz duration
 	dur := 600
 	if c.Base.Cons == 6 {
 		dur += 120
 	}
-	c.ozActiveUntil = c.Core.F + dur
-	c.ozSource = c.Core.F
-
-	ai := combat.AttackInfo{
-		ActorIndex: c.Index,
-		Abil:       fmt.Sprintf("Oz (%v)", src),
-		AttackTag:  combat.AttackTagElementalArt,
-		ICDTag:     combat.ICDTagElementalArt,
-		ICDGroup:   combat.ICDGroupFischl,
-		Element:    attributes.Electro,
-		Durability: 25,
-		Mult:       birdAtk[c.TalentLvlSkill()],
-	}
-	snap := c.Snapshot(&ai)
-	c.ozSnapshot = combat.AttackEvent{
-		Info:        ai,
-		Snapshot:    snap,
-		Pattern:     combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget, combat.TargettableEnemy),
-		SourceFrame: c.Core.F,
-	}
-	c.Core.Tasks.Add(c.ozTick(c.Core.F), 60)
-	c.Core.Log.NewEvent("Oz activated", glog.LogCharacterEvent, c.Index).
-		Write("source", src).
-		Write("expected end", c.ozActiveUntil).
-		Write("next expected tick", c.Core.F+60)
+	c.Core.Tasks.Add(func() {
+		// setup variables for tracking oz
+		c.ozSource = c.Core.F
+		c.ozActiveUntil = c.Core.F + dur
+		// queue up oz removal at the end of the duration for gcsl conditional
+		c.Core.Tasks.Add(c.removeOz(c.Core.F), dur)
+		ai := combat.AttackInfo{
+			ActorIndex: c.Index,
+			Abil:       fmt.Sprintf("Oz (%v)", src),
+			AttackTag:  combat.AttackTagElementalArt,
+			ICDTag:     combat.ICDTagElementalArt,
+			ICDGroup:   combat.ICDGroupFischl,
+			Element:    attributes.Electro,
+			Durability: 25,
+			Mult:       birdAtk[c.TalentLvlSkill()],
+		}
+		snap := c.Snapshot(&ai)
+		c.ozSnapshot = combat.AttackEvent{
+			Info:        ai,
+			Snapshot:    snap,
+			Pattern:     combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget, combat.TargettableEnemy),
+			SourceFrame: c.Core.F,
+		}
+		c.Core.Tasks.Add(c.ozTick(c.Core.F), 60)
+		c.Core.Log.NewEvent("Oz activated", glog.LogCharacterEvent, c.Index).
+			Write("source", src).
+			Write("expected end", c.ozActiveUntil).
+			Write("next expected tick", c.Core.F+60)
+	}, ozSpawn)
 }
 
 func (c *char) ozTick(src int) func() {
 	return func() {
 		c.Core.Log.NewEvent("Oz checking for tick", glog.LogCharacterEvent, c.Index).
 			Write("src", src)
-		//if src != ozSource then this is no longer the same oz, do nothing
+		// if src != ozSource then this is no longer the same oz, do nothing
 		if src != c.ozSource {
 			return
 		}
@@ -114,19 +107,33 @@ func (c *char) ozTick(src int) func() {
 			Write("next expected tick", c.Core.F+60).
 			Write("active", c.ozActiveUntil).
 			Write("src", src)
-		//trigger damage
+		// trigger damage
 		ae := c.ozSnapshot
 		c.Core.QueueAttackEvent(&ae, 0)
-		//check for orb
-		//Particle check is 67% for particle, from datamine
-		//TODO: this delay used to be 120
+		// check for orb
+		// Particle check is 67% for particle, from datamine
+		// TODO: this delay used to be 120
 		if c.Core.Rand.Float64() < .67 {
 			c.Core.QueueParticle("fischl", 1, attributes.Electro, c.ParticleDelay)
 		}
 
-		//queue up next hit only if next hit oz is still active
+		// queue up next hit only if next hit oz is still active
 		if c.Core.F+60 <= c.ozActiveUntil {
 			c.Core.Tasks.Add(c.ozTick(src), 60)
 		}
+	}
+}
+
+func (c *char) removeOz(src int) func() {
+	return func() {
+		// if src != ozSource then this is no longer the same oz, do nothing
+		if c.ozSource != src {
+			c.Core.Log.NewEvent("Oz not removed, src changed", glog.LogCharacterEvent, c.Index).
+				Write("src", src)
+			return
+		}
+		c.Core.Log.NewEvent("Oz removed", glog.LogCharacterEvent, c.Index).
+			Write("src", src)
+		c.ozActive = false
 	}
 }

--- a/pkg/core/task/task.go
+++ b/pkg/core/task/task.go
@@ -28,6 +28,10 @@ func (c *Handler) Run() {
 }
 
 func (c *Handler) Add(f func(), delay int) {
+	if delay == 0 {
+		f()
+		return
+	}
 	c.tasks[*c.f+delay] = append(c.tasks[*c.f+delay], task{
 		f:      f,
 		source: *c.f,


### PR DESCRIPTION
fixes #608 

- replaces the fischloz status with a bool
- changes the semantics of .fischl.oz: instead of specifiying the amount of frames it's still active for, now it instead just specifies whether oz is "active" or not (similar to .albedo.elevator) 
- fixes Oz spawn on Q: Oz should spawn at the end of animation, but he always spawned at the earliest cancel before.

core:
- fixes 0 delay tasks not being executed right away in normal task queue

live:
https://gcsim.app/v3/viewer/share/a6808c9b-140f-44d1-821f-d7ca3f10898a
after fix:
https://gcsim.app/v3/viewer/share/d9f39e3b-8d0d-4206-82db-29d82b29e8ba

config:
```
options swap_delay=12 debug=true iteration=100 duration=100 workers=30;

fischl char lvl=90/90 cons=0 talent=9,9,9;
fischl add weapon="seasonedhuntersbow" refine=5 lvl=90/90;

# ----
target lvl=100 resist=0.1;

# ----
active fischl;
while 1 {
	fischl skill;
	if .fischl.oz == 0 {
		print("shouldn't happen");
	}
}
```

TODO:
- [ ] update docs after merge