### PR TITLE
Add bloom, hyperbloom and burgeon reaction

### DIFF
--- a/internal/characters/amber/bunny.go
+++ b/internal/characters/amber/bunny.go
@@ -12,7 +12,7 @@ type bunny struct {
 	src int
 }
 
-//TODO: forbidden bunny cryo swirl tech
+// TODO: forbidden bunny cryo swirl tech
 func (c *char) makeBunny() {
 	b := bunny{}
 	b.src = c.Core.F
@@ -30,7 +30,7 @@ func (c *char) makeBunny() {
 	snap := c.Snapshot(&ai)
 	b.ae = combat.AttackEvent{
 		Info:        ai,
-		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
 		SourceFrame: c.Core.F,
 		Snapshot:    snap,
 	}
@@ -76,7 +76,7 @@ func (c *char) manualExplode() {
 	c.bunnies = c.bunnies[1:]
 }
 
-//explode all bunnies on overload
+// explode all bunnies on overload
 func (c *char) overloadExplode() {
 	c.Core.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
 

--- a/internal/characters/amber/burst.go
+++ b/internal/characters/amber/burst.go
@@ -40,13 +40,13 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	//TODO: properly implement random hits and hit box range. right now everything is just radius 3
 	for i := 24; i < 120; i += 24 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), burstStart+i)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy, combat.TargettableGadget), burstStart+i)
 	}
 	for i := 36; i < 120; i += 36 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), burstStart+i)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy, combat.TargettableGadget), burstStart+i)
 	}
 	for i := 12; i < 120; i += 12 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), burstStart+i)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy, combat.TargettableGadget), burstStart+i)
 	}
 
 	if c.Base.Cons >= 6 {

--- a/internal/characters/beidou/attack.go
+++ b/internal/characters/beidou/attack.go
@@ -43,7 +43,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -43,7 +43,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   0.1 * 60,
 		CanBeDefenseHalted: false,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
 
 	// beidou burst is not hitlag extendable
 	c.AddStatus(burstKey, 900, false)

--- a/internal/characters/beidou/skill.go
+++ b/internal/characters/beidou/skill.go
@@ -42,7 +42,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   skillHitlagStages[counter] * 60,
 		CanBeDefenseHalted: true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), skillHitmark, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), skillHitmark, skillHitmark)
 
 	//2 if no hit, 3 if 1 hit, 4 if perfect
 	c.Core.QueueParticle("beidou", 2+float64(counter), attributes.Electro, skillHitmark+c.ParticleDelay)

--- a/internal/characters/bennett/attack.go
+++ b/internal/characters/bennett/attack.go
@@ -51,7 +51,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/bennett/burst.go
+++ b/internal/characters/bennett/burst.go
@@ -46,7 +46,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Mult:       burst[c.TalentLvlBurst()],
 	}
 	const radius = 6.0
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius, false, combat.TargettableEnemy), 37, 37)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius, false, combat.TargettableEnemy, combat.TargettableGadget), 37, 37)
 
 	//apply right away
 	stats, _ := c.Stats()

--- a/internal/characters/bennett/charge.go
+++ b/internal/characters/bennett/charge.go
@@ -34,7 +34,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/bennett/skill.go
+++ b/internal/characters/bennett/skill.go
@@ -84,7 +84,7 @@ func (c *char) skillPress() action.ActionInfo {
 		Mult:               skill[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), skillPressHitmark, skillPressHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), skillPressHitmark, skillPressHitmark)
 
 	//25 % chance of 3 orbs
 	var count float64 = 2
@@ -131,7 +131,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ax,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget),
 				0,
 				0,
 			)
@@ -140,7 +140,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 	if level == 2 {
 		ai.Mult = explosion[c.TalentLvlSkill()]
 		ai.HitlagHaltFrames = 0
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), 166, 166)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), 166, 166)
 	}
 
 	//user-specified c4 variant adds an additional attack that deals 135% of the second hit
@@ -148,7 +148,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 		ai.Mult = skillHold[level-1][1][c.TalentLvlSkill()] * 1.35
 		ai.Abil = "Passion Overload (C4)"
 		ai.HitlagHaltFrames = 0.12 * 60
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), 94, 94)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), 94, 94)
 
 	}
 

--- a/internal/characters/diluc/attack.go
+++ b/internal/characters/diluc/attack.go
@@ -42,7 +42,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/diluc/burst.go
+++ b/internal/characters/diluc/burst.go
@@ -29,13 +29,13 @@ func (c *char) phoenixDMG(ai combat.AttackInfo, dot int, explode int) func() {
 		// DoT does max 7 hits + explosion, roughly every 13 frame? blows up at 210 frames
 		// DoT
 		for i := 0; i < dot; i++ {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, i*12)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 0, i*12)
 		}
 		// Explosion
 		if explode > 0 {
 			ai.Abil = "Dawn (Explode)"
 			ai.Mult = burstExplode[c.TalentLvlBurst()]
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, 98)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 98)
 		}
 	}
 }
@@ -84,7 +84,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			CanBeDefenseHalted: true,
 		}
 
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, 1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 1)
 
 		// both initial hit, DoT and explosion all have 50 durability
 		ai.Abil = "Dawn (Tick)"

--- a/internal/characters/diluc/skill.go
+++ b/internal/characters/diluc/skill.go
@@ -68,7 +68,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), hitmark, hitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), hitmark, hitmark)
 
 	var orb float64 = 1
 	if c.Core.Rand.Float64() < 0.33 {

--- a/internal/characters/fischl/burst.go
+++ b/internal/characters/fischl/burst.go
@@ -32,7 +32,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       burst[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
 
 	//check for C4 damage
 	if c.Base.Cons >= 4 {

--- a/internal/characters/fischl/burst.go
+++ b/internal/characters/fischl/burst.go
@@ -48,7 +48,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			Mult:       2.22,
 		}
 		// C4 damage always occurs before burst damage.
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), 8, 8)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), 8, 8)
 		//heal at end of animation
 		heal := c.MaxHP() * 0.2
 		c.Core.Tasks.Add(func() {

--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -39,7 +39,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		ai.Mult += 2
 	}
 	// hitmark is 5 frames after oz spawns
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), skillOzSpawn, skillOzSpawn+5)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), skillOzSpawn, skillOzSpawn+5)
 
 	// CD Delay is 18 frames, but things break if Delay > CanQueueAfter
 	// so we add 18 to the duration instead. this probably mess up CDR stuff

--- a/internal/characters/heizou/burst.go
+++ b/internal/characters/heizou/burst.go
@@ -116,5 +116,5 @@ func (c *char) irisDmg(t combat.Target) {
 		).Write("target", t.Index())
 	}
 
-	c.Core.QueueAttack(aiAbs, combat.NewCircleHit(t, 2.5, false, combat.TargettableEnemy), 0, 40) //if any of this is wrong blame Koli
+	c.Core.QueueAttack(aiAbs, combat.NewCircleHit(t, 2.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 40) //if any of this is wrong blame Koli
 }

--- a/internal/characters/hutao/attack.go
+++ b/internal/characters/hutao/attack.go
@@ -86,7 +86,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget),
 				0,
 				0,
 			)
@@ -123,7 +123,7 @@ func (c *char) ppAttack(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget),
 				0,
 				0,
 				c.ppParticles,

--- a/internal/characters/hutao/burst.go
+++ b/internal/characters/hutao/burst.go
@@ -61,7 +61,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 50,
 		Mult:       mult,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0, burstHitmark, bbcb, c.burstHealCB)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, burstHitmark, bbcb, c.burstHealCB)
 
 	c.ConsumeEnergy(68)
 	c.SetCDWithDelay(action.ActionBurst, 900, 62)

--- a/internal/characters/hutao/charge.go
+++ b/internal/characters/hutao/charge.go
@@ -53,7 +53,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 		IsDeployable:       true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy), 0, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),
@@ -80,7 +80,7 @@ func (c *char) ppChargeAttack(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 		IsDeployable:       true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy), 0, ppChargeHitmark, c.ppParticles, c.applyBB)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, ppChargeHitmark, c.ppParticles, c.applyBB)
 
 	//frames changes if previous action is normal
 	prevState := -1

--- a/internal/characters/kazuha/burst.go
+++ b/internal/characters/kazuha/burst.go
@@ -72,7 +72,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			c.Core.Tasks.Add(func() {
 				if c.qInfuse != attributes.NoElement {
 					aiAbsorb.Element = c.qInfuse
-					c.Core.QueueAttackWithSnap(aiAbsorb, snapAbsorb, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0)
+					c.Core.QueueAttackWithSnap(aiAbsorb, snapAbsorb, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0)
 				}
 				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0)
 			}, (burstFirstTick-(burstHitmark+1))+117*i)

