### PR TITLE
bugfixes - hutao c6, kuki e & c6, noelle, heal logs, superconduct

### DIFF
--- a/internal/characters/hutao/cons.go
+++ b/internal/characters/hutao/cons.go
@@ -17,22 +17,33 @@ func (c *char) c6() {
 	c.c6buff[attributes.CR] = 1
 	// check for C6 proc on hurt
 	c.Core.Events.Subscribe(event.OnCharacterHurt, func(_ ...interface{}) bool {
-		c.checkc6()
+		c.checkc6(false)
 		return false
 	}, "hutao-c6")
 	// check for C6 proc every 2s regardless of hurt
-	c.QueueCharTask(c.checkc6, 120)
+	c.QueueCharTask(func() {
+		c.checkc6(true)
+	}, 120)
 }
 
-func (c *char) checkc6() {
+func (c *char) checkc6(check1HP bool) {
+	// check for C6 proc every 2s regardless of hurt and c6 icd
+	c.QueueCharTask(func() {
+		c.checkc6(true)
+	}, 120)
+	// check if c6 is on icd
 	if c.StatusIsActive(c6ICDKey) {
 		return
 	}
-	//check if hp less than 25%
+	// check if hp less than 25%
 	if c.HPCurrent/c.MaxHP() > .25 {
 		return
 	}
-	//if dead, revive back to 1 hp
+	// check if hp is less than 2 for the 2s check
+	if check1HP && c.HPCurrent >= 2 {
+		return
+	}
+	// if dead, revive back to 1 hp
 	if c.HPCurrent <= -1 {
 		c.HPCurrent = 1
 	}
@@ -47,8 +58,6 @@ func (c *char) checkc6() {
 	})
 
 	c.AddStatus(c6ICDKey, 3600, false)
-	// check for C6 proc every 2s regardless of hurt
-	c.QueueCharTask(c.checkc6, 120)
 }
 
 //Upon defeating an enemy affected by a Blood Blossom that Hu Tao applied

--- a/internal/characters/hutao/cons.go
+++ b/internal/characters/hutao/cons.go
@@ -15,10 +15,13 @@ const (
 func (c *char) c6() {
 	c.c6buff = make([]float64, attributes.EndStatType)
 	c.c6buff[attributes.CR] = 1
+	// check for C6 proc on hurt
 	c.Core.Events.Subscribe(event.OnCharacterHurt, func(_ ...interface{}) bool {
 		c.checkc6()
 		return false
 	}, "hutao-c6")
+	// check for C6 proc every 2s regardless of hurt
+	c.QueueCharTask(c.checkc6, 120)
 }
 
 func (c *char) checkc6() {
@@ -43,7 +46,9 @@ func (c *char) checkc6() {
 		},
 	})
 
-	c.AddStatus(c6ICDKey, 3600, true)
+	c.AddStatus(c6ICDKey, 3600, false)
+	// check for C6 proc every 2s regardless of hurt
+	c.QueueCharTask(c.checkc6, 120)
 }
 
 //Upon defeating an enemy affected by a Blood Blossom that Hu Tao applied

--- a/internal/characters/hutao/skill.go
+++ b/internal/characters/hutao/skill.go
@@ -54,9 +54,6 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Abil:       "Paramita Papilio",
 		Amount:     .30 * c.HPCurrent,
 	})
