### PR TITLE
fix wrong particle mechanics

### DIFF
--- a/internal/characters/ayaka/skill.go
+++ b/internal/characters/ayaka/skill.go
@@ -45,7 +45,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4, false, combat.TargettableEnemy), 0, skillHitmark)
 
-	//2 or 3 1:1 ratio
+	// 4 or 5, 1:1 ratio
 	var count float64 = 4
 	if c.Core.Rand.Float64() < 0.5 {
 		count = 5

--- a/internal/characters/kaeya/skill.go
+++ b/internal/characters/kaeya/skill.go
@@ -61,7 +61,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), 0, skillHitmark, cb)
 
-	//2 or 3 1:1 ratio
+	// 2 or 3, 1:2 ratio
 	var count float64 = 2
 	if c.Core.Rand.Float64() < 0.67 {
 		count = 3

--- a/internal/characters/lisa/skill.go
+++ b/internal/characters/lisa/skill.go
@@ -70,10 +70,6 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget, combat.TargettableEnemy), 0, skillPressHitmark, cb)
 
-	if c.Core.Rand.Float64() < 0.5 {
-		c.Core.QueueParticle("lisa", 1, attributes.Electro, skillPressHitmark+c.ParticleDelay)
-	}
-
 	c.SetCDWithDelay(action.ActionSkill, 60, 17)
 
 	return action.ActionInfo{

--- a/internal/characters/thoma/skill.go
+++ b/internal/characters/thoma/skill.go
@@ -38,9 +38,9 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	// snapshot unknown
 	// snap := c.Snapshot(&ai)
 
-	// 3 or 4, 3:2 ratio
+	// 3 or 4, 1:1 ratio
 	var count float64 = 3
-	if c.Core.Rand.Float64() < 0.4 {
+	if c.Core.Rand.Float64() < 0.5 {
 		count = 4
 	}
 	c.Core.QueueParticle("thoma", count, attributes.Pyro, skillHitmark+c.ParticleDelay)

--- a/internal/characters/venti/skill.go
+++ b/internal/characters/venti/skill.go
@@ -48,10 +48,12 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	cd := 360
 	cdstart := 21
 	hitmark := 51
+	var count float64 = 3
 	if p["hold"] != 0 {
 		cd = 900
 		cdstart = 34
 		hitmark = 74
+		count = 4
 		ai.Mult = skillHold[c.TalentLvlSkill()]
 
 		act = action.ActionInfo{
@@ -63,7 +65,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4, false, combat.TargettableEnemy), 0, hitmark, c.c2)
-	c.Core.QueueParticle("venti", 3, attributes.Anemo, hitmark+c.ParticleDelay)
+	c.Core.QueueParticle("venti", count, attributes.Anemo, hitmark+c.ParticleDelay)
 
 	c.SetCDWithDelay(action.ActionSkill, cd, cdstart)
 

--- a/internal/characters/yaemiko/kitsune.go
+++ b/internal/characters/yaemiko/kitsune.go
@@ -136,13 +136,14 @@ func (c *char) kitsuneTick(totem *kitsune) func() {
 			if c.Core.F < c.totemParticleICD {
 				return
 			}
-			c.totemParticleICD = c.Core.F + 176
+			// 2.5s icd
+			c.totemParticleICD = c.Core.F + 150
 			//TODO: this used to be 30?
 			c.Core.QueueParticle("yaemiko", 1, attributes.Electro, c.ParticleDelay)
 		}
 
 		c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.RandomEnemyTarget(), combat.TargettableEnemy), 1, 1, cb)
-		// tick per 2.5 seconds
+		// tick per ~2.9s seconds
 		c.Core.Tasks.Add(c.kitsuneTick(totem), 176)
 	}
 }

--- a/internal/characters/yoimiya/attack.go
+++ b/internal/characters/yoimiya/attack.go
@@ -53,13 +53,8 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		if c.Core.F < c.lastPart {
 			return
 		}
-		c.lastPart = c.Core.F + 300 // every 5 second
-
-		var count float64 = 2
-		if c.Core.Rand.Float64() < 0.5 {
-			count = 3
-		}
-		c.Core.QueueParticle("yoimiya", count, attributes.Pyro, c.ParticleDelay)
+		c.Core.QueueParticle("yoimiya", 1, attributes.Pyro, c.ParticleDelay) // 1 particle
+		c.lastPart = c.Core.F + 120                                          // every 2s
 	}
 
 	var totalMV float64

--- a/internal/characters/yunjin/skill.go
+++ b/internal/characters/yunjin/skill.go
@@ -74,8 +74,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		ai.HitlagHaltFrames = 0.06 * 60
 		c.Core.QueueParticle("yunjin", 2, attributes.Geo, c.ParticleDelay+hitDelay)
 	case 1:
-		// Currently believed to be 2-3 particles with the ratio 3:2
-		if c.Core.Rand.Float64() < .6 {
+		// 2 or 3, 1:1 ratio
+		if c.Core.Rand.Float64() < 0.5 {
 			c.Core.QueueParticle("yunjin", 2, attributes.Geo, c.ParticleDelay+hitDelay)
 		} else {
 			c.Core.QueueParticle("yunjin", 3, attributes.Geo, c.ParticleDelay+hitDelay)


### PR DESCRIPTION
- adjust ayaka and kaeya comments
- lisa tap e should not be generating any particles
- thoma e should be generating 3.5 particles on average and not 3.4
- venti hold e should be generating 4 particles instead of 3
- yaemiko e particle icd should be 2.5s instead of ~2.9s
- yoimiya particles in e state should be 1 particle on 2s icd instead of 2.5 particles on 5s icd (looks like hutao copy paste)
- yunjin hold e lv. 1 should be generating 2.5 particles instead of 2.4