--- a/internal/characters/kazuha/plunge.go
+++ b/internal/characters/kazuha/plunge.go
@@ -10,7 +10,7 @@ import (
 var plungePressFrames []int
 var plungeHoldFrames []int
 
-//a1 is 1 frame before this
+// a1 is 1 frame before this
 const plungePressHitmark = 36
 const plungeHoldHitmark = 41
 
@@ -103,7 +103,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 			IgnoreInfusion: true,
 		}
 
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), hitmark-1, hitmark-1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), hitmark-1, hitmark-1)
 		c.a1Ele = attributes.NoElement
 	}
 

--- a/internal/characters/keqing/attack.go
+++ b/internal/characters/keqing/attack.go
@@ -55,7 +55,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget),
 				0,
 				0,
 			)

--- a/internal/characters/keqing/burst.go
+++ b/internal/characters/keqing/burst.go
@@ -38,19 +38,19 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       burstInitial[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
 
 	//8 hits
 	ai.Abil = "Starward Sword (Consecutive Slash)"
 	ai.Mult = burstDot[c.TalentLvlBurst()]
 	for i := 82; i < 162; i += 11 {
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), i, i)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), i, i)
 	}
 
 	//final
 	ai.Abil = "Starward Sword (Last Attack)"
 	ai.Mult = burstFinal[c.TalentLvlBurst()]
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 197, 197)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 197, 197)
 
 	if c.Base.Cons >= 6 {
 		c.c6("burst")

--- a/internal/characters/keqing/charge.go
+++ b/internal/characters/keqing/charge.go
@@ -34,7 +34,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	if c.Core.Status.Duration(stilettoKey) > 0 {
@@ -53,7 +53,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 			Mult:       skillCA[c.TalentLvlSkill()],
 		}
 		for i := 0; i < 2; i++ {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), chargeHitmarks[i], chargeHitmarks[i])
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), chargeHitmarks[i], chargeHitmarks[i])
 		}
 
 		// TODO: Particle timing?

--- a/internal/characters/keqing/skill.go
+++ b/internal/characters/keqing/skill.go
@@ -52,7 +52,7 @@ func (c *char) skillFirst(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: false,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), skillHitmark, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), skillHitmark, skillHitmark)
 
 	if c.Base.Cons >= 6 {
 		c.c6("skill")
@@ -87,7 +87,7 @@ func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 		Mult:       skillPress[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), skillRecastHitmark, skillRecastHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), skillRecastHitmark, skillRecastHitmark)
 
 	//add electro infusion
 	c.a1()
@@ -110,7 +110,7 @@ func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 		}
 		// TODO: this should be 1st hit on cast and 2nd at end
 		for i := 0; i < hits; i++ {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), skillRecastHitmark, skillRecastHitmark)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), skillRecastHitmark, skillRecastHitmark)
 		}
 	}
 

--- a/internal/characters/klee/attack.go
+++ b/internal/characters/klee/attack.go
@@ -100,7 +100,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		}
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy),
+			combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget),
 			0,
 			travel,
 			c.a1,

--- a/internal/characters/klee/burst.go
+++ b/internal/characters/klee/burst.go
@@ -55,16 +55,16 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				return
 			}
 			//wave 1 = 1
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), 0)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0)
 			//wave 2 = 1 + 30% chance of 1
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), 12)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 12)
 			if c.Core.Rand.Float64() < 0.3 {
-				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), 12)
+				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 12)
 			}
 			//wave 3 = 1 + 50% chance of 1
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), 24)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 24)
 			if c.Core.Rand.Float64() < 0.5 {
-				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), 24)
+				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 24)
 			}
 		}, start)
 	}
@@ -139,7 +139,7 @@ func (c *char) onExitField() {
 				CanBeDefenseHalted: true,
 				IsDeployable:       true,
 			}
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0, 0)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 		}
 
 		return false

--- a/internal/characters/klee/charge.go
+++ b/internal/characters/klee/charge.go
@@ -60,7 +60,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	c.Core.QueueAttackWithSnap(
 		ai,
 		snap,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
 		chargeHitmark-windup+travel,
 	)
 

--- a/internal/characters/klee/cons.go
+++ b/internal/characters/klee/cons.go
@@ -31,7 +31,7 @@ func (c *char) c1(delay int) {
 		CanBeDefenseHalted: true,
 		IsDeployable:       true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, delay)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 0, delay)
 }
 
 func (c *char) c2(a combat.AttackCB) {

--- a/internal/characters/klee/skill.go
+++ b/internal/characters/klee/skill.go
@@ -120,14 +120,14 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		}
 		for i, data := range bounceAttacks {
 			c.Core.QueueAttackWithSnap(data.ai, data.snap,
-				combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
 				bounceHitmarks[i]-cooldownDelay,
 				c.a1,
 			)
 		}
 		for _, data := range mineAttacks {
 			c.Core.QueueAttackWithSnap(data.ai, data.snap,
-				combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget),
 				mineHitmark-cooldownDelay,
 				c.c2,
 			)

--- a/internal/characters/kuki/burst.go
+++ b/internal/characters/kuki/burst.go
@@ -46,7 +46,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 
 	for i := burstStart; i < count*interval+burstStart; i += interval {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), r, false, combat.TargettableEnemy), i)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), r, false, combat.TargettableEnemy, combat.TargettableGadget), i)
 	}
 
 	c.ConsumeEnergy(4)

--- a/internal/characters/kuki/cons.go
+++ b/internal/characters/kuki/cons.go
@@ -10,7 +10,9 @@ import (
 
 // C4:
 // When the Normal, Charged, or Plunging Attacks of the character affected by Shinobu's Grass Ring of Sanctification hit opponents,
-//  a Thundergrass Mark will land on the opponent's position and deal AoE Electro DMG based on 9.7% of Shinobu's Max HP.
+//
+//	a Thundergrass Mark will land on the opponent's position and deal AoE Electro DMG based on 9.7% of Shinobu's Max HP.
+//
 // This effect can occur once every 5s.
 func (c *char) c4() {
 	//TODO: idk if the damage is instant or not
@@ -48,7 +50,7 @@ func (c *char) c4() {
 		}
 
 		//Particle check is 45% for particle
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 5, 5)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 5, 5)
 		if c.Core.Rand.Float64() < .45 {
 			c.Core.QueueParticle("kuki", 1, attributes.Electro, 100) // TODO: idk the particle timing yet fml (or probability)
 		}

--- a/internal/characters/kuki/skill.go
+++ b/internal/characters/kuki/skill.go
@@ -51,7 +51,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       skill[c.TalentLvlSkill()],
 		FlatDmg:    c.Stat(attributes.EM) * 0.25,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), skillHitmark, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), skillHitmark, skillHitmark)
 
 	// C2: Grass Ring of Sanctification's duration is increased by 3s.
 	skilldur := 720
@@ -97,7 +97,7 @@ func (c *char) bellTick() func() {
 			Mult:       skilldot[c.TalentLvlSkill()],
 			FlatDmg:    c.Stat(attributes.EM) * 0.25,
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), 2, 2)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), 2, 2)
 
 		//A4 is considered here
 		c.Core.Player.Heal(player.HealInfo{

--- a/internal/characters/lisa/burst.go
+++ b/internal/characters/lisa/burst.go
@@ -33,7 +33,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Mult:       0.1,
 	}
 	//based on discussion with nosi; turns out this does not apply def shred
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 7, false, combat.TargettableEnemy), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 7, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
 
 	//duration is 15 seconds, tick every .5 sec
 	//30 zaps once every 30 frame, starting at 119

