### PR TITLE
allow tasks to be queued to end during run

### DIFF
--- a/pkg/core/task/task.go
+++ b/pkg/core/task/task.go
@@ -21,17 +21,13 @@ func New(f *int) *Handler {
 }
 
 func (c *Handler) Run() {
-	for _, x := range c.tasks[*c.f] {
-		x.f()
+	for i := 0; i < len(c.tasks[*c.f]); i++ {
+		c.tasks[*c.f][i].f()
 	}
 	delete(c.tasks, *c.f)
 }
 
 func (c *Handler) Add(f func(), delay int) {
-	if delay == 0 {
-		f()
-		return
-	}
 	c.tasks[*c.f+delay] = append(c.tasks[*c.f+delay], task{
 		f:      f,
 		source: *c.f,

--- a/pkg/core/task/task_test.go
+++ b/pkg/core/task/task_test.go
@@ -1,0 +1,32 @@
+package task
+
+import (
+	"log"
+	"testing"
+)
+
+func TestTaskAddTask(t *testing.T) {
+	//queue a tasks that adds another task to current frame; should execute
+	f := 1
+	h := New(&f)
+
+	count := 0
+	h.Add(func() {
+		log.Println("hello i'm at first task")
+		count++
+
+		h.Add(func() {
+			count++
+			log.Println("hello this is the second task")
+		}, 0)
+
+	}, 0)
+
+	h.Run()
+
+	if count != 2 {
+		log.Printf("expecting count to be 2, got %v\n", count)
+		t.FailNow()
+	}
+
+}


### PR DESCRIPTION
This sets the ground to allow for damage to be potentially queued to the end of the current frame (allowing srp and dendro reactions to work properly)