### PR TITLE
fix c2 kokomi

### DIFF
--- a/internal/characters/kokomi/burst.go
+++ b/internal/characters/kokomi/burst.go
@@ -129,7 +129,7 @@ func (c *char) burstActiveHook() {
 		for _, char := range c.Core.Player.Chars() {
 			src := heal
 
-			// C2 handling - believe this is an additional instance of flat healing
+			// C2 handling
 			// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
 			// Nereid's Ascension Normal and Charged Attacks: 0.6% of Kokomi's Max HP.
 			if c.Base.Cons >= 2 && char.HPCurrent/char.MaxHP() <= .5 {

--- a/internal/characters/kokomi/burst.go
+++ b/internal/characters/kokomi/burst.go
@@ -132,7 +132,7 @@ func (c *char) burstActiveHook() {
 			// C2 handling - believe this is an additional instance of flat healing
 			// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
 			// Nereid's Ascension Normal and Charged Attacks: 0.6% of Kokomi's Max HP.
-			if char.HPCurrent/char.MaxHP() <= .5 {
+			if c.Base.Cons >= 2 && char.HPCurrent/char.MaxHP() <= .5 {
 				bonus := 0.006 * c.MaxHP()
 				src += bonus
 				c.Core.Log.NewEvent("kokomi c2 proc'd", glog.LogCharacterEvent, char.Index).

--- a/internal/characters/kokomi/burst.go
+++ b/internal/characters/kokomi/burst.go
@@ -131,9 +131,9 @@ func (c *char) burstActiveHook() {
 
 			// C2 handling - believe this is an additional instance of flat healing
 			// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
-			// Kurage's Oath Bake-Kurage: 4.5% of Kokomi's Max HP.
+			// Nereid's Ascension Normal and Charged Attacks: 0.6% of Kokomi's Max HP.
 			if char.HPCurrent/char.MaxHP() <= .5 {
-				bonus := 0.045 * c.MaxHP()
+				bonus := 0.006 * c.MaxHP()
 				src += bonus
 				c.Core.Log.NewEvent("kokomi c2 proc'd", glog.LogCharacterEvent, char.Index).
 					Write("bonus", bonus)

--- a/internal/characters/kokomi/burst.go
+++ b/internal/characters/kokomi/burst.go
@@ -124,6 +124,9 @@ func (c *char) burstActiveHook() {
 			return false
 		}
 
+		if c.Base.Cons >= 2 {
+			c.c2()
+		}
 		c.Core.Player.Heal(player.HealInfo{
 			Caller:  c.Index,
 			Target:  -1,
@@ -132,9 +135,6 @@ func (c *char) burstActiveHook() {
 			Bonus:   c.Stat(attributes.Heal),
 		})
 
-		if c.Base.Cons >= 2 {
-			c.c2()
-		}
 		if c.Base.Cons >= 4 {
 			c.c4()
 		}

--- a/internal/characters/kokomi/burst.go
+++ b/internal/characters/kokomi/burst.go
@@ -6,6 +6,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/modifier"
@@ -124,16 +125,27 @@ func (c *char) burstActiveHook() {
 			return false
 		}
 
-		if c.Base.Cons >= 2 {
-			c.c2()
+		heal := burstHealPct[c.TalentLvlBurst()]*c.MaxHP() + burstHealFlat[c.TalentLvlBurst()]
+		for _, char := range c.Core.Player.Chars() {
+			src := heal
+
+			// C2 handling - believe this is an additional instance of flat healing
+			// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
+			// Kurage's Oath Bake-Kurage: 4.5% of Kokomi's Max HP.
+			if char.HPCurrent/char.MaxHP() <= .5 {
+				bonus := 0.045 * c.MaxHP()
+				src += bonus
+				c.Core.Log.NewEvent("kokomi c2 proc'd", glog.LogCharacterEvent, char.Index).
+					Write("bonus", bonus)
+			}
+			c.Core.Player.Heal(player.HealInfo{
+				Caller:  c.Index,
+				Target:  char.Index,
+				Message: "Ceremonial Garment",
+				Src:     src,
+				Bonus:   c.Stat(attributes.Heal),
+			})
 		}
-		c.Core.Player.Heal(player.HealInfo{
-			Caller:  c.Index,
-			Target:  -1,
-			Message: "Ceremonial Garment",
-			Src:     burstHealPct[c.TalentLvlBurst()]*c.MaxHP() + burstHealFlat[c.TalentLvlBurst()],
-			Bonus:   c.Stat(attributes.Heal),
-		})
 
 		if c.Base.Cons >= 4 {
 			c.c4()

--- a/internal/characters/kokomi/cons.go
+++ b/internal/characters/kokomi/cons.go
@@ -3,7 +3,6 @@ package kokomi
 import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/player"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
@@ -31,24 +30,6 @@ func (c *char) c1(f, travel int) {
 
 	// TODO: Is this snapshotted/dynamic?
 	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget, combat.TargettableEnemy), f, f+travel)
-}
-
-// C2 handling
-// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
-// Nereid's Ascension Normal and Charged Attacks: 0.6% of Kokomi's Max HP.
-func (c *char) c2() {
-	for _, char := range c.Core.Player.Chars() {
-		if char.HPCurrent/char.MaxHP() > .5 {
-			continue
-		}
-		c.Core.Player.Heal(player.HealInfo{
-			Caller:  c.Index,
-			Target:  char.Index,
-			Message: "The Clouds Like Waves Rippling",
-			Src:     0.006 * c.MaxHP(),
-			Bonus:   c.Stat(attributes.Heal),
-		})
-	}
 }
 
 // C4 (Energy piece only) handling

--- a/internal/characters/kokomi/skill.go
+++ b/internal/characters/kokomi/skill.go
@@ -86,7 +86,7 @@ func (c *char) skillTick(d *combat.AttackEvent) {
 	maxhp := d.Snapshot.BaseHP*(1+d.Snapshot.Stats[attributes.HPP]) + d.Snapshot.Stats[attributes.HP]
 	src := skillHealPct[c.TalentLvlSkill()]*maxhp + skillHealFlat[c.TalentLvlSkill()]
 
-	// C2 handling - believe this is an additional instance of flat healing
+	// C2 handling
 	// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
 	// Kurage's Oath Bake-Kurage: 4.5% of Kokomi's Max HP.
 	if c.Base.Cons >= 2 {

--- a/internal/characters/kokomi/skill.go
+++ b/internal/characters/kokomi/skill.go
@@ -81,22 +81,9 @@ func (c *char) skillTick(d *combat.AttackEvent) {
 		d.Info.FlatDmg = c.burstDmgBonus(d.Info.AttackTag)
 	}
 
-	maxhp := c.MaxHP()
-
 	c.Core.QueueAttackEvent(d, 0)
-	c.Core.Player.Heal(player.HealInfo{
-		Caller:  c.Index,
-		Target:  c.Core.Player.Active(),
-		Message: "Bake-Kurage",
-		Src:     skillHealPct[c.TalentLvlSkill()]*maxhp + skillHealFlat[c.TalentLvlSkill()],
-		Bonus:   d.Snapshot.Stats[attributes.Heal],
-	})
 
-	// Particles are 0~1 (1:2) on every damage instance
-	if c.Core.Rand.Float64() < .6667 {
-		c.Core.QueueParticle("kokomi", 1, attributes.Hydro, c.ParticleDelay)
-	}
-
+	maxhp := d.Snapshot.BaseHP*(1+d.Snapshot.Stats[attributes.HPP]) + d.Snapshot.Stats[attributes.HP]
 	// C2 handling - believe this is an additional instance of flat healing
 	// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
 	// Kurage's Oath Bake-Kurage: 4.5% of Kokomi's Max HP.
@@ -108,9 +95,22 @@ func (c *char) skillTick(d *combat.AttackEvent) {
 				Target:  c.Core.Player.Active(),
 				Message: "The Clouds Like Waves Rippling",
 				Src:     0.045 * maxhp,
-				Bonus:   c.Stat(attributes.Heal),
+				Bonus:   d.Snapshot.Stats[attributes.Heal],
 			})
 		}
+	}
+
+	c.Core.Player.Heal(player.HealInfo{
+		Caller:  c.Index,
+		Target:  c.Core.Player.Active(),
+		Message: "Bake-Kurage",
+		Src:     skillHealPct[c.TalentLvlSkill()]*maxhp + skillHealFlat[c.TalentLvlSkill()],
+		Bonus:   d.Snapshot.Stats[attributes.Heal],
+	})
+
+	// Particles are 0~1 (1:2) on every damage instance
+	if c.Core.Rand.Float64() < .6667 {
+		c.Core.QueueParticle("kokomi", 1, attributes.Hydro, c.ParticleDelay)
 	}
 }
 


### PR DESCRIPTION
- c2 above the healing of skill/burst cuz after the healing from the talent may not work the condition `active.HPCurrent/active.MaxHP() <= .5` (e.g. char has 49% hp, https://gcsim.app/v3/viewer/share/b16d440d-013e-43f7-8702-dd0fb9f85b48)
- max hp & heal bonus (c2) have a snapshot (https://www.youtube.com/watch?v=oDKhwAV7bX8)