### PR TITLE
fix shenhe c4

### DIFF
--- a/internal/characters/shenhe/cons.go
+++ b/internal/characters/shenhe/cons.go
@@ -4,6 +4,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
@@ -49,4 +50,21 @@ func (c *char) c4() {
 		c.DeleteStatus(c4BuffKey)
 		return false
 	}, "shenhe-c4-reset")
+}
+
+// C4 stacks are gained after the damage has been dealt and not before
+// https://library.keqingmains.com/evidence/characters/cryo/shenhe?q=shenhe#c4-insight
+func (c *char) c4cb() combat.AttackCBFunc {
+	return func(a combat.AttackCB) {
+		//reset stacks to zero if all expired
+		if !c.StatusIsActive(c4BuffKey) {
+			c.c4count = 0
+		}
+		if c.c4count < 50 {
+			c.c4count++
+			c.Core.Log.NewEvent("shenhe-c4 stack gained", glog.LogCharacterEvent, c.Index).
+				Write("stacks", c.c4count)
+		}
+		c.AddStatus(c4BuffKey, 3600, true) // 60 s
+	}
 }

--- a/internal/characters/shenhe/cons.go
+++ b/internal/characters/shenhe/cons.go
@@ -54,17 +54,15 @@ func (c *char) c4() {
 
 // C4 stacks are gained after the damage has been dealt and not before
 // https://library.keqingmains.com/evidence/characters/cryo/shenhe?q=shenhe#c4-insight
-func (c *char) c4cb() combat.AttackCBFunc {
-	return func(a combat.AttackCB) {
-		//reset stacks to zero if all expired
-		if !c.StatusIsActive(c4BuffKey) {
-			c.c4count = 0
-		}
-		if c.c4count < 50 {
-			c.c4count++
-			c.Core.Log.NewEvent("shenhe-c4 stack gained", glog.LogCharacterEvent, c.Index).
-				Write("stacks", c.c4count)
-		}
-		c.AddStatus(c4BuffKey, 3600, true) // 60 s
+func (c *char) c4cb(a combat.AttackCB) {
+	//reset stacks to zero if all expired
+	if !c.StatusIsActive(c4BuffKey) {
+		c.c4count = 0
 	}
+	if c.c4count < 50 {
+		c.c4count++
+		c.Core.Log.NewEvent("shenhe-c4 stack gained", glog.LogCharacterEvent, c.Index).
+			Write("stacks", c.c4count)
+	}
+	c.AddStatus(c4BuffKey, 3600, true) // 60 s
 }

--- a/internal/characters/shenhe/cons.go
+++ b/internal/characters/shenhe/cons.go
@@ -3,6 +3,7 @@ package shenhe
 import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
@@ -34,8 +35,18 @@ func (c *char) c4() {
 			}
 			c.c4bonus[attributes.DmgP] += 0.05 * float64(c.c4count)
 			c.c4count = 0
-			c.DeleteStatus(c4BuffKey)
 			return c.c4bonus, true
 		},
 	})
+	c.Core.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
+		atk := args[1].(*combat.AttackEvent)
+		if c.Core.Player.Active() != c.Index {
+			return false
+		}
+		if atk.Info.AttackTag != combat.AttackTagElementalArt && atk.Info.AttackTag != combat.AttackTagElementalArtHold {
+			return false
+		}
+		c.DeleteStatus(c4BuffKey)
+		return false
+	}, "shenhe-c4-reset")
 }

--- a/internal/characters/shenhe/cons.go
+++ b/internal/characters/shenhe/cons.go
@@ -44,6 +44,9 @@ func (c *char) c4() {
 		if c.Core.Player.Active() != c.Index {
 			return false
 		}
+		if atk.Info.ActorIndex != c.Index {
+			return false
+		}
 		if atk.Info.AttackTag != combat.AttackTagElementalArt && atk.Info.AttackTag != combat.AttackTagElementalArtHold {
 			return false
 		}

--- a/internal/characters/shenhe/skill.go
+++ b/internal/characters/shenhe/skill.go
@@ -193,20 +193,7 @@ func (c *char) quillDamageMod() {
 
 			atk.Info.FlatDmg += amt
 			if c.Base.Cons >= 4 {
-				// C4 stacks are gained after the damage has been dealt and not before
-				// https://library.keqingmains.com/evidence/characters/cryo/shenhe?q=shenhe#c4-insight
-				c.Core.Tasks.Add(func() {
-					//reset stacks to zero if all expired
-					if !c.StatusIsActive(c4BuffKey) {
-						c.c4count = 0
-					}
-					if c.c4count < 50 {
-						c.c4count++
-						c.Core.Log.NewEvent("shenhe-c4 stack gained", glog.LogCharacterEvent, c.Index).
-							Write("stacks", c.c4count)
-					}
-					c.AddStatus(c4BuffKey, 3600, true) // 60 s
-				}, 1)
+				atk.Callbacks = append(atk.Callbacks, c.c4cb())
 			}
 		}
 

--- a/internal/characters/shenhe/skill.go
+++ b/internal/characters/shenhe/skill.go
@@ -193,7 +193,7 @@ func (c *char) quillDamageMod() {
 
 			atk.Info.FlatDmg += amt
 			if c.Base.Cons >= 4 {
-				atk.Callbacks = append(atk.Callbacks, c.c4cb())
+				atk.Callbacks = append(atk.Callbacks, c.c4cb)
 			}
 		}
 

--- a/internal/characters/shenhe/skill.go
+++ b/internal/characters/shenhe/skill.go
@@ -193,14 +193,20 @@ func (c *char) quillDamageMod() {
 
 			atk.Info.FlatDmg += amt
 			if c.Base.Cons >= 4 {
-				//reset stacks to zero if all expired
-				if !c.StatusIsActive(c4BuffKey) {
-					c.c4count = 0
-				}
-				if c.c4count < 50 {
-					c.c4count++
-				}
-				c.AddStatus(c4BuffKey, 3600, true) // 60 s
+				// C4 stacks are gained after the damage has been dealt and not before
+				// https://library.keqingmains.com/evidence/characters/cryo/shenhe?q=shenhe#c4-insight
+				c.Core.Tasks.Add(func() {
+					//reset stacks to zero if all expired
+					if !c.StatusIsActive(c4BuffKey) {
+						c.c4count = 0
+					}
+					if c.c4count < 50 {
+						c.c4count++
+						c.Core.Log.NewEvent("shenhe-c4 stack gained", glog.LogCharacterEvent, c.Index).
+							Write("stacks", c.c4count)
+					}
+					c.AddStatus(c4BuffKey, 3600, true) // 60 s
+				}, 1)
 			}
 		}
 


### PR DESCRIPTION
closes #788 

- mods should not delete other mods in the Amount function because it breaks the for loop over all mods (delete the c4 buff status on damage instead)
- c4 stacks should be gained after damage and not directly on quill consumption
- add logging for c4 stack gain