### PR TITLE
Fixed UI logo path so it can load from any page

### DIFF
--- a/app/src/Components/Nav/Nav.tsx
+++ b/app/src/Components/Nav/Nav.tsx
@@ -29,7 +29,7 @@ export default function Nav() {
     <Navbar>
       <NavbarGroup align={Alignment.LEFT} className="w-full">
         <img
-          src="images/logo.png"
+          src="/images/logo.png"
           className=" object-contain max-h-[75%] mt-auto mb-auto mr-1"
         />
         <Link href="/">


### PR DESCRIPTION
When clicking a share link or opening the site from not the root, logo is unable to load. Fixing the path so it can load regardless of entry point.

Before:
![image](https://user-images.githubusercontent.com/2059811/195451379-0001252e-c0fe-488d-8489-6c8331f0129b.png)


After:
![image](https://user-images.githubusercontent.com/2059811/195451350-59686adb-931a-4012-9450-c8ab7321d74a.png)
