### PR TITLE
ayato radius update

### DIFF
--- a/internal/characters/ayato/attack.go
+++ b/internal/characters/ayato/attack.go
@@ -9,11 +9,14 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{12}, {18}, {20}, {22, 25}, {41}}
-var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0}, {0.08}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false}, {true}}
-var shunsuikenFrames []int
+var (
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, false}, {true}}
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{12}, {18}, {20}, {22, 25}, {41}}
+	attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0}, {0.08}}
+	attackRadius          = []float64{1.7, 1.7, 1.61, 1.64, 3.16}
+	shunsuikenFrames      []int
+)
 
 const normalHitNum = 5
 const shunsuikenHitmark = 5
@@ -63,7 +66,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+				combat.NewCircleHit(c.Core.Combat.Player(), attackRadius[c.NormalCounter], false, combat.TargettableEnemy),
 				0,
 				0,
 			)
@@ -96,7 +99,7 @@ func (c *char) SoukaiKanka(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   0.03 * 60,
 		CanBeDefenseHalted: false,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 0, shunsuikenHitmark, c.generateParticles, c.skillStacks)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5.32, false, combat.TargettableEnemy), 0, shunsuikenHitmark, c.generateParticles, c.skillStacks)
 
 	defer c.AdvanceNormalIndex()
 

--- a/internal/characters/ayato/burst.go
+++ b/internal/characters/ayato/burst.go
@@ -75,7 +75,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				return
 			}
 			//deal dmg
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 9, false, combat.TargettableEnemy), 0)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 2.5, false, combat.TargettableEnemy), 0)
 		}, delay+139)
 	}
 

--- a/internal/characters/ayato/cons.go
+++ b/internal/characters/ayato/cons.go
@@ -71,8 +71,8 @@ func (c *char) c6() {
 			CanBeDefenseHalted: false,
 			IsDeployable:       true,
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 20, 20)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy), 22, 22)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5.31, false, combat.TargettableEnemy), 20, 20)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5.31, false, combat.TargettableEnemy), 22, 22)
 
 		c.Core.Log.NewEvent("ayato c6 proc'd", glog.LogCharacterEvent, c.Index)
 		c.c6ready = false

--- a/internal/characters/ayato/cons.go
+++ b/internal/characters/ayato/cons.go
@@ -71,8 +71,8 @@ func (c *char) c6() {
 			CanBeDefenseHalted: false,
 			IsDeployable:       true,
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5.31, false, combat.TargettableEnemy), 20, 20)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5.31, false, combat.TargettableEnemy), 22, 22)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5.32, false, combat.TargettableEnemy), 20, 20)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5.32, false, combat.TargettableEnemy), 22, 22)
 
 		c.Core.Log.NewEvent("ayato c6 proc'd", glog.LogCharacterEvent, c.Index)
 		c.c6ready = false


### PR DESCRIPTION
ayato n1-n5 now uses radii 1.7, 1.7, 1.61, 1.64, 3.16
ayato e normals now has radius of 5.32 and center on primary target
ayato burst droplets now has radius of 2.5 and center on their target
ayato c6 now has radius of 5.32 and centers on primary target

todo: 

- [ ] ayato droplets should not target enemies within a certain radius (unknown)
- [ ] verify ayato droplets are centering on their own target