### PR TITLE
fix charge attacks not consuming stamina

### DIFF
--- a/pkg/core/player/exec.go
+++ b/pkg/core/player/exec.go
@@ -49,7 +49,7 @@ func (p *Handler) Exec(t action.Action, k keys.Char, param map[string]int) error
 	}
 
 	stamCheck := func(t action.Action, param map[string]int) (float64, bool) {
-		req := p.StamPercentMod(t) * char.ActionStam(t, param)
+		req := (1 + p.StamPercentMod(t)) * char.ActionStam(t, param)
 		return req, p.Stam >= req
 	}
 

--- a/pkg/core/player/exec.go
+++ b/pkg/core/player/exec.go
@@ -49,7 +49,7 @@ func (p *Handler) Exec(t action.Action, k keys.Char, param map[string]int) error
 	}
 
 	stamCheck := func(t action.Action, param map[string]int) (float64, bool) {
-		req := (1 + p.StamPercentMod(t)) * char.ActionStam(t, param)
+		req := p.AbilStamCost(char.Index, t, param)
 		return req, p.Stam >= req
 	}
 


### PR DESCRIPTION
The StamPercentMod() function sums the total modifiers, but does not
output a multiplication-friendly value. We need to add it to `1` to
modify a stamina requirement.

https://gcsim.app/v3/viewer/share/d258ec21-aedd-4dd5-8238-c1d0124ed0f1