### PR TITLE
fischl radius update

### DIFF
--- a/internal/characters/fischl/asc.go
+++ b/internal/characters/fischl/asc.go
@@ -9,7 +9,6 @@ import (
 func (c *char) a4() {
 	last := 0
 	cb := func(args ...interface{}) bool {
-		t := args[0].(combat.Target)
 		ae := args[1].(*combat.AttackEvent)
 
 		if ae.Info.ActorIndex != c.Core.Player.Active() {
@@ -39,7 +38,11 @@ func (c *char) a4() {
 		// Technically should have a separate snapshot for each attack info?
 		// ai.ModsLog = c.ozSnapshot.Info.ModsLog
 		// A4 uses Oz Snapshot
-		c.Core.QueueAttackWithSnap(ai, c.ozSnapshot.Snapshot, combat.NewDefSingleTarget(t.Key(), combat.TargettableEnemy), 3)
+		c.Core.QueueAttackWithSnap(
+			ai,
+			c.ozSnapshot.Snapshot,
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget),
+			3)
 
 		return false
 	}
@@ -48,7 +51,7 @@ func (c *char) a4() {
 	c.Core.Events.Subscribe(event.OnSuperconduct, cb, "fischl-a4")
 	c.Core.Events.Subscribe(event.OnSwirlElectro, cb, "fischl-a4")
 	c.Core.Events.Subscribe(event.OnCrystallizeElectro, cb, "fischl-a4")
-	// c.Core.Events.Subscribe(event.OnHyperbloom, cb, "fischl-a4")
+	c.Core.Events.Subscribe(event.OnHyperbloom, cb, "fischl-a4")
 	c.Core.Events.Subscribe(event.OnQuicken, cb, "fischl-a4")
 	c.Core.Events.Subscribe(event.OnAggravate, cb, "fischl-a4")
 }

--- a/internal/characters/fischl/burst.go
+++ b/internal/characters/fischl/burst.go
@@ -32,7 +32,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       burst[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
 
 	//check for C4 damage
 	if c.Base.Cons >= 4 {
@@ -48,7 +48,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			Mult:       2.22,
 		}
 		// C4 damage always occurs before burst damage.
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), 8, 8)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy, combat.TargettableGadget), 8, 8)
 		//heal at end of animation
 		heal := c.MaxHP() * 0.2
 		c.Core.Tasks.Add(func() {

--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -35,11 +35,13 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       birdSum[c.TalentLvlSkill()],
 	}
 
+	var radius float64 = 2
 	if c.Base.Cons >= 2 {
 		ai.Mult += 2
+		radius = 3
 	}
 	// hitmark is 5 frames after oz spawns
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), skillOzSpawn, skillOzSpawn+5)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), radius, false, combat.TargettableEnemy, combat.TargettableGadget), skillOzSpawn, skillOzSpawn+5)
 
 	// CD Delay is 18 frames, but things break if Delay > CanQueueAfter
 	// so we add 18 to the duration instead. this probably mess up CDR stuff

--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -35,7 +35,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       birdSum[c.TalentLvlSkill()],
 	}
 
-	var radius float64 = 2
+	radius := 2.0
 	if c.Base.Cons >= 2 {
 		ai.Mult += 2
 		radius = 3


### PR DESCRIPTION
fischl a4 now has radius of 0.5m
fischl a4 now hits gadgets
fischl a4 now procs on hyperbloom trigger
fischl q now has radius of 0.5m
fischl c4 now has radius of 5m
fischl e summon now has radius of 2m by default, 3m if c2
fischl e summon now centers on primary target