### PR TITLE
amber and ayaka radius update

### DIFF
--- a/internal/characters/amber/bunny.go
+++ b/internal/characters/amber/bunny.go
@@ -30,7 +30,7 @@ func (c *char) makeBunny() {
 	snap := c.Snapshot(&ai)
 	b.ae = combat.AttackEvent{
 		Info:        ai,
-		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy, combat.TargettableGadget),
+		Pattern:     combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3, false, combat.TargettableEnemy, combat.TargettableGadget),
 		SourceFrame: c.Core.F,
 		Snapshot:    snap,
 	}

--- a/internal/characters/ayaka/attack.go
+++ b/internal/characters/ayaka/attack.go
@@ -9,11 +9,15 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{8}, {10}, {16}, {8, 15, 22}, {27}}
-var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0, 0.03}, {0}}
-var attackHitlagFactor = [][]float64{{0.01}, {0.01}, {0.01}, {0, 0, 0.05}, {0.01}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false, true}, {false}}
+var (
+	attackFrames   [][]int
+	attackHitmarks = [][]int{{8}, {10}, {16}, {8, 15, 22}, {27}}
+	attackRadius   = []float64{1.6, 1.2, 2.8, 1.4, 1.6} // N5 is a bullet, radius unknown
+
+	attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0, 0.03}, {0}}
+	attackHitlagFactor    = [][]float64{{0.01}, {0.01}, {0.01}, {0, 0, 0.05}, {0.01}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, false, true}, {false}}
+)
 
 const normalHitNum = 5
 
@@ -58,7 +62,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), attackRadius[c.NormalCounter], false, combat.TargettableEnemy),
 				0,
 				0,
 				c.c1,

--- a/internal/characters/ayaka/burst.go
+++ b/internal/characters/ayaka/burst.go
@@ -33,7 +33,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	//5 second, 20 ticks, so once every 15 frames, bloom after 5 seconds
 	ai.Mult = burstBloom[c.TalentLvlBurst()]
 	ai.Abil = "Soumetsu (Bloom)"
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), burstHitmark, burstHitmark+300, c.c4)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5, false, combat.TargettableEnemy), burstHitmark, burstHitmark+300, c.c4)
 
 	// C2 mini-frostflake bloom
 	var aiC2 combat.AttackInfo
@@ -42,22 +42,22 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		aiC2.Mult = burstBloom[c.TalentLvlBurst()] * .2
 		aiC2.Abil = "C2 Mini-Frostflake Seki no To (Bloom)"
 		// TODO: Not sure about the positioning/size...
-		c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), burstHitmark, burstHitmark+300, c.c4)
-		c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), burstHitmark, burstHitmark+300, c.c4)
+		c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3, false, combat.TargettableEnemy), burstHitmark, burstHitmark+300, c.c4)
+		c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3, false, combat.TargettableEnemy), burstHitmark, burstHitmark+300, c.c4)
 	}
 
 	for i := 0; i < 19; i++ {
 		ai.Mult = burstCut[c.TalentLvlBurst()]
 		ai.Abil = "Soumetsu (Cutting)"
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5, false, combat.TargettableEnemy), burstHitmark, burstHitmark+i*15, c.c4)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3, false, combat.TargettableEnemy), burstHitmark, burstHitmark+i*15, c.c4)
 
 		// C2 mini-frostflake cutting
 		if c.Base.Cons >= 2 {
 			aiC2.Mult = burstCut[c.TalentLvlBurst()] * .2
 			aiC2.Abil = "C2 Mini-Frostflake Seki no To (Cutting)"
 			// TODO: Not sure about the positioning/size...
-			c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), burstHitmark, burstHitmark+i*15, c.c4)
-			c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), burstHitmark, burstHitmark+i*15, c.c4)
+			c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5, false, combat.TargettableEnemy), burstHitmark, burstHitmark+i*15, c.c4)
+			c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5, false, combat.TargettableEnemy), burstHitmark, burstHitmark+i*15, c.c4)
 		}
 	}
 

--- a/internal/characters/ayaka/charge.go
+++ b/internal/characters/ayaka/charge.go
@@ -34,7 +34,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i := 0; i < 3; i++ {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1, false, combat.TargettableEnemy),
 			chargeHitmarks[i],
 			chargeHitmarks[i],
 			c.c1,

--- a/internal/characters/ayaka/skill.go
+++ b/internal/characters/ayaka/skill.go
@@ -43,7 +43,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		},
 	})
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4, false, combat.TargettableEnemy), 0, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4.5, false, combat.TargettableEnemy), 0, skillHitmark)
 
 	// 4 or 5, 1:1 ratio
 	var count float64 = 4


### PR DESCRIPTION
amber e explosion now has radius of 3 and centers on primary target
ayaka q (bloom) now centers on primary target
ayaka q (cutting) now has radius of 3 and centers on primary target
ayaka c2 (bloom) now has radius of 3 and centers on primary target
ayaka c2 (cutting) now has radius of 1.5 and centers on primary target
ayaka e now has radius of 4.5
ayaka charged attack now has radius of 1 and centers on primary target
ayaka n1-n5 now uses radii of 1.6, 1.2, 2.8, 1.4, and 1.6.
ayaka n5 is a placeholder, exact radius unknown