### PR TITLE
allow condition to be optional in switch statement

### DIFF
--- a/pkg/gcs/ast/parse.go
+++ b/pkg/gcs/ast/parse.go
@@ -48,7 +48,7 @@ func (t Token) precedence() precedence {
 	return Lowest
 }
 
-//Parse returns the ActionList and any error that prevents the ActionList from being parsed
+// Parse returns the ActionList and any error that prevents the ActionList from being parsed
 func (p *Parser) Parse() (*ActionList, error) {
 	var err error
 	for state := parseRows; state != nil; {
@@ -364,9 +364,17 @@ func (p *Parser) parseSwitch() (Stmt, error) {
 		Pos: n.pos,
 	}
 
-	stmt.Condition, err = p.parseExpr(Lowest)
-	if err != nil {
-		return nil, err
+	//condition can be optional; if next item is itemLeftBrace then simply set condition to 1
+	if n := p.peek(); n.Typ != itemLeftBrace {
+		stmt.Condition, err = p.parseExpr(Lowest)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		stmt.Condition = &NumberLit{
+			Pos:    n.pos,
+			IntVal: 1,
+		}
 	}
 
 	if n := p.next(); n.Typ != itemLeftBrace {
@@ -703,7 +711,7 @@ func (p *Parser) parseCallArgs() ([]Expr, error) {
 	return args, nil
 }
 
-//check if it's a valid character action, assuming current token is "character"
+// check if it's a valid character action, assuming current token is "character"
 func (p *Parser) peekValidCharAction() bool {
 	p.next()
 	//check if this is character stats etc or an action
@@ -716,7 +724,7 @@ func (p *Parser) peekValidCharAction() bool {
 	return true
 }
 
-//parseBlock return a node contain and BlockStmt
+// parseBlock return a node contain and BlockStmt
 func (p *Parser) parseBlock() (*BlockStmt, error) {
 	//should be surronded by {}
 	n, err := p.consume(itemLeftBrace)
@@ -777,7 +785,7 @@ func (p *Parser) parseExpr(pre precedence) (Expr, error) {
 	return leftExp, nil
 }
 
-//next is an identifier
+// next is an identifier
 func (p *Parser) parseIdent() (Expr, error) {
 	n := p.next()
 	return &Ident{Pos: n.pos, Value: n.Val}, nil


### PR DESCRIPTION
allows for the following syntax which is a bit to easier to use to write apl

```
switch {
   case <some condition>:
   case <some other condition>:
   default:
      wait(1);
}
```
