### PR TITLE
get duration for char mod

### DIFF
--- a/pkg/core/player/character/mods.go
+++ b/pkg/core/player/character/mods.go
@@ -152,7 +152,7 @@ func (c *CharWrapper) StatusExpiry(key string) int { return c.getModExpiry(key) 
 // Duration.
 
 func (c *CharWrapper) getModDuration(key string) int {
-	m, _ := modifier.FindCheckExpiry(&c.mods, key, *c.f)
+	m := modifier.Find(&c.mods, key)
 	if m == -1 {
 		return 0
 	}

--- a/pkg/core/player/character/mods.go
+++ b/pkg/core/player/character/mods.go
@@ -149,6 +149,20 @@ func (c *CharWrapper) getModExpiry(key string) int {
 }
 func (c *CharWrapper) StatusExpiry(key string) int { return c.getModExpiry(key) }
 
+// Duration.
+
+func (c *CharWrapper) getModDuration(key string) int {
+	m, _ := modifier.FindCheckExpiry(&c.mods, key, *c.f)
+	if m == -1 {
+		return 0
+	}
+	if c.mods[m].Expiry() > *c.f {
+		return c.mods[m].Expiry() - *c.f
+	}
+	return 0
+}
+func (c *CharWrapper) StatusDuration(key string) int { return c.getModDuration(key) }
+
 // Extend.
 
 //extendMod returns true if mod is active and is extended


### PR DESCRIPTION
might be useful in case we: 
- decide to gut c.Core.Status
- want to give the user the option for conditionals off of char status duration

this returns 0 for char mods/status with expiry -1 (it doesn't really make sense to do conditionals off of that anyways? also Duration() in c.Core.Status doesn't check for that)

c.Core.Status has a Duration() function, char status/mod doesn't