-	if c.Base.Cons >= 6 {
-		c.checkc6()
-	}
 
 	//trigger 0 damage attack; matters because this breaks freeze
 	ai := combat.AttackInfo{

--- a/internal/characters/kuki/cons.go
+++ b/internal/characters/kuki/cons.go
@@ -76,7 +76,7 @@ func (c *char) c6() {
 		if c.HPCurrent <= -1 {
 			c.HPCurrent = 1
 		}
-		c.AddStatus(c6IcdKey, 3600, true) // 60s * 60
+		c.AddStatus(c6IcdKey, 3600, false) // 60s * 60
 
 		//increase EM by 150 for 15s
 		c.AddStatMod(character.StatMod{

--- a/internal/characters/kuki/skill.go
+++ b/internal/characters/kuki/skill.go
@@ -24,15 +24,16 @@ func init() {
 func (c *char) Skill(p map[string]int) action.ActionInfo {
 	// only drain HP when above 20% HP
 	if c.HPCurrent/c.MaxHP() > 0.2 {
+		hpdrain := 0.3 * c.HPCurrent
+		// The HP consumption from using this skill can only bring her to 20% HP.
+		if 0.7*c.HPCurrent/c.MaxHP() <= 0.2 {
+			hpdrain = (c.HPCurrent/c.MaxHP() - 0.2) * c.MaxHP()
+		}
 		c.Core.Player.Drain(player.DrainInfo{
 			ActorIndex: c.Index,
 			Abil:       "Sanctifying Ring",
-			Amount:     .30 * c.HPCurrent,
+			Amount:     hpdrain,
 		})
-		// The HP consumption from using this skill can only bring her to 20% HP.
-		if c.HPCurrent/c.MaxHP() < 0.2 {
-			c.HPCurrent = 0.2 * c.MaxHP()
-		}
 	}
 
 	ai := combat.AttackInfo{

--- a/internal/characters/kuki/skill.go
+++ b/internal/characters/kuki/skill.go
@@ -11,7 +11,10 @@ import (
 
 var skillFrames []int
 
-const skillHitmark = 11 // Initial Hit
+const (
+	skillHitmark     = 11 // Initial Hit
+	hpDrainThreshold = 0.2
+)
 
 func init() {
 	skillFrames = frames.InitAbilSlice(52) // E -> Q
@@ -23,11 +26,11 @@ func init() {
 
 func (c *char) Skill(p map[string]int) action.ActionInfo {
 	// only drain HP when above 20% HP
-	if c.HPCurrent/c.MaxHP() > 0.2 {
+	if c.HPCurrent/c.MaxHP() > hpDrainThreshold {
 		hpdrain := 0.3 * c.HPCurrent
 		// The HP consumption from using this skill can only bring her to 20% HP.
-		if 0.7*c.HPCurrent/c.MaxHP() <= 0.2 {
-			hpdrain = (c.HPCurrent/c.MaxHP() - 0.2) * c.MaxHP()
+		if (c.HPCurrent-hpdrain)/c.MaxHP() <= hpDrainThreshold {
+			hpdrain = c.HPCurrent - hpDrainThreshold*c.MaxHP()
 		}
 		c.Core.Player.Drain(player.DrainInfo{
 			ActorIndex: c.Index,

--- a/internal/characters/kuki/skill.go
+++ b/internal/characters/kuki/skill.go
@@ -22,11 +22,17 @@ func init() {
 }
 
 func (c *char) Skill(p map[string]int) action.ActionInfo {
-	//remove some hp
-	if 0.7*(c.HPCurrent/c.MaxHP()) > 0.2 {
-		c.HPCurrent = 0.7 * c.HPCurrent
-	} else if (c.HPCurrent / c.MaxHP()) > 0.2 { //check if below 20%
-		c.HPCurrent = 0.2 * c.MaxHP()
+	// only drain HP when above 20% HP
+	if c.HPCurrent/c.MaxHP() > 0.2 {
+		c.Core.Player.Drain(player.DrainInfo{
+			ActorIndex: c.Index,
+			Abil:       "Sanctifying Ring",
+			Amount:     .30 * c.HPCurrent,
+		})
+		// The HP consumption from using this skill can only bring her to 20% HP.
+		if c.HPCurrent/c.MaxHP() < 0.2 {
+			c.HPCurrent = 0.2 * c.MaxHP()
+		}
 	}
 
 	ai := combat.AttackInfo{
@@ -61,7 +67,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			Write("next expected tick", c.Core.F+90)
 	}, 23)
 
-	c.SetCDWithDelay(action.ActionSkill, 90, 7)
+	c.SetCDWithDelay(action.ActionSkill, 15*60, 7)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(skillFrames),

--- a/internal/characters/noelle/asc.go
+++ b/internal/characters/noelle/asc.go
@@ -18,7 +18,7 @@ func (c *char) a1() {
 		if active.HPCurrent/active.MaxHP() >= 0.3 {
 			return false
 		}
-		c.AddStatus(a1IcdKey, 3600, true)
+		c.AddStatus(a1IcdKey, 3600, false)
 		ai := combat.AttackInfo{
 			ActorIndex: c.Index,
 			Abil:       "A1 Shield",

--- a/internal/characters/noelle/attack.go
+++ b/internal/characters/noelle/attack.go
@@ -7,8 +7,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/player"
-	"github.com/genshinsim/gcsim/pkg/core/player/shield"
 )
 
 var attackFrames [][]int
@@ -49,35 +47,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			ai.HitlagHaltFrames = 0.1 * 60
 		}
 	}
-	done := false
-	cb := func(a combat.AttackCB) {
-		if done {
-			return
-		}
-		//check for healing
-		if c.Core.Player.Shields.Get(shield.ShieldNoelleSkill) != nil {
-			var prob float64
-			if c.Base.Cons >= 1 && c.StatModIsActive(burstBuffKey) {
-				prob = 1
-			} else {
-				prob = healChance[c.TalentLvlSkill()]
-			}
-			if c.Core.Rand.Float64() < prob {
-				//heal target
-				x := a.AttackEvent.Snapshot.BaseDef*(1+a.AttackEvent.Snapshot.Stats[attributes.DEFP]) + a.AttackEvent.Snapshot.Stats[attributes.DEF]
-				heal := shieldHeal[c.TalentLvlSkill()]*x + shieldHealFlat[c.TalentLvlSkill()]
-				c.Core.Player.Heal(player.HealInfo{
-					Caller:  c.Index,
-					Target:  -1,
-					Message: "Breastplate (Attack)",
-					Src:     heal,
-					Bonus:   a.AttackEvent.Snapshot.Stats[attributes.Heal],
-				})
-				done = true
-			}
-		}
-
-	}
+	// TODO: don't forget this when implementing her CA
+	c.healDone = false
+	cb := c.skillHealCB
 	// need char queue because of potential hitlag from C4
 	c.QueueCharTask(func() {
 		c.Core.QueueAttack(

--- a/internal/characters/noelle/attack.go
+++ b/internal/characters/noelle/attack.go
@@ -48,8 +48,8 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		}
 	}
 	// TODO: don't forget this when implementing her CA
-	c.healDone = false
-	cb := c.skillHealCB
+	done := false
+	cb := c.skillHealCB(done)
 	// need char queue because of potential hitlag from C4
 	c.QueueCharTask(func() {
 		c.Core.QueueAttack(

--- a/internal/characters/noelle/burst.go
+++ b/internal/characters/noelle/burst.go
@@ -46,7 +46,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	dur := 900 + burstStart //default duration
 	if c.Base.Cons >= 6 {
 		// https://library.keqingmains.com/evidence/characters/geo/noelle#noelle-c6-burst-extension
-		//check extension
+		// check extension
 		ext, ok := p["extend"]
 		if ok {
 			if ext < 0 {
@@ -56,7 +56,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				ext = 10
 			}
 		} else {
-			ext = 10 //to maintain prev default behaviour of full extension
+			ext = 10 // to maintain prev default behaviour of full extension
 		}
 
 		dur += ext * 60
@@ -77,6 +77,10 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Write("atk added", c.burstBuff[attributes.ATK]).
 		Write("mult", mult)
 
+	// every Q hit can proc her heal
+	c.healDone = false
+	cb := c.skillHealCB
+
 	ai := combat.AttackInfo{
 		ActorIndex:         c.Index,
 		Abil:               "Sweeping Time (Burst)",
@@ -91,15 +95,20 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   0.15 * 60,
 		CanBeDefenseHalted: true,
 	}
+	// Burst part
 	c.QueueCharTask(func() {
 		c.Core.QueueAttack(
 			ai,
 			combat.NewCircleHit(c.Core.Combat.Player(), 6.5, false, combat.TargettableEnemy),
 			0,
 			0,
+			cb,
 		)
+		// reset healDone so the Skill part can proc her heal
+		c.healDone = false
 	}, 24)
 
+	// Skill part
 	// Burst and Skill part of Q have the same hitlag values
 	c.QueueCharTask(func() {
 		ai.Abil = "Sweeping Time (Skill)"
@@ -109,6 +118,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			combat.NewCircleHit(c.Core.Combat.Player(), 4.5, false, combat.TargettableEnemy),
 			0,
 			0,
+			cb,
 		)
 	}, 65)
 

--- a/internal/characters/noelle/burst.go
+++ b/internal/characters/noelle/burst.go
@@ -78,8 +78,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Write("mult", mult)
 
 	// every Q hit can proc her heal
-	c.healDone = false
-	cb := c.skillHealCB
+	done := false
+	cb := c.skillHealCB(done)
 
 	ai := combat.AttackInfo{
 		ActorIndex:         c.Index,
@@ -105,7 +105,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			cb,
 		)
 		// reset healDone so the Skill part can proc her heal
-		c.healDone = false
+		done = false
+		cb = c.skillHealCB(done)
 	}, 24)
 
 	// Skill part

--- a/internal/characters/noelle/noelle.go
+++ b/internal/characters/noelle/noelle.go
@@ -19,6 +19,7 @@ type char struct {
 	shieldTimer int
 	a4Counter   int
 	burstBuff   []float64
+	healDone    bool
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {

--- a/internal/characters/noelle/shield.go
+++ b/internal/characters/noelle/shield.go
@@ -28,6 +28,12 @@ func (n *noelleShield) OnExpire() {
 	}
 }
 
+func (n *noelleShield) OnOverwrite() {
+	if n.c.Base.Cons >= 4 {
+		n.c.explodeShield()
+	}
+}
+
 func (n *noelleShield) OnDamage(dmg float64, ele attributes.Element, bonus float64) (float64, bool) {
 	taken, ok := n.Tmpl.OnDamage(dmg, ele, bonus)
 	if !ok && n.c.Base.Cons >= 4 {

--- a/internal/characters/noelle/skill.go
+++ b/internal/characters/noelle/skill.go
@@ -5,12 +5,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/player"
 	"github.com/genshinsim/gcsim/pkg/core/player/shield"
 )
 
 var skillFrames []int
 
-const skillHitmark = 15
+const skillHitmark = 14
 
 func init() {
 	skillFrames = frames.InitAbilSlice(78)
@@ -48,6 +49,10 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	c.a4Counter = 0
 
+	// initial E hit can proc her heal
+	c.healDone = false
+	cb := c.skillHealCB
+
 	// center on player
 	// use char queue for this just to be safe in case of C4
 	c.QueueCharTask(func() {
@@ -56,6 +61,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
 			0,
 			0,
+			cb,
 		)
 	}, skillHitmark)
 
@@ -79,13 +85,41 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 }
 
+func (c *char) skillHealCB(atk combat.AttackCB) {
+	if c.healDone {
+		return
+	}
+	// check for healing
+	if c.Core.Player.Shields.Get(shield.ShieldNoelleSkill) != nil {
+		var prob float64
+		if c.Base.Cons >= 1 && c.StatModIsActive(burstBuffKey) {
+			prob = 1
+		} else {
+			prob = healChance[c.TalentLvlSkill()]
+		}
+		if c.Core.Rand.Float64() < prob {
+			// heal target
+			x := atk.AttackEvent.Snapshot.BaseDef*(1+atk.AttackEvent.Snapshot.Stats[attributes.DEFP]) + atk.AttackEvent.Snapshot.Stats[attributes.DEF]
+			heal := shieldHeal[c.TalentLvlSkill()]*x + shieldHealFlat[c.TalentLvlSkill()]
+			c.Core.Player.Heal(player.HealInfo{
+				Caller:  c.Index,
+				Target:  -1,
+				Message: "Breastplate (Attack)",
+				Src:     heal,
+				Bonus:   atk.AttackEvent.Snapshot.Stats[attributes.Heal],
+			})
+			c.healDone = true
+		}
+	}
+}
+
 // C4:
 // When Breastplate's duration expires or it is destroyed by DMG, it will deal 400% ATK of Geo DMG to surrounding opponents.
 func (c *char) explodeShield() {
 	c.shieldTimer = 0
 	ai := combat.AttackInfo{
 		ActorIndex:         c.Index,
-		Abil:               "Breastplate",
+		Abil:               "Breastplate (C4)",
 		AttackTag:          combat.AttackTagElementalArt,
 		ICDTag:             combat.ICDTagElementalArt,
 		ICDGroup:           combat.ICDGroupDefault,

--- a/pkg/core/player/heal.go
+++ b/pkg/core/player/heal.go
@@ -43,14 +43,14 @@ func (h *Handler) HealIndex(info *HealInfo, index int) {
 	}
 	heal := hp * bonus
 
-	prevhp := c.Base.HP
+	prevhp := c.HPCurrent
 	c.ModifyHP(heal)
 
 	h.Log.NewEvent(info.Message, glog.LogHealEvent, index).
 		Write("previous", prevhp).
 		Write("amount", hp).
 		Write("bonus", bonus).
-		Write("current", c.Base.HP).
+		Write("current", c.HPCurrent).
 		Write("max_hp", c.MaxHP())
 
 	h.Events.Emit(event.OnHeal, info.Caller, index, heal)

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -214,6 +214,7 @@ func SetupMisc(c *core.Core) {
 		//add shred
 		t.AddResistMod(enemy.ResistMod{
 			Base:  modifier.NewBaseWithHitlag("superconduct-phys-shred", 12*60),
+			Ele:   attributes.Physical,
 			Value: -0.4,
 		})
 		return false


### PR DESCRIPTION
Hu Tao:
- hutao c6 should check every 2s regardless of hurt and c6 icd but should only proc when at < 2 hp for this check only
- removed unnecessary c6Check call on hutao e (hutao e hp drain calls Drain(), which emits OnCharacterHurt to trigger c6Check anyways)

Kuki:
- adjusted kuki e to use Drain() in order to be able to proc HPDown related effects (like her C6)
- fix incorrect kuki e cd (was 90f = 1.5s instead 15s, my fault)

Noelle:
- fix noelle e cast not having a chance to heal
- fix noelle e hitmark being after E -> E/Q cancel
- fix noelle q cast hit 1 and 2 not having a chance to heal
- fix noelle c4 not proccing if e is recast while shield is still up 

core:
- heal logs used c.Base.HP instead of c.HPCurrent, so the logs were showing wrong previous / current hp values
- fixes superconduct not working because of missing Ele

hitlag related:
- hutao c6 icd should not be affected by hitlag
- kuki c6 icd should not be affected by hitlag
- noelle a1 icd should not be affected by hitlag