### PR TITLE
add logging of infusions as a status

### DIFF
--- a/internal/characters/aloy/skill.go
+++ b/internal/characters/aloy/skill.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 const (
-	rushingIceKey = "rushingice"
+	rushingIceKey = "aloy-rushing-ice"
 )
 
 // Skill - Handles main damage, bomblet, and coil effects
@@ -143,14 +143,21 @@ func (c *char) coilStacks() {
 
 // Handles rushing ice state
 func (c *char) rushingIce() {
-	c.AddStatus(rushingIceKey, 600, true)
-	c.Core.Player.AddWeaponInfuse(c.Index, "aloy-rushing-ice", attributes.Cryo, 600, true, combat.AttackTagNormal)
+	// rushing ice cryo infusion and status
+	c.Core.Player.AddWeaponInfuse(
+		c.CharWrapper,
+		rushingIceKey,
+		attributes.Cryo,
+		600,
+		true,
+		combat.AttackTagNormal,
+	)
 
-	// Rushing ice NA bonus
+	// rushing ice NA bonus
 	val := make([]float64, attributes.EndStatType)
 	val[attributes.DmgP] = skillRushingIceNABonus[c.TalentLvlSkill()]
 	c.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBaseWithHitlag("aloy-rushing-ice", 600),
+		Base: modifier.NewBaseWithHitlag(rushingIceKey+"-na-bonus", 600),
 		Amount: func(atk *combat.AttackEvent, _ combat.Target) ([]float64, bool) {
 			if atk.Info.AttackTag == combat.AttackTagNormal {
 				return val, true

--- a/internal/characters/ayaka/dash.go
+++ b/internal/characters/ayaka/dash.go
@@ -63,7 +63,7 @@ func (c *char) Dash(p map[string]int) action.ActionInfo {
 	//TODO: check weapon infuse timing; this SHOULD be ok?
 	c.Core.Tasks.Add(func() {
 		c.Core.Player.AddWeaponInfuse(
-			c.Index,
+			c.CharWrapper,
 			"ayaka-dash",
 			attributes.Cryo,
 			300,

--- a/internal/characters/bennett/burst.go
+++ b/internal/characters/bennett/burst.go
@@ -128,7 +128,7 @@ func (c *char) applyBennettField(stats [attributes.EndStatType]float64) func() {
 					fallthrough
 				case weapon.WeaponClassSword:
 					c.Core.Player.AddWeaponInfuse(
-						active.Index,
+						active,
 						"bennett-fire-weapon",
 						attributes.Pyro,
 						burstBuffDuration,

--- a/internal/characters/chongyun/skill.go
+++ b/internal/characters/chongyun/skill.go
@@ -161,15 +161,13 @@ func (c *char) infuse(active *character.CharWrapper) {
 		fallthrough
 	case weapon.WeaponClassSword:
 		c.Core.Player.AddWeaponInfuse(
-			active.Index,
+			active,
 			"chongyun-ice-weapon",
 			attributes.Cryo,
 			infuseDur[c.TalentLvlSkill()],
 			true,
 			combat.AttackTagNormal, combat.AttackTagExtra, combat.AttackTagPlunge,
 		)
-		c.Core.Log.NewEvent("chongyun adding infusion", glog.LogCharacterEvent, c.Index).
-			Write("expiry", c.Core.F+infuseDur[c.TalentLvlSkill()])
 	default:
 		return
 	}

--- a/internal/characters/kazuha/cons.go
+++ b/internal/characters/kazuha/cons.go
@@ -63,7 +63,7 @@ func (c *char) c2(src int) func() {
 func (c *char) c6() {
 	// add anemo infusion
 	c.Core.Player.AddWeaponInfuse(
-		c.Index,
+		c.CharWrapper,
 		"kazuha-c6-infusion",
 		attributes.Anemo,
 		60*5,

--- a/internal/characters/keqing/asc.go
+++ b/internal/characters/keqing/asc.go
@@ -8,11 +8,10 @@ import (
 )
 
 func (c *char) a1() {
-	//account for it starting somewhere around hitmark
-	dur := 300 + skillRecastHitmark
-	c.Core.Status.Add("keqinginfuse", dur)
+	// barely cover 5N1C + N1 combo hitlagless
+	dur := 300 + skillRecastHitmark + 12
 	c.Core.Player.AddWeaponInfuse(
-		c.Index,
+		c.CharWrapper,
 		"keqing-a1",
 		attributes.Electro,
 		dur,

--- a/pkg/core/player/infusion/infusion.go
+++ b/pkg/core/player/infusion/infusion.go
@@ -4,6 +4,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/glog"
+	"github.com/genshinsim/gcsim/pkg/core/player/character"
 )
 
 type WeaponInfusion struct {
@@ -39,7 +40,8 @@ func (i *InfusionHandler) ExtendInfusion(char int, factor, dur float64) {
 	i.infusion[char].Expiry += dur * (1 - factor)
 }
 
-func (i *InfusionHandler) AddWeaponInfuse(char int, key string, ele attributes.Element, dur int, canBeOverriden bool, tags ...combat.AttackTag) {
+func (i *InfusionHandler) AddWeaponInfuse(c *character.CharWrapper, key string, ele attributes.Element, dur int, canBeOverriden bool, tags ...combat.AttackTag) {
+	char := c.Index
 	if !i.infusion[char].CanBeOverridden && i.infusion[char].Expiry > float64(*i.f) {
 		return
 	}
@@ -50,10 +52,13 @@ func (i *InfusionHandler) AddWeaponInfuse(char int, key string, ele attributes.E
 		CanBeOverridden: canBeOverriden,
 		Tags:            tags,
 	}
+	hitlag := true
 	if dur == -1 {
 		inf.Expiry = -1
+		hitlag = false
 	}
 	i.infusion[char] = inf
+	c.AddStatus(key, dur, hitlag)
 }
 
 func (i *InfusionHandler) WeaponInfuseIsActive(char int, key string) bool {


### PR DESCRIPTION
This PR addresses the fact that weapon infusions aren't being logged anywhere. To fix this issue, I adjusted the AddWeaponInfuse method to add a hitlag extendable (only if dur != -1) status for every infusion. This eliminates the need to add an extra status when you need to keep track of the weapon infusion like in Aloy's case and makes it easier to tell in debug whether an infusion is up or not.

Some other char specific changes:
- adjusted aloy's e key names 
- removed logging for chongyun's infusion, because it can be seen as a status now
- Keqing can do 5N1C + N1 hitlagless with her electro infusion ingame, so I adjusted the infusion duration to barely cover that combo. She will only be able to do 5N1C with hitlag like she does ingame (this is because the status extension is fractional and hitlag rounds up for animation, so you lose a little bit of time when hitlagged in the sim).

TODO:
- [ ] update docs at some point after merge (every infusion doubles as a status now)