### PR TITLE
fix eval switch no default case

### DIFF
--- a/pkg/gcs/stmt.go
+++ b/pkg/gcs/stmt.go
@@ -288,6 +288,9 @@ func (e *Eval) evalSwitchStmt(swt *ast.SwitchStmt, env *Env) (Obj, error) {
 		}
 	}
 	if !found || ft {
+		if swt.Default == nil {
+			return &null{}, nil
+		}
 		return e.evalBlock(swt.Default, env)
 	}
 	return &null{}, nil


### PR DESCRIPTION
switch eval wasn't checking if default case is nil, causing it to crash