--- a/internal/characters/lisa/charge.go
+++ b/internal/characters/lisa/charge.go
@@ -60,7 +60,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 			t.SetTag(conductiveTag, count+1)
 		}
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), chargeHitmark-windup, chargeHitmark-windup, cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), chargeHitmark-windup, chargeHitmark-windup, cb)
 
 	return action.ActionInfo{
 		Frames:          func(next action.Action) int { return chargeFrames[next] - windup },

--- a/internal/characters/lisa/skill.go
+++ b/internal/characters/lisa/skill.go
@@ -35,7 +35,7 @@ func init() {
 	skillHoldFrames[action.ActionSwap] = 117
 }
 
-//p = 0 for no hold, p = 1 for hold
+// p = 0 for no hold, p = 1 for hold
 func (c *char) Skill(p map[string]int) action.ActionInfo {
 	hold := p["hold"]
 	if hold == 1 {
@@ -44,7 +44,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	return c.skillPress(p)
 }
 
-//TODO: how long do stacks last?
+// TODO: how long do stacks last?
 func (c *char) skillPress(p map[string]int) action.ActionInfo {
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -84,8 +84,8 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 	}
 }
 
-//After an extended casting time, calls down lightning from the heavens, dealing massive Electro DMG to all nearby opponents.
-//Deals great amounts of extra damage to opponents based on the number of Conductive stacks applied to them, and clears their Conductive status.
+// After an extended casting time, calls down lightning from the heavens, dealing massive Electro DMG to all nearby opponents.
+// Deals great amounts of extra damage to opponents based on the number of Conductive stacks applied to them, and clears their Conductive status.
 func (c *char) skillHold(p map[string]int) action.ActionInfo {
 	//no multiplier as that's target dependent
 	ai := combat.AttackInfo{
@@ -126,7 +126,7 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 
 	//[8:31 PM] ArchedNosi | Lisa Unleashed: yeah 4-5 50/50 with Hold
 	//[9:13 PM] ArchedNosi | Lisa Unleashed: @gimmeabreak actually wait, xd i noticed i misread my sheet, Lisa Hold E always gens 5 orbs
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), 0, skillHoldHitmark, c1cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy, combat.TargettableGadget), 0, skillHoldHitmark, c1cb)
 
 	// count := 4
 	// if c.Core.Rand.Float64() < 0.5 {

--- a/internal/characters/raiden/attack.go
+++ b/internal/characters/raiden/attack.go
@@ -119,7 +119,7 @@ func (c *char) swordAttack(p map[string]int) action.ActionInfo {
 			ai.IgnoreDefPercent = .6
 		}
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(ax, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, 0, c.burstRestorefunc, c.c6)
+			c.Core.QueueAttack(ax, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0, c.burstRestorefunc, c.c6)
 		}, swordHitmarks[c.NormalCounter][i])
 	}
 

--- a/internal/characters/raiden/burst.go
+++ b/internal/characters/raiden/burst.go
@@ -71,7 +71,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	if c.Base.Cons >= 2 {
 		ai.IgnoreDefPercent = 0.6
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
 
 	c.SetCD(action.ActionBurst, 18*60)
 	c.ConsumeEnergy(8)

--- a/internal/characters/raiden/charge.go
+++ b/internal/characters/raiden/charge.go
@@ -84,7 +84,7 @@ func (c *char) swordCharge(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget),
 				0,
 				0,
 				c.burstRestorefunc,

--- a/internal/characters/raiden/skill.go
+++ b/internal/characters/raiden/skill.go
@@ -40,7 +40,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       skill[c.TalentLvlSkill()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), skillHitmark, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), skillHitmark, skillHitmark)
 
 	// Add pre-damage mod
 	mult := skillBurstBonus[c.TalentLvlSkill()]
@@ -73,10 +73,12 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 }
 
-/**
+/*
+*
 When characters with this buff attack and hit opponents, the Eye will unleash a coordinated attack, dealing AoE Electro DMG at the opponent's position.
 The Eye can initiate one coordinated attack every 0.9s per party.
-**/
+*
+*/
 func (c *char) eyeOnDamage() {
 	c.Core.Events.Subscribe(event.OnDamage, func(args ...interface{}) bool {
 		ae := args[1].(*combat.AttackEvent)
@@ -120,7 +122,7 @@ func (c *char) eyeOnDamage() {
 		if c.Base.Cons >= 2 && c.StatusIsActive(burstKey) {
 			ai.IgnoreDefPercent = 0.6
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 5, 5)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 5, 5)
 
 		c.eyeICD = c.Core.F + 54 //0.9 sec icd
 		return false

--- a/internal/characters/razor/attack.go
+++ b/internal/characters/razor/attack.go
@@ -42,7 +42,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/razor/burst.go
+++ b/internal/characters/razor/burst.go
@@ -44,7 +44,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
 		burstHitmark,
 		burstHitmark,
 	)
@@ -103,7 +103,7 @@ func (c *char) wolfBurst() {
 
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy),
+			combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget),
 			1,
 			1,
 		)

--- a/internal/characters/razor/cons.go
+++ b/internal/characters/razor/cons.go
@@ -96,7 +96,7 @@ func (c *char) c6() {
 		}
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy),
+			combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget),
 			1,
 			1,
 		)

--- a/internal/characters/razor/skill.go
+++ b/internal/characters/razor/skill.go
@@ -91,7 +91,7 @@ func (c *char) SkillPress(burstActive int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
 		skillPressHitmarks[burstActive],
 		skillPressHitmarks[burstActive],
 		c4cb,
@@ -128,7 +128,7 @@ func (c *char) SkillHold(burstActive int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget),
 		skillHoldHitmarks[burstActive],
 		skillHoldHitmarks[burstActive],
 	)

--- a/internal/characters/sara/aimed.go
+++ b/internal/characters/sara/aimed.go
@@ -85,7 +85,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		//TODO: snapshot?
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+			combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
 			aimedHitmarks[skillActive],
 			aimedHitmarks[skillActive]+travel+90,
 			c.a4,

--- a/internal/characters/sara/burst.go
+++ b/internal/characters/sara/burst.go
@@ -74,7 +74,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	if waveClusterHits%10 == 1 {
 		// Actual hit procs after the full cast duration, or 50 frames
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), burstStart, burstInitialHitmark, c1cb)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), burstStart, burstInitialHitmark, c1cb)
 	}
 	if waveAttackProcs%10 == 1 {
 		c.attackBuff(burstInitialHitmark)
@@ -93,7 +93,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		waveAttackProc := int((waveAttackProcs % PowInt(10, waveN+2)) / PowInt(10, waveN+2-1))
 		if waveHits > 0 {
 			for j := 0; j < waveHits; j++ {
-				c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), burstStart, burstClusterHitmark+18*waveN, c1cb)
+				c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), burstStart, burstClusterHitmark+18*waveN, c1cb)
 			}
 		}
 		if waveAttackProc == 1 {

--- a/internal/characters/sara/skill.go
+++ b/internal/characters/sara/skill.go
@@ -50,7 +50,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			Mult:       0.3 * skill[c.TalentLvlSkill()],
 		}
 		// TODO: not sure of snapshot? timing
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 50, c2Hitmark, c.a4)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 50, c2Hitmark, c.a4)
 		c.attackBuff(c2Hitmark)
 	}
 

--- a/internal/characters/sayu/skill.go
+++ b/internal/characters/sayu/skill.go
@@ -295,7 +295,7 @@ func (c *char) rollAbsorb() {
 				Durability: 25,
 				Mult:       skillAbsorb[c.TalentLvlSkill()],
 			}
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), 1, 1)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), 1, 1)
 		case combat.AttackTagElementalArtHold:
 			// Kick Elemental DMG
 			ai := combat.AttackInfo{
@@ -308,7 +308,7 @@ func (c *char) rollAbsorb() {
 				Durability: 25,
 				Mult:       skillAbsorbEnd[c.TalentLvlSkill()],
 			}
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), 1, 1)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), 1, 1)
 		}
 
 		return false

--- a/internal/characters/sucrose/burst.go
+++ b/internal/characters/sucrose/burst.go
@@ -69,12 +69,12 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 
 	for i := 137; i <= duration+5; i += 113 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy), i, cb)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), i, cb)
 
 		c.Core.Tasks.Add(func() {
 			if c.qInfused != attributes.NoElement {
 				aiAbs.Element = c.qInfused
-				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy), 0)
+				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0)
 			}
 			//check if infused
 		}, i)

--- a/internal/characters/thoma/burst.go
+++ b/internal/characters/thoma/burst.go
@@ -42,7 +42,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// damage component not final
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
 		burstHitmark,
 		burstHitmark,
 	)
@@ -153,6 +153,6 @@ func (c *char) summonFieryCollapse() {
 		c.genShield("Thoma Burst", shieldamt, true)
 		done = true
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy), 0, 11, shieldCb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 11, shieldCb)
 	c.AddStatus(burstICDKey, 60, true)
 }

--- a/internal/characters/thoma/skill.go
+++ b/internal/characters/thoma/skill.go
@@ -53,7 +53,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	// damage component not final
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
 		skillHitmark,
 		skillHitmark,
 	)

--- a/internal/characters/traveleranemo/burst.go
+++ b/internal/characters/traveleranemo/burst.go
@@ -78,7 +78,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				if c.Base.Cons >= 6 {
 					cbAbs = c6cb(c.qInfuse)
 				}
