### PR TITLE
implement kaeya c2, rewrite kaeya q ticks

### DIFF
--- a/internal/characters/kaeya/burst.go
+++ b/internal/characters/kaeya/burst.go
@@ -55,7 +55,6 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	c.burstTickSrc = c.Core.F
 	for i := 0; i < count; i++ {
 		// each icicle will start at i * offset (i.e. 0, 40, 80 OR 0, 30, 60, 90)
-		// assume each icicle will last for 8 seconds
 		// assume damage dealt every 120 (since only hitting at the front)
 		// on icicle collision, it'll trigger an aoe dmg with radius 2
 		// in effect, every target gets hit every time icicles rotate around

--- a/internal/characters/kaeya/cons.go
+++ b/internal/characters/kaeya/cons.go
@@ -4,12 +4,15 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/core/player/shield"
 	"github.com/genshinsim/gcsim/pkg/enemy"
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
+// C1:
+// The CRIT Rate of Kaeya's Normal and Charge Attacks against opponents affected by Cryo is increased by 15%.
 func (c *char) c1() {
 	m := make([]float64, attributes.EndStatType)
 	c.AddAttackMod(character.AttackMod{
@@ -31,8 +34,46 @@ func (c *char) c1() {
 	})
 }
 
-//TOOD: c2 missing
+// C2:
+// Every time Glacial Waltz defeats an opponent during its duration, its duration is increased by 2.5s, up to a maximum of 15s.
+func (c *char) c2() {
+	c.Core.Events.Subscribe(event.OnTargetDied, func(args ...interface{}) bool {
+		_, ok := args[0].(*enemy.Enemy)
+		// ignore if not an enemy
+		if !ok {
+			return false
+		}
+		// ignore if burst isn't up
+		if c.Core.Status.Duration(burstKey) == 0 {
+			return false
+		}
+		// ignore if extension limit reached
+		if c.c2ProcCount > 2 {
+			return false
+		}
+		// burst duration steps
+		// 8s
+		// 10.5s (+2.5s from previous)
+		// 13s (+2.5s from previous)
+		// 15s (+2.0s from previous because extension is capped to 15s)
+		extension := 150
+		if c.c2ProcCount == 2 {
+			extension = 120
+		}
+		c.Core.Status.Extend(burstKey, extension)
+		c.c2ProcCount++
+		c.Core.Log.NewEvent("kaeya-c2 proc'd", glog.LogCharacterEvent, c.Index).
+			Write("c2ProcCount", c.c2ProcCount).
+			Write("extension", extension)
+		return false
+	}, "kaeya-c2")
+}
 
+// C4:
+// Triggers automatically when Kaeya's HP falls below 20%:
+// Creates a shield that absorbs damage equal to 30% of Kaeya's Max HP. Lasts for 20s.
+// This shield absorbs Cryo DMG with 250% efficiency.
+// Can only occur once every 60s.
 func (c *char) c4() {
 	c.Core.Events.Subscribe(event.OnCharacterHurt, func(_ ...interface{}) bool {
 		if c.Core.F < c.c4icd && c.c4icd != 0 {

--- a/internal/characters/kaeya/kaeya.go
+++ b/internal/characters/kaeya/kaeya.go
@@ -14,7 +14,9 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	c4icd int
+	burstTickSrc int
+	c2ProcCount  int
+	c4icd        int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
@@ -23,6 +25,7 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 60
 	c.NormalHitNum = normalHitNum
+	c.c2ProcCount = 0
 
 	w.Character = &c
 
@@ -32,6 +35,9 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 func (c *char) Init() error {
 	if c.Base.Cons > 0 {
 		c.c1()
+	}
+	if c.Base.Cons >= 2 {
+		c.c2()
 	}
 	if c.Base.Cons >= 4 {
 		c.c4()


### PR DESCRIPTION
fixes #766 

tested here (turn on status and character logs): https://gcsim.app/v3/viewer/share/dd07faf3-ea73-4c56-b13b-fb0539917776

- implements kaeya c2
- adds a status for kaeya's burst ("kaeya-q")
- rewrite kaeya q tick logic to depend on burst status duration instead of the burst duration being hardcoded 8s
- adds a few comments for Kaeya's constellations

TODO:
- [ ] update docs after merge