### PR TITLE
replace current energy syntax with old syntax

### DIFF
--- a/pkg/gcs/ast/parse_test.go
+++ b/pkg/gcs/ast/parse_test.go
@@ -194,7 +194,7 @@ xiangling add stats def%=0.124 def=39.36 hp=507.88 hp%=0.0992 atk=33.08 atk%=0.0
 
 active raiden;
 
-energy every=10 amount=1;
+energy every interval=480,720 amount=1;
 `
 
 func TestCharAdd(t *testing.T) {

--- a/pkg/gcs/ast/parser.go
+++ b/pkg/gcs/ast/parser.go
@@ -45,9 +45,12 @@ type ActionList struct {
 }
 
 type EnergySettings struct {
-	Every  float64
-	Amount int
-	Mean   float64
+	Active         bool
+	Once           bool //how often
+	Start          int
+	End            int
+	Amount         int
+	LastEnergyDrop int
 }
 
 type SimulatorSettings struct {

--- a/pkg/simulation/config.go
+++ b/pkg/simulation/config.go
@@ -5,11 +5,12 @@ import (
 )
 
 type EnergyEvent struct {
-	Active    bool
-	Once      bool //how often
-	Start     int
-	End       int
-	Particles int
+	Active         bool
+	Once           bool //how often
+	Start          int
+	End            int
+	Particles      int
+	LastEnergyDrop int
 }
 
 type HurtEvent struct {

--- a/pkg/simulation/example/main.go
+++ b/pkg/simulation/example/main.go
@@ -12,7 +12,7 @@ import (
 
 const cfg = `target lvl=100 resist=0.1;
 options swap_delay=12 debug=true iteration=1000 duration=109 workers=30 mode=sl;
-energy every=8 amount=1;
+energy every interval=480,720 amount=1;
 
 #Chars Builds
 

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -41,9 +41,6 @@ func (s *Simulation) Run() (Result, error) {
 	go s.queuer.Run()
 	defer close(s.continueEval)
 
-	//queue up enery tasks
-	s.SetupRandEnergyDrop()
-
 	for !stop {
 		err = s.AdvanceFrame()
 		if err != nil {
@@ -78,6 +75,7 @@ func (s *Simulation) Run() (Result, error) {
 func (s *Simulation) AdvanceFrame() error {
 	s.C.F++
 	s.C.Tick()
+	s.handleEnergy()
 	s.collectStats()
 	err := s.queueAndExec()
 	if err != nil {


### PR DESCRIPTION
tagging #699
- `energy every=10 amount=1;` is no longer valid
- `energy once interval=300 amount=1;` and `energy every interval=480,720 amount=1;` are valid (like pre-rewrite)