### PR TITLE
Fix bug with SD when running a single iteration

### DIFF
--- a/pkg/agg/result.go
+++ b/pkg/agg/result.go
@@ -32,12 +32,12 @@ type FloatStat struct {
 	Min  float64 `json:"min"`
 	Max  float64 `json:"max"`
 	Mean float64 `json:"mean"`
-	SD   float64 `json:"sd,omitempty"`
+	SD   float64 `json:"sd"`
 }
 
 type IntStat struct {
 	Min  int     `json:"min"`
 	Max  int     `json:"max"`
 	Mean float64 `json:"mean"`
-	SD   float64 `json:"sd,omitempty"`
+	SD   float64 `json:"sd"`
 }

--- a/pkg/agg/util/util.go
+++ b/pkg/agg/util/util.go
@@ -66,7 +66,7 @@ func (b *FloatBuffer) Flush() agg.FloatStat {
 		for _, e := range b.entries {
 			variance += (e - b.mean) * (e - b.mean)
 		}
-		out.SD = math.Sqrt(variance / float64(b.n-1))
+		out.SD = math.Sqrt(variance / math.Max(float64(b.n-1), 1))
 	}
 
 	return out


### PR DESCRIPTION
Fixing bug for SD to return `0` instead of `NaN` when running a single iteration simulation