### PR TITLE
implement mona c1 and c6

### DIFF
--- a/internal/characters/mona/asc.go
+++ b/internal/characters/mona/asc.go
@@ -23,7 +23,7 @@ func (c *char) a1() func() {
 		if c.Core.Player.CurrentState() != action.DashState {
 			return
 		}
-		c.Core.Log.NewEvent("A1 Phantom added", glog.LogCharacterEvent, c.Index).
+		c.Core.Log.NewEvent("mona-a1 phantom added", glog.LogCharacterEvent, c.Index).
 			Write("expiry:", c.Core.F+120)
 		// queue up phantom explosion
 		c.Core.Tasks.Add(func() {

--- a/internal/characters/mona/cons.go
+++ b/internal/characters/mona/cons.go
@@ -157,8 +157,6 @@ func (c *char) c6(src int) func() {
 					return nil, false
 				}
 				m[attributes.DmgP] = 0.60 * float64(c.c6Stacks)
-				// reset stacks and remove buff on CA
-				c.c6Stacks = 0
 				return m, true
 			},
 		})

--- a/internal/characters/mona/cons.go
+++ b/internal/characters/mona/cons.go
@@ -1,15 +1,76 @@
 package mona
 
 import (
+	"fmt"
+
+	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/enemy"
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
-//When a Normal Attack hits, there is a 20% chance that it will be automatically followed by a Charged Attack.
-//This effect can only occur once every 5s.
+const c6Key = "mona-c6"
+
+// C1:
+// When any of your own party members hits an opponent affected by an Omen, the effects of Hydro-related Elemental Reactions are enhanced for 8s:
+// - Electro-Charged DMG increases by 15%.
+// - Vaporize DMG increases by 15%.
+// - Hydro Swirl DMG increases by 15%.
+// - Frozen duration is extended by 15%.
+func (c *char) c1() {
+	// TODO: "Frozen duration is extended by 15%." is bugged
+	c.Core.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
+		//ignore if target doesn't have debuff
+		t, ok := args[0].(*enemy.Enemy)
+		if !ok {
+			return false
+		}
+		if !t.StatusIsActive(bubbleKey) && !t.StatusIsActive(omenKey) {
+			return false
+		}
+		// add c1 to all party members, delay by 1, because:
+		// "This bonus does not apply in the triggering attack nor from the resulting Hydro DMG dealt by Illusory Bubble in Stellaris Phantasm regardless if they were from resulting reactions."
+		for _, x := range c.Core.Player.Chars() {
+			char := x
+			c.Core.Tasks.Add(func() {
+				// TODO: "Vaporize DMG increases by 15%." should be getting snapshot, see https://library.keqingmains.com/evidence/characters/hydro/mona#mona-c1-snapshot-for-vape
+				// requires ReactBonusMod refactor
+				char.AddReactBonusMod(character.ReactBonusMod{
+					Base: modifier.NewBase("mona-c1", 8*60),
+					Amount: func(ai combat.AttackInfo) (float64, bool) {
+						// doesn't work off-field
+						if c.Core.Player.Active() != char.Index {
+							return 0, false
+						}
+						// Electro-Charged DMG increases by 15%.
+						if ai.AttackTag == combat.AttackTagECDamage {
+							return 0.15, false
+						}
+						// Vaporize DMG increases by 15%.
+						// the only way Hydro Swirl can vape is via an AoE Hydro Swirl which doesn't do damage anyways, so this is fine
+						if ai.Amped {
+							return 0.15, false
+						}
+						// Hydro Swirl DMG increases by 15%.
+						if ai.AttackTag == combat.AttackTagSwirlHydro {
+							return 0.15, false
+						}
+						return 0, false
+					},
+				})
+			}, 1)
+		}
+		return false
+	}, "mona-c1-check")
+}
+
+// C2:
+// When a Normal Attack hits, there is a 20% chance that it will be automatically followed by a Charged Attack.
+// This effect can only occur once every 5s.
 func (c *char) c2(a combat.AttackCB) {
 	if c.Base.Cons < 2 {
 		return
@@ -36,7 +97,8 @@ func (c *char) c2(a combat.AttackCB) {
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.3, false, combat.TargettableEnemy), 0, 0)
 }
 
-//When any party member attacks an opponent affected by an Omen, their CRIT Rate is increased by 15%.
+// C4:
+// When any party member attacks an opponent affected by an Omen, their CRIT Rate is increased by 15%.
 func (c *char) c4() {
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.CR] = 0.15
@@ -56,5 +118,84 @@ func (c *char) c4() {
 				return nil, false
 			},
 		})
