### PR TITLE
rewrite darkironsword, update trigger condition for dendro

### DIFF
--- a/internal/weapons/sword/darkironsword/darkironsword.go
+++ b/internal/weapons/sword/darkironsword/darkironsword.go
@@ -24,9 +24,7 @@ type Weapon struct {
 func (w *Weapon) SetIndex(idx int) { w.Index = idx }
 func (w *Weapon) Init() error      { return nil }
 
-// Overloaded
-// Upon causing an Overloaded, Superconduct, Electro-Charged, or an Electro-infused Swirl reaction,
-// ATK is increased by 20/25/30/35/40% for 12s.
+// Upon causing an Overloaded, Superconduct, Electro-Charged, Quicken, Aggravate, Hyperbloom, or Electro-infused Swirl reaction, ATK is increased by 20/25/30/35/40% for 12s.
 func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile) (weapon.Weapon, error) {
 	w := &Weapon{}
 	r := p.Refine
@@ -34,33 +32,31 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.ATKP] = 0.15 + float64(r)*0.05
 
-	c.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
+	buff := func(args ...interface{}) bool {
 		atk := args[1].(*combat.AttackEvent)
-
 		if atk.Info.ActorIndex != char.Index {
 			return false
 		}
-
-		//ignore if character not on field
 		if c.Player.Active() != char.Index {
 			return false
 		}
-
-		switch atk.Info.AttackTag {
-		case combat.AttackTagSuperconductDamage,
-			combat.AttackTagECDamage,
-			combat.AttackTagOverloadDamage,
-			combat.AttackTagSwirlElectro:
-			char.AddStatMod(character.StatMod{
-				Base:         modifier.NewBaseWithHitlag("darkironsword", 720),
-				AffectedStat: attributes.NoStat,
-				Amount: func() ([]float64, bool) {
-					return m, true
-				},
-			})
-		}
-
+		char.AddStatMod(character.StatMod{
+			Base:         modifier.NewBaseWithHitlag("darkironsword", 720),
+			AffectedStat: attributes.ATKP,
+			Amount: func() ([]float64, bool) {
+				return m, true
+			},
+		})
 		return false
-	}, fmt.Sprintf("darkironsword-%v", char.Base.Key.String()))
+	}
+
+	c.Events.Subscribe(event.OnOverload, buff, fmt.Sprintf("darkironsword-%v", char.Base.Key.String()))
+	c.Events.Subscribe(event.OnSuperconduct, buff, fmt.Sprintf("darkironsword-%v", char.Base.Key.String()))
+	c.Events.Subscribe(event.OnElectroCharged, buff, fmt.Sprintf("darkironsword-%v", char.Base.Key.String()))
+	c.Events.Subscribe(event.OnQuicken, buff, fmt.Sprintf("darkironsword-%v", char.Base.Key.String()))
+	c.Events.Subscribe(event.OnAggravate, buff, fmt.Sprintf("darkironsword-%v", char.Base.Key.String()))
+	// c.Events.Subscribe(event.OnHyperbloom, buff, fmt.Sprintf("darkironsword-%v", char.Base.Key.String()))
+	c.Events.Subscribe(event.OnSwirlElectro, buff, fmt.Sprintf("darkironsword-%v", char.Base.Key.String()))
+
 	return w, nil
 }


### PR DESCRIPTION
With Version 3.0 the description of Dark Iron Sword was changed to:
```
Upon causing an Overloaded, Superconduct, Electro-Charged, Quicken, Aggravate, Hyperbloom, or Electro-infused Swirl reaction, ATK is increased by 20/25/30/35/40% for 12s.
```
This PR includes Quicken/Aggravate/Hyperbloom as trigger conditions (Hyperbloom is commented out for now) and rewrites the trigger condition to listen to OnReaction instead of OnDamage.