### PR TITLE
change bloom dendro core delay to 20f

### DIFF
--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -10,7 +10,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/gadget"
 )
 
-const DendroCoreDelay = 45
+const DendroCoreDelay = 20
 
 func (r *Reactable) tryBloom(a *combat.AttackEvent) {
 	//can be hydro bloom, dendro bloom, or quicken bloom


### PR DESCRIPTION
Based off these videos, the dendro core is counted as a gadget starting at ~20f from the bloom reaction trigger. This is also the time when the 5 dendro core limit is checked. The delay on damage is likely caused by the 12f linger of the core after being ruptured, hyperbloomed, or burgeoned.

The spawn delay is probably not always 20f. My hypothesis is that it is variable depending on the spawn location of the gadget. However for the sim, 20f suffices.

https://discord.com/channels/845087716541595668/869210750596554772/1027611051124064356