-				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0, cbAbs)
+				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, cbAbs)
 			}
 			//check if infused
 		}, 94+30*i)

--- a/internal/characters/traveleranemo/skill.go
+++ b/internal/characters/traveleranemo/skill.go
@@ -108,7 +108,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 				if c.eInfuse != attributes.NoElement {
 					aiMaxCutAbs.Element = c.eInfuse
 					aiMaxCutAbs.ICDTag = c.eICDTag
-					c.Core.QueueAttack(aiMaxCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), 0, 0)
+					c.Core.QueueAttack(aiMaxCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 				}
 				//check if infused
 			}, hitmark)
@@ -117,7 +117,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 				if c.eInfuse != attributes.NoElement {
 					aiCutAbs.Element = c.eInfuse
 					aiCutAbs.ICDTag = c.eICDTag
-					c.Core.QueueAttack(aiCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), 0, 0)
+					c.Core.QueueAttack(aiCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 				}
 				//check if infused
 			}, hitmark)
@@ -177,7 +177,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 		if c.eInfuse != attributes.NoElement {
 			aiStormAbs.Element = c.eInfuse
 			aiStormAbs.ICDTag = c.eICDTag
-			c.Core.QueueAttack(aiStormAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy), 0, 0)
+			c.Core.QueueAttack(aiStormAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 		}
 		//check if infused
 	}, hitmark)

--- a/internal/characters/travelerelectro/burst.go
+++ b/internal/characters/travelerelectro/burst.go
@@ -30,10 +30,12 @@ func init() {
 	burstFrames[1][action.ActionSwap] = 61    // Q -> Swap
 }
 
-/**
+/*
+*
 [12:01 PM] pai: never tried to measure it but emc burst looks like it has roughly 1~1.5 abyss tile of range, skill goes a bit further i think
 [12:01 PM] pai: the 3 hits from the skill also like split out and kind of auto target if that's useful information
-**/
+*
+*/
 func (c *char) Burst(p map[string]int) action.ActionInfo {
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -47,7 +49,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Mult:       burst[c.TalentLvlBurst()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), 0, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, burstHitmark)
 
 	c.SetCDWithDelay(action.ActionBurst, 1200, 35)
 	c.ConsumeEnergy(37)
@@ -113,7 +115,7 @@ func (c *char) burstProc() {
 		atk := *c.burstAtk
 		atk.SourceFrame = c.Core.F
 		//attack is 2 (or 2.5 for enhanced) aoe centered on target
-		atk.Pattern = combat.NewCircleHit(t, 2, false, combat.TargettableEnemy)
+		atk.Pattern = combat.NewCircleHit(t, 2, false, combat.TargettableEnemy, combat.TargettableGadget)
 
 		// C2 - Violet Vehemence
 		// When Falling Thunder created by Bellowing Thunder hits an opponent, it will decrease their Electro RES by 15% for 8s.

--- a/internal/characters/travelerelectro/skill.go
+++ b/internal/characters/travelerelectro/skill.go
@@ -99,7 +99,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 
 	for i := 0; i < hits; i++ {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 0.3, false, combat.TargettableEnemy), skillHitmark, particlesCB, amuletCB)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 0.3, false, combat.TargettableEnemy, combat.TargettableGadget), skillHitmark, particlesCB, amuletCB)
 	}
 
 	// try to pick up amulets

--- a/internal/characters/venti/burst.go
+++ b/internal/characters/venti/burst.go
@@ -83,7 +83,7 @@ func (c *char) burstInfusedTicks() {
 
 	// ticks at 24f. 15 total
 	for i := 0; i < 15; i++ {
-		c.Core.QueueAttackWithSnap(c.aiAbsorb, c.snapAbsorb, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4, false, combat.TargettableEnemy), i*24, cb)
+		c.Core.QueueAttackWithSnap(c.aiAbsorb, c.snapAbsorb, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4, false, combat.TargettableEnemy, combat.TargettableGadget), i*24, cb)
 	}
 }
 

--- a/internal/characters/xiangling/attack.go
+++ b/internal/characters/xiangling/attack.go
@@ -72,7 +72,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			Mult:       .75,
 		}
 		//TODO: explosion frames
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), 120, 120)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), 120, 120)
 	}
 
 	defer c.AdvanceNormalIndex()

--- a/internal/characters/xiangling/burst.go
+++ b/internal/characters/xiangling/burst.go
@@ -33,7 +33,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			Mult:               pyronadoInitial[i][c.TalentLvlBurst()],
 		}
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(initialHit, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy), 0, 0)
+			c.Core.QueueAttack(initialHit, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 		}, burstHitmarks[i])
 	}
 
@@ -61,7 +61,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		}
 		c.Core.Status.Add("xianglingburst", max)
 		for delay := 0; delay <= max; delay += 73 { //first hit on same frame as 3rd initial hit
-			c.Core.QueueAttack(burstHit, combat.NewCircleHit(c.Core.Combat.Player(), 2.5, false, combat.TargettableEnemy), 0, delay)
+			c.Core.QueueAttack(burstHit, combat.NewCircleHit(c.Core.Combat.Player(), 2.5, false, combat.TargettableEnemy, combat.TargettableGadget), 0, delay)
 		}
 		//add an effect starting at frame 55 to end of duration to increase pyro dmg by 15% if c6
 		if c.Base.Cons >= 6 {

--- a/internal/characters/xiangling/guoba.go
+++ b/internal/characters/xiangling/guoba.go
@@ -69,7 +69,7 @@ func (p *panda) breath() {
 	p.Core.QueueAttackWithSnap(
 		p.ai,
 		p.snap,
-		combat.NewCircleHit(p, 0.5, false, combat.TargettableEnemy),
+		combat.NewCircleHit(p, 0.5, false, combat.TargettableEnemy, combat.TargettableGadget),
 		10,
 		p.c.c1,
 		part,

--- a/internal/characters/xinyan/burst.go
+++ b/internal/characters/xinyan/burst.go
@@ -47,12 +47,12 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 	// 1st DoT
 	c.QueueCharTask(func() {
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), 0, 0)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 0)
 		ai.CanBeDefenseHalted = false // only the first DoT has hitlag
 		// 2nd DoT onwards
 		c.QueueCharTask(func() {
 			for i := 0; i < 6; i++ {
-				c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), i*17, i*17)
+				c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy, combat.TargettableGadget), i*17, i*17)
 			}
 		}, 17)
 	}, burstDoT1Hitmark)

--- a/internal/characters/xinyan/skill.go
+++ b/internal/characters/xinyan/skill.go
@@ -59,7 +59,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			c.updateShield(1, defFactor)
 		}, skillShieldStart)
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy), skillHitmark, skillHitmark, cb, c.c4)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget), skillHitmark, skillHitmark, cb, c.c4)
 
 	c.SetCDWithDelay(action.ActionSkill, 18*60, 13)
 	c.Core.QueueParticle("xinyan", 4, attributes.Pyro, skillHitmark+c.ParticleDelay)
@@ -94,7 +94,7 @@ func (c *char) shieldDot(src int) func() {
 			Durability: 25,
 			Mult:       skillDot[c.TalentLvlSkill()],
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 1, 1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 1, 1)
 
 		c.Core.Tasks.Add(c.shieldDot(src), 2*60)
 	}

--- a/internal/characters/yaemiko/burst.go
+++ b/internal/characters/yaemiko/burst.go
@@ -37,7 +37,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	ai.Abil = "Tenko Thunderbolt"
 	ai.Mult = burst[1][c.TalentLvlBurst()]
-	c.kitsuneBurst(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy))
+	c.kitsuneBurst(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget))
 
 	c.ConsumeEnergy(2)
 	c.SetCD(action.ActionBurst, 22*60)

--- a/internal/characters/yaemiko/charge.go
+++ b/internal/characters/yaemiko/charge.go
@@ -43,7 +43,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	// TODO: check snapshot delay
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.3, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 0.3, false, combat.TargettableEnemy, combat.TargettableGadget),
 		0,
 		chargeHitmark-windup,
 	)

--- a/internal/characters/yanfei/asc.go
+++ b/internal/characters/yanfei/asc.go
@@ -55,7 +55,7 @@ func (c *char) a4() {
 			HitlagFactor:       0.05,
 			CanBeDefenseHalted: defhalt,
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy), 10, 10)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), 10, 10)
 
 		return false
 	}, "yanfei-a4")

