### PR TITLE
fix wasm sim not computing sim duration correctly

### DIFF
--- a/app/src/Components/Select/OmniSelect.tsx
+++ b/app/src/Components/Select/OmniSelect.tsx
@@ -115,7 +115,6 @@ export function GenerateDefaultCharacters(): Item[] {
     if (TravelerCheck(k)) {
       extra = ` (${ele})`;
     }
-    console.log(k, extra);
     return {
       key: k,
       text:

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -168,11 +168,6 @@ func collect(this js.Value, args []js.Value) interface{} {
 
 	r.Iterations = cfg.Settings.Iterations
 	r.ActiveChar = cfg.InitialChar.String()
-	if cfg.Settings.DamageMode {
-		r.Duration.Mean = float64(cfg.Settings.Duration)
-		r.Duration.Min = float64(cfg.Settings.Duration)
-		r.Duration.Max = float64(cfg.Settings.Duration)
-	}
 
 	r.NumTargets = len(cfg.Targets)
 	r.CharDetails = in[0].CharDetails

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -153,11 +153,6 @@ func aggregateResults(in []simulation.Result, cfg *ast.ActionList) result.Summar
 
 	r.Iterations = cfg.Settings.Iterations
 	r.ActiveChar = cfg.InitialChar.String()
-	// if cfg.DamageMode {
-	// 	r.Duration.Mean = float64(cfg.Settings.Duration)
-	// 	r.Duration.Min = float64(cfg.Settings.Duration)
-	// 	r.Duration.Max = float64(cfg.Settings.Duration)
-	// }
 
 	r.NumTargets = len(cfg.Targets)
 	r.CharDetails = in[0].CharDetails


### PR DESCRIPTION
This fixes an issue where people running TTK sims on web/wasm would have their sim stats set to the default duration value (0 for most cases).

EDIT: this fixes #840.