### PR TITLE
fix anemo absorption location and naming

### DIFF
--- a/internal/characters/heizou/heizou.go
+++ b/internal/characters/heizou/heizou.go
@@ -5,7 +5,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
-	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/core/player/character/profile"
@@ -17,11 +16,10 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	decStack            int
-	infuseCheckLocation combat.AttackPattern
-	c1buff              []float64
-	a4buff              []float64
-	burstTaggedCount    int
+	decStack         int
+	c1buff           []float64
+	a4buff           []float64
+	burstTaggedCount int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
@@ -32,8 +30,6 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.NormalHitNum = normalHitNum
 	c.SkillCon = 3
 	c.BurstCon = 5
-
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy)
 
 	w.Character = &c
 

--- a/internal/characters/kazuha/asc.go
+++ b/internal/characters/kazuha/asc.go
@@ -71,7 +71,7 @@ func (c *char) absorbCheckA1(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.a1Absorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
+		c.a1Absorb = c.Core.Combat.AbsorbCheck(c.a1AbsorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
 
 		if c.a1Absorb != attributes.NoElement {
 			c.Core.Log.NewEventBuildMsg(glog.LogCharacterEvent, c.Index,

--- a/internal/characters/kazuha/asc.go
+++ b/internal/characters/kazuha/asc.go
@@ -71,11 +71,11 @@ func (c *char) absorbCheckA1(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.a1Ele = c.Core.Combat.AbsorbCheck(c.infuseCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
+		c.a1Absorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
 
-		if c.a1Ele != attributes.NoElement {
+		if c.a1Absorb != attributes.NoElement {
 			c.Core.Log.NewEventBuildMsg(glog.LogCharacterEvent, c.Index,
-				"kazuha a1 infused ", c.a1Ele.String(),
+				"kazuha a1 absorbed ", c.a1Absorb.String(),
 			)
 			return
 		}

--- a/internal/characters/kazuha/burst.go
+++ b/internal/characters/kazuha/burst.go
@@ -27,7 +27,7 @@ func init() {
 func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.qAbsorb = attributes.NoElement
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	c.qAbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	ai := combat.AttackInfo{
 		ActorIndex:         c.Index,
@@ -117,7 +117,7 @@ func (c *char) absorbCheckQ(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.qAbsorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
+		c.qAbsorb = c.Core.Combat.AbsorbCheck(c.qAbsorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
 
 		if c.qAbsorb != attributes.NoElement {
 			return

--- a/internal/characters/kazuha/burst.go
+++ b/internal/characters/kazuha/burst.go
@@ -26,8 +26,9 @@ func init() {
 
 func (c *char) Burst(p map[string]int) action.ActionInfo {
 
-	c.qInfuse = attributes.NoElement
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	c.qAbsorb = attributes.NoElement
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+
 	ai := combat.AttackInfo{
 		ActorIndex:         c.Index,
 		Abil:               "Kazuha Slash",
@@ -70,8 +71,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		// updated to 140 based on koli's count: https://docs.google.com/spreadsheets/d/1uEbP13O548-w_nGxFPGsf5jqj1qGD3pqFZ_AiV4w3ww/edit#gid=775340159
 		for i := 0; i < 5; i++ {
 			c.Core.Tasks.Add(func() {
-				if c.qInfuse != attributes.NoElement {
-					aiAbsorb.Element = c.qInfuse
+				if c.qAbsorb != attributes.NoElement {
+					aiAbsorb.Element = c.qAbsorb
 					c.Core.QueueAttackWithSnap(aiAbsorb, snapAbsorb, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0)
 				}
 				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0)
@@ -116,9 +117,9 @@ func (c *char) absorbCheckQ(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.qInfuse = c.Core.Combat.AbsorbCheck(c.infuseCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
+		c.qAbsorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
 
-		if c.qInfuse != attributes.NoElement {
+		if c.qAbsorb != attributes.NoElement {
 			return
 		}
 		//otherwise queue up

--- a/internal/characters/kazuha/kazuha.go
+++ b/internal/characters/kazuha/kazuha.go
@@ -17,10 +17,10 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	a1Ele               attributes.Element
-	qInfuse             attributes.Element
+	a1Absorb            attributes.Element
+	qAbsorb             attributes.Element
 	qFieldSrc           int
-	infuseCheckLocation combat.AttackPattern
+	absorbCheckLocation combat.AttackPattern
 	c2buff              []float64
 }
 
@@ -33,7 +33,7 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.SkillCon = 3
 	c.NormalHitNum = normalHitNum
 
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	w.Character = &c
 

--- a/internal/characters/kazuha/kazuha.go
+++ b/internal/characters/kazuha/kazuha.go
@@ -17,11 +17,12 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	a1Absorb            attributes.Element
-	qAbsorb             attributes.Element
-	qFieldSrc           int
-	absorbCheckLocation combat.AttackPattern
-	c2buff              []float64
+	a1Absorb              attributes.Element
+	a1AbsorbCheckLocation combat.AttackPattern
+	qAbsorb               attributes.Element
+	qFieldSrc             int
+	qAbsorbCheckLocation  combat.AttackPattern
+	c2buff                []float64
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
@@ -33,7 +34,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.SkillCon = 3
 	c.NormalHitNum = normalHitNum
 
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	c.a1AbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	c.qAbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	w.Character = &c
 

--- a/internal/characters/kazuha/plunge.go
+++ b/internal/characters/kazuha/plunge.go
@@ -89,7 +89,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), hitmark, hitmark)
 
 	// a1 if applies
-	if c.a1Ele != attributes.NoElement {
+	if c.a1Absorb != attributes.NoElement {
 		ai := combat.AttackInfo{
 			ActorIndex:     c.Index,
 			Abil:           "Kazuha A1",
@@ -97,14 +97,14 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 			ICDTag:         combat.ICDTagNone,
 			ICDGroup:       combat.ICDGroupDefault,
 			StrikeType:     combat.StrikeTypeDefault,
-			Element:        c.a1Ele,
+			Element:        c.a1Absorb,
 			Durability:     25,
 			Mult:           2,
 			IgnoreInfusion: true,
 		}
 
 		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), hitmark-1, hitmark-1)
-		c.a1Ele = attributes.NoElement
+		c.a1Absorb = attributes.NoElement
 	}
 
 	return act

--- a/internal/characters/kazuha/skill.go
+++ b/internal/characters/kazuha/skill.go
@@ -36,7 +36,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	hold := p["hold"]
 
 	c.a1Absorb = attributes.NoElement
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	c.a1AbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	// why is the same code written twice..
 	if hold == 0 {

--- a/internal/characters/kazuha/skill.go
+++ b/internal/characters/kazuha/skill.go
@@ -34,7 +34,9 @@ func init() {
 
 func (c *char) Skill(p map[string]int) action.ActionInfo {
 	hold := p["hold"]
-	c.a1Ele = attributes.NoElement
+
+	c.a1Absorb = attributes.NoElement
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	// why is the same code written twice..
 	if hold == 0 {

--- a/internal/characters/sayu/sayu.go
+++ b/internal/characters/sayu/sayu.go
@@ -16,10 +16,10 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	eInfused            attributes.Element
-	eInfusedTag         combat.ICDTag
 	eDuration           int
-	infuseCheckLocation combat.AttackPattern
+	eAbsorb             attributes.Element
+	eAbsorbTag          combat.ICDTag
+	absorbCheckLocation combat.AttackPattern
 	c2Bonus             float64
 }
 
@@ -32,8 +32,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.BurstCon = 3
 	c.SkillCon = 5
 
-	c.eInfused = attributes.NoElement
 	c.eDuration = -1
+	c.eAbsorb = attributes.NoElement
 	c.c2Bonus = .0
 
 	w.Character = &c

--- a/internal/characters/sayu/skill.go
+++ b/internal/characters/sayu/skill.go
@@ -61,7 +61,6 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 }
 
 func (c *char) skillPress(p map[string]int) action.ActionInfo {
-
 	c.c2Bonus = 0.033
 
 	// Fuufuu Windwheel DMG
@@ -107,11 +106,12 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 }
 
 func (c *char) skillShortHold(p map[string]int) action.ActionInfo {
-	c.eInfused = attributes.NoElement
-	c.eInfusedTag = combat.ICDTagNone
 	c.eDuration = c.Core.F + skillShortHoldKickHitmark
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, true, combat.TargettablePlayer, combat.TargettableEnemy, combat.TargettableGadget)
 	c.c2Bonus = .0
+
+	c.eAbsorb = attributes.NoElement
+	c.eAbsorbTag = combat.ICDTagNone
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, true, combat.TargettablePlayer, combat.TargettableEnemy, combat.TargettableGadget)
 
 	// 1 DoT Tick
 	d := c.createSkillHoldSnapshot()
@@ -147,7 +147,7 @@ func (c *char) skillShortHold(p map[string]int) action.ActionInfo {
 	c.Core.QueueParticle("sayu-skill", 2, attributes.Anemo, skillShortHoldKickHitmark+c.ParticleDelay)
 
 	// 6.2s cooldown
-	c.SetCDWithDelay(action.ActionSkill, 372, 30)
+	c.SetCDWithDelay(action.ActionSkill, 372, skillShortHoldCDStart)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(skillShortHoldFrames),
@@ -158,12 +158,12 @@ func (c *char) skillShortHold(p map[string]int) action.ActionInfo {
 }
 
 func (c *char) skillHold(p map[string]int, duration int) action.ActionInfo {
-
-	c.eInfused = attributes.NoElement
-	c.eInfusedTag = combat.ICDTagNone
 	c.eDuration = c.Core.F + (skillHoldKickHitmark - 600) + duration
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, true, combat.TargettablePlayer, combat.TargettableEnemy, combat.TargettableGadget)
 	c.c2Bonus = .0
+
+	c.eAbsorb = attributes.NoElement
+	c.eAbsorbTag = combat.ICDTagNone
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, true, combat.TargettablePlayer, combat.TargettableEnemy, combat.TargettableGadget)
 
 	// ticks
 	d := c.createSkillHoldSnapshot()
@@ -245,20 +245,20 @@ func (c *char) absorbCheck(src, count, max int) func() {
 			return
 		}
 
-		c.eInfused = c.Core.Combat.AbsorbCheck(c.infuseCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
-		if c.eInfused != attributes.NoElement {
-			switch c.eInfused {
+		c.eAbsorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
+		if c.eAbsorb != attributes.NoElement {
+			switch c.eAbsorb {
 			case attributes.Pyro:
-				c.eInfusedTag = combat.ICDTagElementalArtPyro
+				c.eAbsorbTag = combat.ICDTagElementalArtPyro
 			case attributes.Hydro:
-				c.eInfusedTag = combat.ICDTagElementalArtHydro
+				c.eAbsorbTag = combat.ICDTagElementalArtHydro
 			case attributes.Electro:
-				c.eInfusedTag = combat.ICDTagElementalArtElectro
+				c.eAbsorbTag = combat.ICDTagElementalArtElectro
 			case attributes.Cryo:
-				c.eInfusedTag = combat.ICDTagElementalArtCryo
+				c.eAbsorbTag = combat.ICDTagElementalArtCryo
 			}
 			c.Core.Log.NewEventBuildMsg(glog.LogCharacterEvent, c.Index,
-				"sayu infused ", c.eInfused.String(),
+				"sayu absorbed ", c.eAbsorb.String(),
 			)
 			return
 		}
@@ -275,7 +275,7 @@ func (c *char) rollAbsorb() {
 		if atk.Info.AttackTag != combat.AttackTagElementalArt && atk.Info.AttackTag != combat.AttackTagElementalArtHold {
 			return false
 		}
-		if atk.Info.Element != attributes.Anemo || c.eInfused == attributes.NoElement {
+		if atk.Info.Element != attributes.Anemo || c.eAbsorb == attributes.NoElement {
 			return false
 		}
 		if c.Core.F > c.eDuration {
@@ -289,9 +289,9 @@ func (c *char) rollAbsorb() {
 				ActorIndex: c.Index,
 				Abil:       "Fuufuu Windwheel Elemental (Elemental DoT Hold)",
 				AttackTag:  combat.AttackTagElementalArtHold,
-				ICDTag:     c.eInfusedTag,
+				ICDTag:     c.eAbsorbTag,
 				ICDGroup:   combat.ICDGroupDefault,
-				Element:    c.eInfused,
+				Element:    c.eAbsorb,
 				Durability: 25,
 				Mult:       skillAbsorb[c.TalentLvlSkill()],
 			}
@@ -304,7 +304,7 @@ func (c *char) rollAbsorb() {
 				AttackTag:  combat.AttackTagElementalArt,
 				ICDTag:     combat.ICDTagNone,
 				ICDGroup:   combat.ICDGroupDefault,
-				Element:    c.eInfused,
+				Element:    c.eAbsorb,
 				Durability: 25,
 				Mult:       skillAbsorbEnd[c.TalentLvlSkill()],
 			}

--- a/internal/characters/sucrose/burst.go
+++ b/internal/characters/sucrose/burst.go
@@ -27,8 +27,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 
 	// reset location
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
-	c.qInfused = attributes.NoElement
+	c.qAbsorb = attributes.NoElement
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	c.Core.Status.Add("sucroseburst", duration)
 	ai := combat.AttackInfo{
@@ -72,8 +72,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), i, cb)
 
 		c.Core.Tasks.Add(func() {
-			if c.qInfused != attributes.NoElement {
-				aiAbs.Element = c.qInfused
+			if c.qAbsorb != attributes.NoElement {
+				aiAbs.Element = c.qAbsorb
 				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0)
 			}
 			//check if infused
@@ -98,9 +98,9 @@ func (c *char) absorbCheck(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.qInfused = c.Core.Combat.AbsorbCheck(c.infuseCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
+		c.qAbsorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
 
-		if c.qInfused != attributes.NoElement {
+		if c.qAbsorb != attributes.NoElement {
 			if c.Base.Cons >= 6 {
 				c.c6()
 			}

--- a/internal/characters/sucrose/burst.go
+++ b/internal/characters/sucrose/burst.go
@@ -76,7 +76,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				aiAbs.Element = c.qAbsorb
 				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0)
 			}
-			//check if infused
+			//check if absorbed
 		}, i)
 	}
 

--- a/internal/characters/sucrose/cons.go
+++ b/internal/characters/sucrose/cons.go
@@ -28,7 +28,7 @@ func (c *char) c4() {
 }
 
 func (c *char) c6() {
-	stat := attributes.EleToDmgP(c.qInfused)
+	stat := attributes.EleToDmgP(c.qAbsorb)
 	c.c6buff[stat] = .20
 
 	for _, char := range c.Core.Player.Chars() {

--- a/internal/characters/sucrose/sucrose.go
+++ b/internal/characters/sucrose/sucrose.go
@@ -17,8 +17,8 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	qInfused            attributes.Element
-	infuseCheckLocation combat.AttackPattern
+	qAbsorb             attributes.Element
+	absorbCheckLocation combat.AttackPattern
 	a1buff              []float64
 	a4buff              []float64
 	c4Count             int
@@ -32,7 +32,7 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.EnergyMax = 80
 	c.NormalHitNum = normalHitNum
 
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	if c.Base.Cons >= 1 {
 		c.SetNumCharges(action.ActionSkill, 2)

--- a/internal/characters/traveleranemo/burst.go
+++ b/internal/characters/traveleranemo/burst.go
@@ -38,6 +38,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.qInfuse = attributes.NoElement
 	c.qICDTag = combat.ICDTagNone
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Gust Surge",
@@ -103,7 +105,7 @@ func (c *char) absorbCheckQ(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.qInfuse = c.Core.Combat.AbsorbCheck(c.infuseCheckLocation, attributes.Cryo, attributes.Pyro, attributes.Hydro, attributes.Electro)
+		c.qInfuse = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Cryo, attributes.Pyro, attributes.Hydro, attributes.Electro)
 		switch c.qInfuse {
 		case attributes.Cryo:
 			c.qICDTag = combat.ICDTagElementalBurstCryo

--- a/internal/characters/traveleranemo/burst.go
+++ b/internal/characters/traveleranemo/burst.go
@@ -36,7 +36,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.Core.Status.Add("amcburst", duration)
 
-	c.qInfuse = attributes.NoElement
+	c.qAbsorb = attributes.NoElement
 	c.qICDTag = combat.ICDTagNone
 	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
@@ -74,11 +74,11 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 94+30*i, cb)
 
 		c.Core.Tasks.Add(func() {
-			if c.qInfuse != attributes.NoElement {
-				aiAbs.Element = c.qInfuse
+			if c.qAbsorb != attributes.NoElement {
+				aiAbs.Element = c.qAbsorb
 				var cbAbs combat.AttackCBFunc
 				if c.Base.Cons >= 6 {
-					cbAbs = c6cb(c.qInfuse)
+					cbAbs = c6cb(c.qAbsorb)
 				}
 				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, cbAbs)
 			}
@@ -105,8 +105,8 @@ func (c *char) absorbCheckQ(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.qInfuse = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Cryo, attributes.Pyro, attributes.Hydro, attributes.Electro)
-		switch c.qInfuse {
+		c.qAbsorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Cryo, attributes.Pyro, attributes.Hydro, attributes.Electro)
+		switch c.qAbsorb {
 		case attributes.Cryo:
 			c.qICDTag = combat.ICDTagElementalBurstCryo
 		case attributes.Pyro:

--- a/internal/characters/traveleranemo/skill.go
+++ b/internal/characters/traveleranemo/skill.go
@@ -73,8 +73,9 @@ func (c *char) SkillPress() action.ActionInfo {
 
 func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 
-	c.eInfuse = attributes.NoElement
+	c.eAbsorb = attributes.NoElement
 	c.eICDTag = combat.ICDTagNone
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	aiCut := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -105,8 +106,8 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 		c.Core.QueueAttack(aiCut, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), hitmark, hitmark)
 		if i > 1 {
 			c.Core.Tasks.Add(func() {
-				if c.eInfuse != attributes.NoElement {
-					aiMaxCutAbs.Element = c.eInfuse
+				if c.eAbsorb != attributes.NoElement {
+					aiMaxCutAbs.Element = c.eAbsorb
 					aiMaxCutAbs.ICDTag = c.eICDTag
 					c.Core.QueueAttack(aiMaxCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 				}
@@ -114,8 +115,8 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 			}, hitmark)
 		} else {
 			c.Core.Tasks.Add(func() {
-				if c.eInfuse != attributes.NoElement {
-					aiCutAbs.Element = c.eInfuse
+				if c.eAbsorb != attributes.NoElement {
+					aiCutAbs.Element = c.eAbsorb
 					aiCutAbs.ICDTag = c.eICDTag
 					c.Core.QueueAttack(aiCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 				}
@@ -174,8 +175,8 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 
 	c.Core.QueueAttack(aiStorm, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), hitmark, hitmark)
 	c.Core.Tasks.Add(func() {
-		if c.eInfuse != attributes.NoElement {
-			aiStormAbs.Element = c.eInfuse
+		if c.eAbsorb != attributes.NoElement {
+			aiStormAbs.Element = c.eAbsorb
 			aiStormAbs.ICDTag = c.eICDTag
 			c.Core.QueueAttack(aiStormAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 		}
@@ -216,8 +217,8 @@ func (c *char) absorbCheckE(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.eInfuse = c.Core.Combat.AbsorbCheck(c.infuseCheckLocation, attributes.Cryo, attributes.Pyro, attributes.Hydro, attributes.Electro)
-		switch c.eInfuse {
+		c.eAbsorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Cryo, attributes.Pyro, attributes.Hydro, attributes.Electro)
+		switch c.eAbsorb {
 		case attributes.Cryo:
 			c.eICDTag = combat.ICDTagElementalArtCryo
 		case attributes.Pyro:

--- a/internal/characters/traveleranemo/skill.go
+++ b/internal/characters/traveleranemo/skill.go
@@ -111,7 +111,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 					aiMaxCutAbs.ICDTag = c.eICDTag
 					c.Core.QueueAttack(aiMaxCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 				}
-				//check if infused
+				//check if absorbed
 			}, hitmark)
 		} else {
 			c.Core.Tasks.Add(func() {
@@ -120,7 +120,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 					aiCutAbs.ICDTag = c.eICDTag
 					c.Core.QueueAttack(aiCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 				}
-				//check if infused
+				//check if absorbed
 			}, hitmark)
 		}
 
@@ -180,7 +180,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 			aiStormAbs.ICDTag = c.eICDTag
 			c.Core.QueueAttack(aiStormAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 		}
-		//check if infused
+		//check if absorbed
 	}, hitmark)
 
 	// starts absorbing after the first tick?

--- a/internal/characters/traveleranemo/traveleranemo.go
+++ b/internal/characters/traveleranemo/traveleranemo.go
@@ -17,7 +17,7 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	qInfuse             attributes.Element
+	qAbsorb             attributes.Element
 	qICDTag             combat.ICDTag
 	eAbsorb             attributes.Element
 	eICDTag             combat.ICDTag

--- a/internal/characters/traveleranemo/traveleranemo.go
+++ b/internal/characters/traveleranemo/traveleranemo.go
@@ -19,9 +19,9 @@ type char struct {
 	*tmpl.Character
 	qInfuse             attributes.Element
 	qICDTag             combat.ICDTag
-	eInfuse             attributes.Element
+	eAbsorb             attributes.Element
 	eICDTag             combat.ICDTag
-	infuseCheckLocation combat.AttackPattern
+	absorbCheckLocation combat.AttackPattern
 	gender              int
 }
 
@@ -37,7 +37,7 @@ func NewChar(gender int) core.NewCharacterFunc {
 		c.BurstCon = 3
 		c.SkillCon = 5
 		c.NormalHitNum = normalHitNum
-		c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+		c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 		w.Character = &c
 

--- a/internal/characters/venti/asc.go
+++ b/internal/characters/venti/asc.go
@@ -4,11 +4,11 @@ import "github.com/genshinsim/gcsim/pkg/core/attributes"
 
 func (c *char) a4() {
 	c.AddEnergy("venti-a4", 15)
-	if c.qInfuse == attributes.NoElement {
+	if c.qAbsorb == attributes.NoElement {
 		return
 	}
 	for _, char := range c.Core.Player.Chars() {
-		if char.Base.Element == c.qInfuse {
+		if char.Base.Element == c.qAbsorb {
 			char.AddEnergy("venti-a4", 15)
 		}
 	}

--- a/internal/characters/venti/burst.go
+++ b/internal/characters/venti/burst.go
@@ -19,8 +19,8 @@ func init() {
 
 func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// reset location
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
-	c.qInfuse = attributes.NoElement
+	c.qAbsorb = attributes.NoElement
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	//8 second duration, tick every .4 second
 	ai := combat.AttackInfo{
@@ -34,7 +34,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Mult:       burstDot[c.TalentLvlBurst()],
 	}
 	c.aiAbsorb = ai
-	c.aiAbsorb.Abil = "Wind's Grand Ode (Infused)"
+	c.aiAbsorb.Abil = "Wind's Grand Ode (Absorbed)"
 	c.aiAbsorb.Mult = burstAbsorbDot[c.TalentLvlBurst()]
 	c.aiAbsorb.Element = attributes.NoElement
 
@@ -75,10 +75,10 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 }
 
-func (c *char) burstInfusedTicks() {
+func (c *char) burstAbsorbedTicks() {
 	var cb combat.AttackCBFunc
 	if c.Base.Cons >= 6 {
-		cb = c.c6(c.qInfuse)
+		cb = c.c6(c.qAbsorb)
 	}
 
 	// ticks at 24f. 15 total
@@ -92,10 +92,10 @@ func (c *char) absorbCheckQ(src, count, max int) func() {
 		if count == max {
 			return
 		}
-		c.qInfuse = c.Core.Combat.AbsorbCheck(c.infuseCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
-		if c.qInfuse != attributes.NoElement {
-			c.aiAbsorb.Element = c.qInfuse
-			switch c.qInfuse {
+		c.qAbsorb = c.Core.Combat.AbsorbCheck(c.absorbCheckLocation, attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo)
+		if c.qAbsorb != attributes.NoElement {
+			c.aiAbsorb.Element = c.qAbsorb
+			switch c.qAbsorb {
 			case attributes.Pyro:
 				c.aiAbsorb.ICDTag = combat.ICDTagElementalBurstPyro
 			case attributes.Hydro:
@@ -106,7 +106,7 @@ func (c *char) absorbCheckQ(src, count, max int) func() {
 				c.aiAbsorb.ICDTag = combat.ICDTagElementalBurstCryo
 			}
 			//trigger dmg ticks here
-			c.burstInfusedTicks()
+			c.burstAbsorbedTicks()
 			return
 		}
 		//otherwise queue up

--- a/internal/characters/venti/venti.go
+++ b/internal/characters/venti/venti.go
@@ -16,8 +16,8 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	qInfuse             attributes.Element
-	infuseCheckLocation combat.AttackPattern
+	qAbsorb             attributes.Element
+	absorbCheckLocation combat.AttackPattern
 	aiAbsorb            combat.AttackInfo
 	snapAbsorb          combat.Snapshot
 	c4bonus             []float64
@@ -32,7 +32,7 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.BurstCon = 3
 	c.SkillCon = 5
 
-	c.infuseCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
 
 	w.Character = &c
 


### PR DESCRIPTION
This PR fixes cases in which the absorption location was not reset on every ability use (Kazuha E, Traveler (Anemo) E and Q) and adjusts the variable naming/logging to use "absorb" instead of "infuse" (+ a few formatting adjustments). 