--- a/internal/characters/yanfei/attack.go
+++ b/internal/characters/yanfei/attack.go
@@ -69,7 +69,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 		addSeal,

--- a/internal/characters/yanfei/burst.go
+++ b/internal/characters/yanfei/burst.go
@@ -71,7 +71,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, burstHitmark, addSeal)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 0, burstHitmark, addSeal)
 
 	c.Core.Tasks.Add(c.burstAddSealHook(), 60)
 

--- a/internal/characters/yanfei/charge.go
+++ b/internal/characters/yanfei/charge.go
@@ -52,7 +52,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	}
 
 	// TODO: Not sure of snapshot timing
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), chargeHitmark-windup, chargeHitmark-windup)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), chargeHitmark-windup, chargeHitmark-windup)
 
 	c.Core.Log.NewEvent("yanfei charge attack consumed seals", glog.LogCharacterEvent, c.Index).
 		Write("current_seals", c.sealCount)

--- a/internal/characters/yanfei/skill.go
+++ b/internal/characters/yanfei/skill.go
@@ -51,7 +51,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       skill[c.TalentLvlSkill()],
 	}
 	// TODO: Not sure of snapshot timing
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, skillHitmark, addSeal)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget), 0, skillHitmark, addSeal)
 
 	c.Core.QueueParticle("yanfei", 3, attributes.Pyro, skillHitmark+c.ParticleDelay)
 

--- a/internal/characters/yoimiya/burst.go
+++ b/internal/characters/yoimiya/burst.go
@@ -40,7 +40,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget),
 		0,
 		burstHitmark,
 		c.applyAB, // callback to apply Aurous Blaze
@@ -128,7 +128,7 @@ func (c *char) burstHook() {
 			Durability: 25,
 			Mult:       burstExplode[c.TalentLvlBurst()],
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy), 0, 1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3, false, combat.TargettableEnemy, combat.TargettableGadget), 0, 1)
 
 		trg.AddStatus(abIcdKey, 120, true) // trigger Aurous Blaze ICD
 

--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -90,6 +90,7 @@ func (r *Reactable) newDendroCore(a *combat.AttackEvent) *dendroCore {
 		r.core.QueueAttack(ai, combat.NewCircleHit(s.Gadget, 5, false, combat.TargettableEnemy), -1, 1)
 
 		// queue self damage
+		ai.Abil += " (self damage)"
 		ai.FlatDmg = 0.05 * ai.FlatDmg
 		r.core.QueueAttack(ai, combat.NewCircleHit(s.Gadget, 5, true, combat.TargettablePlayer), -1, 1)
 	}
@@ -124,6 +125,7 @@ func (s *dendroCore) Attack(atk *combat.AttackEvent, evt glog.Event) (float64, b
 			s.Core.QueueAttack(ai, combat.NewCircleHit(s.Core.Combat.Enemy(enemies[0]), 1, false, combat.TargettableEnemy), -1, 5)
 
 			// also queue self damage
+			ai.Abil += " (self damage)"
 			ai.FlatDmg = 0.05 * ai.FlatDmg
 			s.Core.QueueAttack(ai, combat.NewCircleHit(s.Core.Combat.Enemy(enemies[0]), 1, true, combat.TargettablePlayer), -1, 5)
 		}
@@ -140,6 +142,7 @@ func (s *dendroCore) Attack(atk *combat.AttackEvent, evt glog.Event) (float64, b
 		s.Core.QueueAttack(ai, combat.NewCircleHit(s.Gadget, 5, false, combat.TargettableEnemy), -1, 1)
 
 		// queue self damage
+		ai.Abil += " (self damage)"
 		ai.FlatDmg = 0.05 * ai.FlatDmg
 		s.Core.QueueAttack(ai, combat.NewCircleHit(s.Gadget, 5, true, combat.TargettablePlayer), -1, 1)
 

--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -1,9 +1,11 @@
 package reactable
 
 import (
+	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/gadget"
 )
 
@@ -35,28 +37,153 @@ func (r *Reactable) tryBloom(a *combat.AttackEvent) {
 			return
 		}
 		consumed = r.reduce(attributes.Hydro, a.Info.Durability, 2)
-	case attributes.Quicken:
-		//TODO: ?? how to handle this??
-		if r.Durability[ModifierHydro] < ZeroDur {
-			return
-		}
-		consumed = r.reduce(attributes.Quicken, a.Info.Durability, 2)
+		// case attributes.Quicken:
+		// 	//TODO: ?? how to handle this??
+		// 	if r.Durability[ModifierHydro] < ZeroDur {
+		// 		return
+		// 	}
+		// 	consumed = r.reduce(attributes.Quicken, a.Info.Durability, 2)
 	}
 	a.Info.Durability -= consumed
 	a.Info.Durability = max(a.Info.Durability, 0)
 	a.Reacted = true
 
+	r.addBloomGadget(a)
+
 	r.core.Events.Emit(event.OnBloom, r.self, a)
+
+	// check if quicken added, and quicken gonna self-react with hydro if there's any hydro left
+	if r.Durability[ModifierQuicken] >= ZeroDur && r.Durability[ModifierHydro] >= ZeroDur {
+		hydroConsumed := r.reduce(attributes.Quicken, r.Durability[ModifierHydro], 0.5)
+		r.Durability[ModifierHydro] -= hydroConsumed
+		r.Durability[ModifierHydro] = max(r.Durability[ModifierHydro], 0)
+
+		r.addBloomGadget(a)
+
+		r.core.Events.Emit(event.OnBloom, r.self, a)
+	}
 }
 
-func (r *Reactable) tryHyperbloom(a *combat.AttackEvent) {
+// guess we don't need them
+// func (r *Reactable) tryHyperbloom(a *combat.AttackEvent) {
+// }
 
-}
-
-func (r *Reactable) tryBurgeon(a *combat.AttackEvent) {
-
-}
+// func (r *Reactable) tryBurgeon(a *combat.AttackEvent) {
+// }
 
 type dendroCore struct {
 	*gadget.Gadget
+	reactable *Reactable
+	reacted   bool // sanity check
 }
