### PR TITLE
fix itto c6 and replace old hitbox methods

### DIFF
--- a/internal/characters/itto/charge.go
+++ b/internal/characters/itto/charge.go
@@ -175,8 +175,12 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 
 	prevSlash := c.slashState
 	stacks := c.Tags[strStackKey]
-	c6Proc := c.Base.Cons >= 6 && c.Core.Rand.Float64() < 0.5
-	c.slashState = prevSlash.Next(stacks, c6Proc)
+	if !c.c6CarryOver {
+		c.c6Proc = c.Base.Cons >= 6 && c.Core.Rand.Float64() < 0.5
+	} else {
+		c.c6CarryOver = false
+	}
+	c.slashState = prevSlash.Next(stacks, c.c6Proc)
 
 	// figure out how many frames we need to skip
 	windup := c.windupFrames(prevSlash, c.slashState)
@@ -212,10 +216,15 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	}
 	// TODO: hitmark is not getting adjusted for atk speed
 	// TODO: Does Itto CA snapshot at the start of CA? (rn assuming he does)
-	c.Core.QueueAttack(ai, combat.NewDefCircHit(r, false, combat.TargettableEnemy), 0, chargeHitmarks[c.slashState]-windup)
+	c.Core.QueueAttack(
+		ai,
+		combat.NewCircleHit(c.Core.Combat.Player(), r, false, combat.TargettableEnemy),
+		0,
+		chargeHitmarks[c.slashState]-windup,
+	)
 
 	// C6: has a 50% chance to not consume stacks of Superlative Superstrength.
-	if !c6Proc {
+	if !c.c6Proc {
 		c.addStrStack("charge", -1)
 	}
 
@@ -229,7 +238,9 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Frames: func(next action.Action) int {
 			f := chargeFrames[curSlash][next]
 			// handle CA1/CA2 -> CAF frames
-			if next == action.ActionCharge && curSlash.Next(c.Tags[strStackKey], c6Proc) == FinalSlash {
+			c.c6Proc = c.Base.Cons >= 6 && c.Core.Rand.Float64() < 0.5
+			c.c6CarryOver = true
+			if next == action.ActionCharge && curSlash.Next(c.Tags[strStackKey], c.c6Proc) == FinalSlash {
 				switch curSlash {
 				case LeftSlash: // CA1 -> CAF
 					f = 60

--- a/internal/characters/itto/charge.go
+++ b/internal/characters/itto/charge.go
@@ -175,11 +175,6 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 
 	prevSlash := c.slashState
 	stacks := c.Tags[strStackKey]
-	if !c.c6CarryOver {
-		c.c6Proc = c.Base.Cons >= 6 && c.Core.Rand.Float64() < 0.5
-	} else {
-		c.c6CarryOver = false
-	}
 	c.slashState = prevSlash.Next(stacks, c.c6Proc)
 
 	// figure out how many frames we need to skip
@@ -233,14 +228,14 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 
 	// required for the frames func
 	curSlash := c.slashState
+	c.c6Proc = c.Base.Cons >= 6 && c.Core.Rand.Float64() < 0.5
+	nextSlash := curSlash.Next(c.Tags[strStackKey], c.c6Proc)
 
 	return action.ActionInfo{
 		Frames: func(next action.Action) int {
 			f := chargeFrames[curSlash][next]
 			// handle CA1/CA2 -> CAF frames
-			c.c6Proc = c.Base.Cons >= 6 && c.Core.Rand.Float64() < 0.5
-			c.c6CarryOver = true
-			if next == action.ActionCharge && curSlash.Next(c.Tags[strStackKey], c.c6Proc) == FinalSlash {
+			if next == action.ActionCharge && nextSlash == FinalSlash {
 				switch curSlash {
 				case LeftSlash: // CA1 -> CAF
 					f = 60

--- a/internal/characters/itto/itto.go
+++ b/internal/characters/itto/itto.go
@@ -33,7 +33,6 @@ type char struct {
 	c2GeoMemberCount   int
 	applyC4            bool
 	c6Proc             bool
-	c6CarryOver        bool
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
@@ -70,6 +69,7 @@ func (c *char) Init() error {
 	}
 	if c.Base.Cons >= 6 {
 		c.c6()
+		c.c6Proc = c.Base.Cons >= 6 && c.Core.Rand.Float64() < 0.5 // setup c6 proc
 	}
 
 	return nil

--- a/internal/characters/itto/itto.go
+++ b/internal/characters/itto/itto.go
@@ -32,6 +32,8 @@ type char struct {
 	burstCastF         int
 	c2GeoMemberCount   int
 	applyC4            bool
+	c6Proc             bool
+	c6CarryOver        bool
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {

--- a/internal/characters/itto/skill.go
+++ b/internal/characters/itto/skill.go
@@ -72,7 +72,13 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	// Assume that Ushi always hits for a stack
 	c.Core.Tasks.Add(func() { c.addStrStack("ushi-hit", 1) }, skillRelease+travel)
-	c.Core.QueueAttack(ai, combat.NewDefCircHit(1, false, combat.TargettableEnemy), skillRelease, skillRelease+travel, cb)
+	c.Core.QueueAttack(
+		ai,
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1, false, combat.TargettableEnemy),
+		skillRelease,
+		skillRelease+travel,
+		cb,
+	)
 
 	// Cooldown
 	c.SetCDWithDelay(action.ActionSkill, 600, skillRelease) // cd starts on release


### PR DESCRIPTION
previous C6 fix didn't recalculate the C6 proc when checking for CA1/CA2 -> CAF, which is wrong.
also replaces old hitbox methods with the newer calls.
tested here: https://gcsim.app/v3/viewer/share/7e139306-0bd8-4055-a461-e1d55f4e0047