### PR TITLE
fix husk artifact initial stacking

### DIFF
--- a/internal/artifacts/huskofopulentdreams/huskofopulentdreams.go
+++ b/internal/artifacts/huskofopulentdreams/huskofopulentdreams.go
@@ -38,7 +38,7 @@ func (s *Set) SetIndex(idx int) { s.Index = idx }
 // Initiate off-field stacking if off-field at start of the sim
 func (s *Set) Init() error {
 	if s.core.Player.Active() != s.char.Index {
-		s.core.Tasks.Add(s.gainStackOfffield(s.core.F), 1)
+		s.core.Tasks.Add(s.gainStackOfffield(s.lastSwap), 180)
 	}
 	return nil
 }


### PR DESCRIPTION
4pc husk would not start its passive stack function until after a
character swapped in. We fix this by correcting the call used in Init().

https://gcsim.app/v3/viewer/share/6a597796-2d08-4138-bb6f-a24eb8a0e43b