### PR TITLE
end sim in damage mode when no more action

### DIFF
--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -57,6 +57,8 @@ func (s *Simulation) Run() (Result, error) {
 					break
 				}
 			}
+			//TODO: this may result in unexpected behaviour? but beats infinite loop when out of actions
+			stop = stop || s.noMoreActions
 		} else {
 			stop = s.C.F == f
 		}


### PR DESCRIPTION
Need to think about this still because with this change, any damage mode sim will end immediately after the last action's animation ends. This means that any queued tasks (including the one from last action) will not execute