+	}
+}
+
+// C6:
+// Upon entering Illusory Torrent, Mona gains a 60% increase to the DMG of her next Charged Attack per second of movement.
+// A maximum DMG Bonus of 180% can be achieved in this manner.
+// The effect lasts for no more than 8s.
+func (c *char) c6(src int) func() {
+	return func() {
+		if c.c6Src != src {
+			c.Core.Log.NewEvent(fmt.Sprintf("%v stack gain check ignored, src diff", c6Key), glog.LogCharacterEvent, c.Index).
+				Write("src", src).
+				Write("new src", c.c6Src)
+			return
+		}
+		// do nothing if not Mona
+		if c.Core.Player.Active() != c.Index {
+			return
+		}
+		// do nothing if we aren't dashing anymore
+		if c.Core.Player.CurrentState() != action.DashState {
+			return
+		}
+
+		c.c6Stacks++
+		if c.c6Stacks > 3 {
+			c.c6Stacks = 3
+		}
+		c.Core.Log.NewEvent(fmt.Sprintf("%v stack gained", c6Key), glog.LogCharacterEvent, c.Index).
+			Write("c6Stacks", c.c6Stacks)
+
+		m := make([]float64, attributes.EndStatType)
+		c.AddAttackMod(character.AttackMod{
+			Base: modifier.NewBase(c6Key, 8*60),
+			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
+				if atk.Info.AttackTag != combat.AttackTagExtra {
+					return nil, false
+				}
+				m[attributes.DmgP] = 0.60 * float64(c.c6Stacks)
+				// reset stacks and remove buff on CA
+				c.c6Stacks = 0
+				return m, true
+			},
+		})
+
+		// reset C6 stacks in 8s if we didn't use a CA
+		c.Core.Tasks.Add(c.c6TimerReset, 8*60+1)
+		// queue up another stack and buff refresh in 1s
+		c.Core.Tasks.Add(c.c6(src), 60)
+	}
+}
+
+func (c *char) c6CAReset() {
+	// handle C6 stack reset if CA used before c6 buff expires
+	c.Core.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
+		atk := args[1].(*combat.AttackEvent)
+		if c.Core.Player.Active() != c.Index {
+			return false
+		}
+		if atk.Info.ActorIndex != c.Index {
+			return false
+		}
+		if atk.Info.AttackTag != combat.AttackTagExtra {
+			return false
+		}
+		if c.StatusIsActive(c6Key) {
+			c.c6Stacks = 0
+			c.DeleteStatus(c6Key)
+			c.Core.Log.NewEvent(fmt.Sprintf("%v stacks reset via charge attack", c6Key), glog.LogCharacterEvent, c.Index)
+		}
+		return false
+	}, fmt.Sprintf("%v-reset", c6Key))
+}
+
+func (c *char) c6TimerReset() {
+	// handle C6 stack reset if CA not used before c6 buff expires
+	if c.c6Stacks > 0 && !c.StatusIsActive(c6Key) {
+		c.c6Stacks = 0
+		c.Core.Log.NewEvent(fmt.Sprintf("%v stacks reset via timer", c6Key), glog.LogCharacterEvent, c.Index)
 	}
 }

--- a/internal/characters/mona/dash.go
+++ b/internal/characters/mona/dash.go
@@ -40,6 +40,15 @@ func (c *char) Dash(p map[string]int) action.ActionInfo {
 
 	// A1
 	c.Core.Tasks.Add(c.a1(), 120)
+	// C6
+	if c.Base.Cons >= 6 {
+		// reset c6 stacks in case we dash again before using a CA
+		c.c6Stacks = 0
+		// need to keep track of src in case of Mona Dash Dash, where the second dash starts between two c6 ticks
+		// without a src check the second Dash would gain a stack before 1s is up and a second one at 1s
+		c.c6Src = c.Core.F
+		c.Core.Tasks.Add(c.c6(c.Core.F), 60)
+	}
 
 	// call default implementation to handle stamina
 	c.Character.Dash(p)

--- a/internal/characters/mona/mona.go
+++ b/internal/characters/mona/mona.go
@@ -19,7 +19,9 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	c2icd int
+	c2icd    int
+	c6Src    int
+	c6Stacks int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
@@ -42,8 +44,14 @@ func (c *char) Init() error {
 	c.burstHook()
 	c.burstDamageBonus()
 	c.a4()
+	if c.Base.Cons >= 1 {
+		c.c1()
+	}
 	if c.Base.Cons >= 4 {
 		c.c4()
+	}
+	if c.Base.Cons >= 6 {
+		c.c6CAReset()
 	}
 	return nil
 }


### PR DESCRIPTION
closes #873 
closes #874 

C1 Vaporize bonus is not getting snapshot at the current moment even though it should, so ReactBonusMod needs to be refactored in order to fix this. See https://library.keqingmains.com/evidence/characters/hydro/mona#mona-c1-snapshot-for-vape.

- also adjust a1 logs