### PR TITLE
add HPP to yelan optimizer substats

### DIFF
--- a/pkg/optimization/details.go
+++ b/pkg/optimization/details.go
@@ -474,6 +474,7 @@ func NewSubstatOptimizerDetails(cfg string, simopt simulator.Options, simcfg *as
 		keys.Yunjin:  {attributes.DEFP},
 		keys.Noelle:  {attributes.DEFP},
 		keys.Gorou:   {attributes.DEFP},
+		keys.Yelan:   {attributes.HPP},
 	}
 
 	// Final output array that holds [character][substat_count]


### PR DESCRIPTION
Yelan scales off HP%, which deviates from the default optimizer
heuristic.