### PR TITLE
fix ayato a1 and a4

### DIFF
--- a/internal/characters/ayato/asc.go
+++ b/internal/characters/ayato/asc.go
@@ -5,6 +5,10 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/glog"
 )
 
+// A1:
+// Kamisato Art: Kyouka has the following properties:
+// - After it is used, Kamisato Ayato will gain 2 Namisen stacks. (handled here)
+// - When the water illusion explodes, Ayato will gain a Namisen effect equal to the maximum number of stacks possible. (handled in skill.go)
 func (c *char) a1() {
 	//TODO: this used to be PostSkill; check if working correctly still
 	c.Core.Events.Subscribe(event.OnSkill, func(_ ...interface{}) bool {
@@ -17,21 +21,15 @@ func (c *char) a1() {
 	}, "ayato-a1")
 }
 
+// A4:
+// If Kamisato Ayato is not on the field and his Energy is less than 40, he will regenerate 2 Energy for himself every second.
 func (c *char) a4() {
-	c.Core.Tasks.Add(c.a4task, 60)
-}
-
-func (c *char) a4task() {
 	if c.Core.Player.Active() == c.Index {
-		return
-	}
-	if c.StatusIsActive(a4ICDKey) {
 		return
 	}
 	if c.Energy >= 40 {
 		return
 	}
 	c.AddEnergy("ayato-a4", 2)
-	c.Core.Tasks.Add(c.a4task, 60)
-	c.AddStatus(a4ICDKey, 60, true)
+	c.Core.Tasks.Add(c.a4, 60)
 }

--- a/internal/characters/ayato/ayato.go
+++ b/internal/characters/ayato/ayato.go
@@ -24,7 +24,6 @@ type char struct {
 }
 
 const (
-	a4ICDKey       = "ayato-a4-icd"
 	particleICDKey = "ayato-particle-icd"
 )
 

--- a/internal/characters/ayato/skill.go
+++ b/internal/characters/ayato/skill.go
@@ -47,15 +47,11 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			Write("stacks", c.stacks)
 	}, delay)
 
-	//start skill buff after animation
-	//TODO: make sure this isn't causing bugs?
-	c.QueueCharTask(func() {
-		c.AddStatus(skillBuffKey, 6*60, true)
-	}, skillStart)
+	//start skill buff on cast
+	c.AddStatus(skillBuffKey, 6*60, true)
 	//figure out atk buff
 	if c.Base.Cons >= 6 {
 		c.c6ready = true
-
 	}
 	c.SetCD(action.ActionSkill, 12*60)
 


### PR DESCRIPTION
fixes #854 

a1: 
- illusion explosion should set namisen stacks to max because of a1 instead of just doing +1

a4: 
- fix missing check on swap that checks whether previous char was ayato, having no check messes with a4
- remove a4task in favor of just queing up a4 itself
- remove a4Icd because the icd is just the task delay, also this delay should not be affected by hitlag

e:
- the buff should start on ability start and not later (max possible slashes should be 16 and not 17)