+
+func (r *Reactable) addBloomGadget(a *combat.AttackEvent) {
+	s := r.newDendroCore(a)
+	r.core.Combat.AddGadget(s)
+	// r.core.Combat.Log.NewEvent("bloom created", glog.LogElementEvent, a.Info.ActorIndex)
+}
+
+func (r *Reactable) newDendroCore(a *combat.AttackEvent) *dendroCore {
+	s := &dendroCore{
+		reactable: r,
+		reacted:   false,
+	}
+
+	x, y := r.self.Pos()
+	// for simplicity, seeds spawn randomly within 1 radius of target
+	x = x + r.core.Rand.Float64()
+	y = y + r.core.Rand.Float64()
+	s.Gadget = gadget.New(r.core, core.Coord{X: x, Y: y, R: 0.2})
+	s.Gadget.Duration = 300 // spawning time??
+	s.Gadget.OnRemoved = func() {
+		if !s.reacted {
+			s.reacted = true
+			atk := combat.AttackInfo{
+				ActorIndex:       a.Info.ActorIndex,
+				DamageSrc:        r.self.Key(),
+				Abil:             string(combat.Bloom),
+				AttackTag:        combat.AttackTagBloom,
+				ICDTag:           combat.ICDTagBloomDamage,
+				ICDGroup:         combat.ICDGroupReactionA,
+				Element:          attributes.Dendro,
+				Durability:       0,
+				IgnoreDefPercent: 1,
+			}
+			em := r.core.Player.ByIndex(a.Info.ActorIndex).Stat(attributes.EM)
+			atk.FlatDmg = 2.0 * r.calcReactionDmg(atk, em)
+
+			// self harm not active for now
+			r.core.QueueAttack(atk, combat.NewCircleHit(s, 5, false, combat.TargettableEnemy), -1, 1)
+		}
+	}
+
+	return s
+}
+
+func (s *dendroCore) Tick() {
+	//this is needed since gadget tick
+	s.Gadget.Tick()
+}
+
+func (s *dendroCore) Type() combat.TargettableType { return combat.TargettableGadget }
+
+func (s *dendroCore) Attack(atk *combat.AttackEvent, evt glog.Event) (float64, bool) {
+	if atk.Info.Durability < ZeroDur {
+		return 0, false
+	}
+
+	ai := combat.AttackInfo{
+		ActorIndex:       atk.Info.ActorIndex,
+		DamageSrc:        s.Key(),
+		Element:          attributes.Dendro,
+		IgnoreDefPercent: 1,
+	}
+	em := s.Core.Player.ByIndex(atk.Info.ActorIndex).Stat(attributes.EM)
+	ai.FlatDmg = 3 * s.reactable.calcReactionDmg(ai, em)
+
+	// only contact with pyro/electro to trigger burgeon/hyperbloom accordingly
+	switch atk.Info.Element {
+	case attributes.Electro:
+		// trigger hyperbloom targets the nearest enemy
+		// it can also do damage to player in small aoe
+		ai.AttackTag = combat.AttackTagHyperbloom
+		ai.ICDTag = combat.ICDTagHyperbloomDamage
+		ai.ICDGroup = combat.ICDGroupReactionA   // ??
+		ai.StrikeType = combat.StrikeTypeDefault // doesn't sound like a blunt to me
+		ai.Abil = string(combat.Hyperbloom)
+		s.reacted = true
+
+		// queue dmg nearest enemy
+		if len(s.Core.Combat.Enemies()) <= 1 {
+			s.Core.QueueAttack(ai, combat.NewDefSingleTarget(s.Core.Combat.DefaultTarget, combat.TargettableEnemy), -1, 5)
+		} else {
+			x, y := s.Pos()
+			nearest := s.Core.Combat.EnemyByDistance(x, y, s.Index())[0]
+			s.Core.QueueAttack(ai, combat.NewDefSingleTarget(nearest, combat.TargettableEnemy), -1, 5)
+		}
+
+		s.Core.Combat.RemoveGadget(s.Gadget.Index())
+		s.Core.Events.Emit(event.OnHyperbloom, s, atk)
+		// s.Core.Combat.Log.NewEvent("hyperbloom triggered", glog.LogElementEvent, atk.Info.ActorIndex)
+	case attributes.Pyro:
+		// trigger burgeon, aoe dendro damage
+		// self damage
+		ai.AttackTag = combat.AttackTagBurgeon
+		ai.ICDTag = combat.ICDTagBurgeonDamage
+		ai.ICDGroup = combat.ICDGroupReactionA // ??
+		ai.StrikeType = combat.StrikeTypeBlunt // blunt ig
+		ai.Abil = string(combat.Burgeon)
+		s.reacted = true
+
+		// self harm not active for now
+		s.Core.QueueAttack(ai, combat.NewCircleHit(s, 5, false, combat.TargettableEnemy), -1, 1)
+		s.Core.Combat.RemoveGadget(s.Gadget.Index())
+		s.Core.Events.Emit(event.OnBurgeon, s, atk)
+	default:
+		return 0, false
+	}
+
+	return 0, false
+}
+
+func (s *dendroCore) ApplyDamage(*combat.AttackEvent, float64) {}

--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -37,6 +37,8 @@ func (r *Reactable) tryBloom(a *combat.AttackEvent) {
 			return
 		}
 		consumed = r.reduce(attributes.Hydro, a.Info.Durability, 2)
+	default:
+		return
 	}
 	a.Info.Durability -= consumed
 	a.Info.Durability = max(a.Info.Durability, 0)
@@ -60,7 +62,7 @@ func (r *Reactable) tryBloom(a *combat.AttackEvent) {
 
 type dendroCore struct {
 	*gadget.Gadget
-	reactable *Reactable
+	reactable *Reactable // for func calcReactionDmg
 }
 
 func (r *Reactable) addBloomGadget(a *combat.AttackEvent) {

--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -44,18 +44,22 @@ func (r *Reactable) tryBloom(a *combat.AttackEvent) {
 	a.Info.Durability = max(a.Info.Durability, 0)
 	a.Reacted = true
 
-	// should add delay for spawning time maybe?
-	r.addBloomGadget(a)
+	// TODO: re-check the frame delay
+	r.core.Tasks.Add(func() {
+		r.addBloomGadget(a)
+	}, 45)
 	r.core.Events.Emit(event.OnBloom, r.self, a)
 
-	// check if quicken just added, then quicken gonna self-react with hydro if there's any hydro left
+	// if quicken just added, then quicken gonna self-react with hydro if there's any hydro left
 	if r.Durability[ModifierQuicken] >= ZeroDur && r.Durability[ModifierHydro] >= ZeroDur {
 		hydroConsumed := r.reduce(attributes.Quicken, r.Durability[ModifierHydro], 0.5)
 		r.Durability[ModifierHydro] -= hydroConsumed
 		r.Durability[ModifierHydro] = max(r.Durability[ModifierHydro], 0)
 
-		// same as above
-		r.addBloomGadget(a)
+		// TODO: re-check the frame delay
+		r.core.Tasks.Add(func() {
+			r.addBloomGadget(a)
+		}, 45)
 		r.core.Events.Emit(event.OnBloom, r.self, a)
 	}
 }

--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -50,7 +50,11 @@ func (r *Reactable) tryBloom(a *combat.AttackEvent) {
 	}, 45)
 	r.core.Events.Emit(event.OnBloom, r.self, a)
 
-	// if quicken just added, then quicken gonna self-react with hydro if there's any hydro left
+	r.checkQuickenBloom(a)
+}
+
+// if quicken just added, then quicken gonna self-react with hydro if there's any hydro left
+func (r *Reactable) checkQuickenBloom(a *combat.AttackEvent) {
 	if r.Durability[ModifierQuicken] >= ZeroDur && r.Durability[ModifierHydro] >= ZeroDur {
 		hydroConsumed := r.reduce(attributes.Quicken, r.Durability[ModifierHydro], 0.5)
 		r.Durability[ModifierHydro] -= hydroConsumed

--- a/pkg/reactable/bloom_test.go
+++ b/pkg/reactable/bloom_test.go
@@ -26,7 +26,9 @@ func TestHydroBloom(t *testing.T) {
 	}
 	trg.React(next)
 	// should create a seed, explodes after 5s
-	advanceCoreFrame(c)
+	for i := 0; i < 46; i++ {
+		advanceCoreFrame(c)
+	}
 
 	if c.Combat.GadgetCount() != 1 {
 		t.Errorf("expected created a gadget (bloom), got %v", c.Combat.GadgetCount())
@@ -58,7 +60,9 @@ func TestDendroBloom(t *testing.T) {
 	}
 	trg.React(next)
 	// should create a seed, explodes after 5s
-	advanceCoreFrame(c)
+	for i := 0; i < 46; i++ {
+		advanceCoreFrame(c)
+	}
 
 	if c.Combat.GadgetCount() != 1 {
 		t.Errorf("expected created a gadget (bloom), got %v", c.Combat.GadgetCount())
@@ -102,6 +106,9 @@ func TestECBloom(t *testing.T) {
 		},
 	}
 	trg.React(next)
+	for i := 0; i < 46; i++ {
+		advanceCoreFrame(c)
+	}
 
 	// t.Logf("active auras %v", trg.ActiveAuraString())
 	if c.Combat.GadgetCount() != 2 {

--- a/pkg/reactable/bloom_test.go
+++ b/pkg/reactable/bloom_test.go
@@ -28,7 +28,7 @@ func TestHydroBloom(t *testing.T) {
 	// should create a seed, explodes after 5s
 	advanceCoreFrame(c)
 
-	if !(c.Combat.GadgetCount() == 1) {
+	if c.Combat.GadgetCount() != 1 {
 		t.Errorf("expected created a gadget (bloom), got %v", c.Combat.GadgetCount())
 	}
 	if !next.Reacted {
@@ -60,7 +60,7 @@ func TestDendroBloom(t *testing.T) {
 	// should create a seed, explodes after 5s
 	advanceCoreFrame(c)
 
-	if !(c.Combat.GadgetCount() == 1) {
+	if c.Combat.GadgetCount() != 1 {
 		t.Errorf("expected created a gadget (bloom), got %v", c.Combat.GadgetCount())
 	}
 	if !next.Reacted {
@@ -104,7 +104,7 @@ func TestECBloom(t *testing.T) {
 	trg.React(next)
 
 	// t.Logf("active auras %v", trg.ActiveAuraString())
-	if !(c.Combat.GadgetCount() == 2) {
+	if c.Combat.GadgetCount() != 2 {
 		t.Errorf("expected created 2 blooms, got %v", c.Combat.GadgetCount())
 	}
 }

--- a/pkg/reactable/bloom_test.go
+++ b/pkg/reactable/bloom_test.go
@@ -1,0 +1,110 @@
+package reactable
+
+import (
+	"testing"
+
+	"github.com/genshinsim/gcsim/pkg/core/attributes"
+	"github.com/genshinsim/gcsim/pkg/core/combat"
+)
+
+func TestHydroBloom(t *testing.T) {
+	c := testCore()
+	trg := addTargetToCore(c)
+	c.Init()
+
+	trg.AttachOrRefill(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Dendro,
+			Durability: 25,
+		},
+	})
+	next := &combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Hydro,
+			Durability: 50,
+		},
+	}
+	trg.React(next)
+	// should create a seed, explodes after 5s
+	advanceCoreFrame(c)
+
+	if !(c.Combat.GadgetCount() == 1) {
+		t.Errorf("expected created a gadget (bloom), got %v", c.Combat.GadgetCount())
+	}
+	if !next.Reacted {
+		t.Errorf("expected reacted to be true, got %v", next.Reacted)
+	}
+	if trg.AuraContains(attributes.Hydro, attributes.Dendro) {
+		t.Error("expecting target to not contain any remaining hydro or dendro aura")
+	}
+}
+
+func TestDendroBloom(t *testing.T) {
+	c := testCore()
+	trg := addTargetToCore(c)
+	c.Init()
+
+	trg.AttachOrRefill(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Hydro,
+			Durability: 50,
+		},
+	})
+	next := &combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Dendro,
+			Durability: 25,
+		},
+	}
+	trg.React(next)
+	// should create a seed, explodes after 5s
+	advanceCoreFrame(c)
+
+	if !(c.Combat.GadgetCount() == 1) {
+		t.Errorf("expected created a gadget (bloom), got %v", c.Combat.GadgetCount())
+	}
+	if !next.Reacted {
+		t.Errorf("expected reacted to be true, got %v", next.Reacted)
+	}
+	if trg.AuraContains(attributes.Hydro, attributes.Dendro) {
+		t.Error("expecting target to not contain any remaining hydro or dendro aura")
+	}
+}
+
+// testing if it could create 2 seeds with dendro -> ec
+func TestECBloom(t *testing.T) {
+	c := testCore()
+	trg := addTargetToCore(c)
+	c.Init()
+
+	trg.AttachOrRefill(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Hydro,
+			Durability: 25,
+		},
+	})
+	trg.React(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Electro,
+			Durability: 25,
+		},
+	})
+	// reduce a bit ec aura
+	for i := 0; i < 10; i++ {
+		advanceCoreFrame(c)
+	}
+
+	// dendro -> ec
+	next := &combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Dendro,
+			Durability: 25,
+		},
+	}
+	trg.React(next)
+
+	// t.Logf("active auras %v", trg.ActiveAuraString())
+	if !(c.Combat.GadgetCount() == 2) {
+		t.Errorf("expected created 2 blooms, got %v", c.Combat.GadgetCount())
+	}
+}

