### PR TITLE
Added param to determine whether Sucrose Venti and Anemo MC self absorb

### DIFF
--- a/internal/characters/sucrose/burst.go
+++ b/internal/characters/sucrose/burst.go
@@ -28,7 +28,15 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	// reset location
 	c.qAbsorb = attributes.NoElement
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	self_absorb, ok := p["self_absorb"]
+	if !ok {
+		self_absorb = 1
+	}
+	if self_absorb == 0 {
+		c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget)
+	} else {
+		c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	}
 
 	c.Core.Status.Add("sucroseburst", duration)
 	ai := combat.AttackInfo{

--- a/internal/characters/traveleranemo/burst.go
+++ b/internal/characters/traveleranemo/burst.go
@@ -38,7 +38,15 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.qAbsorb = attributes.NoElement
 	c.qICDTag = combat.ICDTagNone
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	self_absorb, ok := p["self_absorb"]
+	if !ok {
+		self_absorb = 0
+	}
+	if self_absorb == 0 {
+		c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget)
+	} else {
+		c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	}
 
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,

--- a/internal/characters/venti/burst.go
+++ b/internal/characters/venti/burst.go
@@ -20,7 +20,15 @@ func init() {
 func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// reset location
 	c.qAbsorb = attributes.NoElement
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	self_absorb, ok := p["self_absorb"]
+	if !ok {
+		self_absorb = 0
+	}
+	if self_absorb == 0 {
+		c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget)
+	} else {
+		c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1, false, combat.TargettableEnemy, combat.TargettablePlayer, combat.TargettableGadget)
+	}
 
 	//8 second duration, tick every .4 second
 	ai := combat.AttackInfo{


### PR DESCRIPTION
Added `self_absorb` param to Venti, Sucrose and Anemo MC bursts. With value `0`, characters will not check themselves for self absorption, while other values will. By Default, Venti and Anemo MC are disabled while Sucrose is enabled

https://gcsim.app/v3/viewer/share/6ade3731-2446-4c6c-9835-900594fc921b