### PR TITLE
albedo radius update

### DIFF
--- a/internal/characters/albedo/attack.go
+++ b/internal/characters/albedo/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{12, 11, 17, 17, 27}
-var attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{12, 11, 17, 17, 27}
+	attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
+	attackRadius          = []float64{1.6, 2.0, 1.98, 1.99, 2.0}
+)
 
 const normalHitNum = 5
 
@@ -52,7 +55,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	//we don't need to use char queue here since each hit is single hit
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+		combat.NewCircleHit(c.Core.Combat.Player(), attackRadius[c.NormalCounter]),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/albedo/burst.go
+++ b/internal/characters/albedo/burst.go
@@ -47,14 +47,14 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 
 	//TODO: damage frame
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), burstHitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 8), burstHitmark)
 
 	// Blossoms are generated on a slight delay from initial hit
 	// TODO: no precise frame data for time between Blossoms
 	ai.Abil = "Rite of Progeniture: Tectonic Tide (Blossom)"
 	ai.Mult = burstPerBloom[c.TalentLvlBurst()]
 	for i := 0; i < hits; i++ {
-		c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHit(c.Core.Combat.Player(), 3), fatalBlossomHitmark+i*5)
+		c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3), fatalBlossomHitmark+i*5)
 	}
 
 	//Party wide EM buff

--- a/internal/characters/albedo/charge.go
+++ b/internal/characters/albedo/charge.go
@@ -34,7 +34,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/albedo/skill.go
+++ b/internal/characters/albedo/skill.go
@@ -39,7 +39,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 	// TODO: damage frame
 	c.bloomSnapshot = c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHit(c.Core.Combat.Player(), 3), skillHitmark)
+	c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHit(c.Core.Combat.Player(), 5), skillHitmark)
 
 	// snapshot for ticks
 	ai.Abil = "Abiogenesis: Solar Isotoma (Tick)"
@@ -96,7 +96,7 @@ func (c *char) skillHook() {
 		c.Core.QueueAttackWithSnap(
 			c.skillAttackInfo,
 			c.skillSnapshot,
-			combat.NewCircleHit(c.Core.Combat.Player(), 3),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3.4),
 			1,
 		)
 


### PR DESCRIPTION
albedo q initial hit now has radius of 8
albedo q fatal blossoms now center on primary target
albedo CA now has radius of 2
albedo e cast now has radius 5
albedo e tick now has radius 3.4 and centers on primary target
albedo n1-n5 now uses radii 1.6, 2.0, 1.98, 1.99, 2.0