--- a/pkg/reactable/burgeon_test.go
+++ b/pkg/reactable/burgeon_test.go
@@ -57,8 +57,11 @@ func TestBurgeon(t *testing.T) {
 	if src == nil {
 		t.Error("should get one Burgeon")
 	}
+	if src.Info.FlatDmg == 0 {
+		t.Error("expected FlatDmg not to be 0")
+	}
 	if c.Combat.GadgetCount() != 0 {
-		t.Logf("gadget should be removed, got %v", c.Combat.GadgetCount())
+		t.Errorf("gadget should be removed, got %v", c.Combat.GadgetCount())
 	}
 }
 
@@ -98,10 +101,10 @@ func TestECBurgeon(t *testing.T) {
 		t.Errorf("expected 2 blooms, got %v", c.Combat.GadgetCount())
 	}
 
-	var count int = 0
+	var count []*combat.AttackEvent = []*combat.AttackEvent{}
 	trg.onDmgCallBack = func(ae *combat.AttackEvent) (float64, bool) {
 		if ae.Info.Abil == "Burgeon" {
-			count++
+			count = append(count, ae)
 		}
 		return 0, false
 	}
@@ -122,7 +125,12 @@ func TestECBurgeon(t *testing.T) {
 	if c.Combat.GadgetCount() != 0 {
 		t.Errorf("expected blooms wiped, still got %v", c.Combat.GadgetCount())
 	}
-	if count != 2 {
+	if len(count) != 2 {
 		t.Errorf("Expected 2 Burgeons, got %v", count)
+	}
+	for _, v := range count {
+		if v.Info.FlatDmg == 0 {
+			t.Error("expected FlatDmg not to be 0")
+		}
 	}
 }

--- a/pkg/reactable/burgeon_test.go
+++ b/pkg/reactable/burgeon_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-// test hyperbloom interacts with a seed
-func TestHyperBloom(t *testing.T) {
+// test burgeon
+func TestBurgeon(t *testing.T) {
 	c := testCore()
 	trg2 := addTargetToCore(c)
 	trg1 := addTargetToCore(c)
@@ -18,7 +18,7 @@ func TestHyperBloom(t *testing.T) {
 
 	var src *combat.AttackEvent
 	trg1.onDmgCallBack = func(atk *combat.AttackEvent) (float64, bool) {
-		if atk.Info.Abil == "Hyperbloom" {
+		if atk.Info.Abil == "Burgeon" {
 			src = atk
 		}
 		return 0, false
@@ -41,10 +41,10 @@ func TestHyperBloom(t *testing.T) {
 		advanceCoreFrame(c)
 	}
 
-	// summon aoe electro to proc hyperbloom nearby trg1
+	// queue aoe pyro to proc burgeon
 	ae := &combat.AttackEvent{
 		Info: combat.AttackInfo{
-			Element:    attributes.Electro,
+			Element:    attributes.Pyro,
 			Durability: 25,
 		},
 	}
@@ -53,17 +53,17 @@ func TestHyperBloom(t *testing.T) {
 		advanceCoreFrame(c)
 	}
 
-	// trg1 should get hyperbloom damage
+	// trg1 should get Burgeon damage
 	if src == nil {
-		t.Error("should get one Hyperbloom")
+		t.Error("should get one Burgeon")
 	}
 	if c.Combat.GadgetCount() != 0 {
 		t.Logf("gadget should be removed, got %v", c.Combat.GadgetCount())
 	}
 }
 
-// hyperbloom with 2 seeds
-func TestECHyperBloom(t *testing.T) {
+// Burgeon with 2 seeds
+func TestECBurgeon(t *testing.T) {
 	c := testCore()
 	trg := addTargetToCore(c)
 	c.Init()
@@ -100,17 +100,17 @@ func TestECHyperBloom(t *testing.T) {
 
 	var count int = 0
 	trg.onDmgCallBack = func(ae *combat.AttackEvent) (float64, bool) {
-		if ae.Info.Abil == "Hyperbloom" {
+		if ae.Info.Abil == "Burgeon" {
 			count++
 		}
 		return 0, false
 	}
 
-	// queue an aoe electro to proc 2 hyperblooms
+	// queue an aoe pyro to proc 2 Burgeons
 	ae := &combat.AttackEvent{
 		Info: combat.AttackInfo{
-			Element:    attributes.Electro,
-			Durability: 50,
+			Element:    attributes.Pyro,
+			Durability: 25,
 		},
 	}
 	c.QueueAttack(ae.Info, combat.NewCircleHit(trg.self, 10, true, combat.TargettableGadget), -1, 1)
@@ -123,6 +123,6 @@ func TestECHyperBloom(t *testing.T) {
 		t.Errorf("expected blooms wiped, still got %v", c.Combat.GadgetCount())
 	}
 	if count != 2 {
-		t.Errorf("Expected 2 hyperblooms, got %v", count)
+		t.Errorf("Expected 2 Burgeons, got %v", count)
 	}
 }

--- a/pkg/reactable/burgeon_test.go
+++ b/pkg/reactable/burgeon_test.go
@@ -37,7 +37,7 @@ func TestBurgeon(t *testing.T) {
 		},
 	})
 	// wait a bit for bloom spawns
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 46; i++ {
 		advanceCoreFrame(c)
 	}
 
@@ -95,6 +95,9 @@ func TestECBurgeon(t *testing.T) {
 			Durability: 25,
 		},
 	})
+	for i := 0; i < 46; i++ {
+		advanceCoreFrame(c)
+	}
 
 	// should create 2 blooms
 	if c.Combat.GadgetCount() != 2 {

--- a/pkg/reactable/catalyze.go
+++ b/pkg/reactable/catalyze.go
@@ -69,4 +69,8 @@ func (r *Reactable) tryQuicken(a *combat.AttackEvent) {
 
 	//attach quicken aura; special amount
 	r.attachQuicken(consumed)
+
+	if r.Durability[ModifierElectro] >= ZeroDur {
+		r.checkQuickenBloom(a)
+	}
 }

--- a/pkg/reactable/hyperbloom_test.go
+++ b/pkg/reactable/hyperbloom_test.go
@@ -57,8 +57,11 @@ func TestHyperBloom(t *testing.T) {
 	if src == nil {
 		t.Error("should get one Hyperbloom")
 	}
+	if src.Info.FlatDmg == 0 {
+		t.Error("expected FlatDmg not to be 0")
+	}
 	if c.Combat.GadgetCount() != 0 {
-		t.Logf("gadget should be removed, got %v", c.Combat.GadgetCount())
+		t.Errorf("gadget should be removed, got %v", c.Combat.GadgetCount())
 	}
 }
 
@@ -98,10 +101,10 @@ func TestECHyperBloom(t *testing.T) {
 		t.Errorf("expected 2 blooms, got %v", c.Combat.GadgetCount())
 	}
 
-	var count int = 0
+	var count []*combat.AttackEvent = []*combat.AttackEvent{}
 	trg.onDmgCallBack = func(ae *combat.AttackEvent) (float64, bool) {
 		if ae.Info.Abil == "Hyperbloom" {
-			count++
+			count = append(count, ae)
 		}
 		return 0, false
 	}
@@ -122,7 +125,12 @@ func TestECHyperBloom(t *testing.T) {
 	if c.Combat.GadgetCount() != 0 {
 		t.Errorf("expected blooms wiped, still got %v", c.Combat.GadgetCount())
 	}
-	if count != 2 {
+	if len(count) != 2 {
 		t.Errorf("Expected 2 hyperblooms, got %v", count)
+	}
+	for _, v := range count {
+		if v.Info.FlatDmg == 0 {
+			t.Error("expected FlatDmg not to be 0")
+		}
 	}
 }

--- a/pkg/reactable/hyperbloom_test.go
+++ b/pkg/reactable/hyperbloom_test.go
@@ -37,7 +37,7 @@ func TestHyperBloom(t *testing.T) {
 		},
 	})
 	// wait a bit for bloom spawns
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 46; i++ {
 		advanceCoreFrame(c)
 	}
 
@@ -95,6 +95,9 @@ func TestECHyperBloom(t *testing.T) {
 			Durability: 25,
 		},
 	})
+	for i := 0; i < 46; i++ {
+		advanceCoreFrame(c)
+	}
 
 	// should create 2 blooms
 	if c.Combat.GadgetCount() != 2 {

--- a/pkg/reactable/hyperbloom_test.go
+++ b/pkg/reactable/hyperbloom_test.go
@@ -1,0 +1,117 @@
+package reactable
+
+import (
+	"testing"
+
+	"github.com/genshinsim/gcsim/pkg/core/attributes"
+	"github.com/genshinsim/gcsim/pkg/core/combat"
+)
+
+func TestHyperBloom(t *testing.T) {
+	c := testCore()
+	trg2 := addTargetToCore(c)
+	trg1 := addTargetToCore(c)
+	trg2.SetPos(3, 0)
+	trg1.SetPos(1, 0)
+	c.Init()
+
+	var src *combat.AttackEvent
+	trg1.onDmgCallBack = func(atk *combat.AttackEvent) (float64, bool) {
+		if atk.Info.Abil == "Hyperbloom" {
+			src = atk
+		}
+		return 0, false
+	}
+
+	trg1.AttachOrRefill(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Hydro,
+			Durability: 25,
+		},
+	})
+	trg1.React(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Dendro,
+			Durability: 25,
+		},
+	})
+	// wait a bit for bloom spawns
+	for i := 0; i < 10; i++ {
+		advanceCoreFrame(c)
+	}
+
+	// summon aoe electro to proc hyperbloom nearby trg1
+	ae := &combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Electro,
+			Durability: 25,
+		},
+	}
+	c.QueueAttack(ae.Info, combat.NewCircleHit(trg2.self, 5, false, combat.TargettableGadget), 1, 1)
+	for i := 0; i < 10; i++ {
+		advanceCoreFrame(c)
+	}
+
+	// trg1 should get hyperbloom damage
+	if src == nil {
+		t.Error("should get Hyperbloom")
+	}
+	if c.Combat.GadgetCount() != 0 {
+		t.Logf("gadget should be removed, got %v", c.Combat.GadgetCount())
+	}
+}
+
+func TestECHyperBloom(t *testing.T) {
+	c := testCore()
+	trg := addTargetToCore(c)
+	c.Init()
+
+	// creates 2 seeds with ec
+	trg.AttachOrRefill(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Hydro,
+			Durability: 25,
+		},
+	})
+	trg.React(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Electro,
+			Durability: 25,
+		},
+	})
+	// reduce a bit ec aura
+	for i := 0; i < 10; i++ {
+		advanceCoreFrame(c)
+	}
+	// dendro -> ec
+	trg.React(&combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Dendro,
+			Durability: 25,
+		},
+	})
+
+	var count int = 0
+	trg.onDmgCallBack = func(ae *combat.AttackEvent) (float64, bool) {
+		if ae.Info.Abil == "Hyperbloom" {
+			count++
+		}
+		return 0, false
+	}
+
+	// summon aoe electro to proc 2 hyperbloom
+	ae := &combat.AttackEvent{
+		Info: combat.AttackInfo{
+			Element:    attributes.Electro,
+			Durability: 25,
+		},
+	}
+	c.QueueAttack(ae.Info, combat.NewCircleHit(trg.self, 5, false, combat.TargettableGadget), 1, 1)
+	for i := 0; i < 10; i++ {
+		advanceCoreFrame(c)
+	}
+
+	if count != 2 {
+		t.Errorf("Expected 2 hyperblooms, got %v", count)
+	}
+}

