### PR TITLE
fix sucrose burst doing extra absorb damage

### DIFF
--- a/internal/characters/sucrose/burst.go
+++ b/internal/characters/sucrose/burst.go
@@ -71,8 +71,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	for i := 137; i <= duration+5; i += 113 {
 		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy), i, cb)
 
+		firstHit := i == 137
 		c.Core.Tasks.Add(func() {
-			if c.qInfused != attributes.NoElement {
+			if !firstHit && c.qInfused != attributes.NoElement {
 				aiAbs.Element = c.qInfused
 				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy), 0)
 			}

--- a/internal/characters/sucrose/burst.go
+++ b/internal/characters/sucrose/burst.go
@@ -71,14 +71,15 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	for i := 137; i <= duration+5; i += 113 {
 		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy), i, cb)
 
-		firstHit := i == 137
-		c.Core.Tasks.Add(func() {
-			if !firstHit && c.qInfused != attributes.NoElement {
-				aiAbs.Element = c.qInfused
-				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy), 0)
-			}
-			//check if infused
-		}, i)
+		if i != 137 { // is not first hit
+			c.Core.Tasks.Add(func() {
+				if c.qInfused != attributes.NoElement {
+					aiAbs.Element = c.qInfused
+					c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy), 0)
+				}
+				//check if infused
+			}, i)
+		}
 	}
 
 	c.Core.Tasks.Add(c.absorbCheck(c.Core.F, 0, int(duration/18)), 136)


### PR DESCRIPTION
Sucrose elemental ticks only apply after the first hit, making a total of 3 elemental hits rather than 4. Issue was made in discord: https://discord.com/channels/845087716541595668/869210750596554772/1013250508636573746

https://gcsim.app/v3/viewer/share/f9f1e2dd-e7fb-4ab6-a777-6946aa143862