--- a/pkg/reactable/hyperbloom_test.go
+++ b/pkg/reactable/hyperbloom_test.go
@@ -54,7 +54,7 @@ func TestHyperBloom(t *testing.T) {
 
 	// trg1 should get hyperbloom damage
 	if src == nil {
-		t.Error("should get Hyperbloom")
+		t.Error("should get one Hyperbloom")
 	}
 	if c.Combat.GadgetCount() != 0 {
 		t.Logf("gadget should be removed, got %v", c.Combat.GadgetCount())
@@ -99,7 +99,7 @@ func TestECHyperBloom(t *testing.T) {
 		return 0, false
 	}
 
-	// summon aoe electro to proc 2 hyperbloom
+	// queue an aoe electro to proc 2 hyperblooms
 	ae := &combat.AttackEvent{
 		Info: combat.AttackInfo{
 			Element:    attributes.Electro,

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -141,7 +141,7 @@ func (r *Reactable) React(a *combat.AttackEvent) {
 	case attributes.Hydro:
 		r.tryVaporize(a)
 		r.tryFreeze(a)
-		//bloom
+		r.tryBloom(a)
 		r.tryAddEC(a)
 	case attributes.Anemo:
 		r.trySwirlElectro(a)
@@ -155,7 +155,7 @@ func (r *Reactable) React(a *combat.AttackEvent) {
 		r.trySpread(a)
 		r.tryQuicken(a)
 		//burning
-		//bloom
+		r.tryBloom(a)
 	}
 }
 

--- a/pkg/reactable/swirl.go
+++ b/pkg/reactable/swirl.go
@@ -50,7 +50,7 @@ func (r *Reactable) queueSwirl(rt combat.ReactionType, ele attributes.Element, t
 	r.core.QueueAttackWithSnap(
 		ai,
 		snap,
-		combat.NewCircleHit(r.self, 5, false, combat.TargettableEnemy),
+		combat.NewCircleHit(r.self, 5, false, combat.TargettableEnemy, combat.TargettableGadget),
 		1,
 	)
 }

--- a/pkg/simulation/data.go
+++ b/pkg/simulation/data.go
@@ -115,6 +115,9 @@ func (s *Simulation) initDetailLog() {
 		event.OnAggravate:          combat.Aggravate,
 		event.OnSpread:             combat.Spread,
 		event.OnQuicken:            combat.Quicken,
+		event.OnBloom:              combat.Bloom,
+		event.OnHyperbloom:         combat.Hyperbloom,
+		event.OnBurgeon:            combat.Burgeon,
 	}
 
 	for k, v := range reactions {


### PR DESCRIPTION
Bloom, Hyperbloom and Burgeon reaction
Add couple characters' ability to target gadget on aoe attack (electro units/hyperbloom mostly): swirl, beidou, fischl, cooki, raiden, sucrose, yae

- [x] Add `combat.TargetableGadget` on every other pyro/electro/anemo character (or maybe all characters)
