### PR TITLE
barbara and beidou radius update

### DIFF
--- a/internal/characters/barbara/attack.go
+++ b/internal/characters/barbara/attack.go
@@ -72,7 +72,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 
 	c.Core.QueueAttack(ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1, false, combat.TargettableEnemy),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 		cb,

--- a/internal/characters/barbara/charge.go
+++ b/internal/characters/barbara/charge.go
@@ -74,7 +74,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 
 	// TODO: Not sure of snapshot timing
 	c.Core.QueueAttack(ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2, false, combat.TargettableEnemy),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3, false, combat.TargettableEnemy),
 		chargeHitmark-windup,
 		chargeHitmark-windup,
 		cb,

--- a/internal/characters/beidou/attack.go
+++ b/internal/characters/beidou/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{23, 22, 45, 25, 43}
-var attackHitlagHaltFrame = []float64{.09, .12, .09, .09, .12}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{23, 22, 45, 25, 43}
+	attackHitlagHaltFrame = []float64{.09, .12, .09, .09, .12}
+	attackRadius          = []float64{2.0, 1.6, 2, 2, 1.8}
+)
 
 const normalHitNum = 5
 
@@ -43,7 +46,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget),
+		combat.NewCircleHit(c.Core.Combat.Player(), attackRadius[c.NormalCounter], false, combat.TargettableEnemy, combat.TargettableGadget),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -43,7 +43,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   0.1 * 60,
 		CanBeDefenseHalted: false,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4, false, combat.TargettableEnemy, combat.TargettableGadget), burstHitmark, burstHitmark)
 
 	// beidou burst is not hitlag extendable
 	c.AddStatus(burstKey, 900, false)

--- a/internal/characters/beidou/skill.go
+++ b/internal/characters/beidou/skill.go
@@ -8,8 +8,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/player/shield"
 )
 
-var skillFrames []int
-var skillHitlagStages = []float64{.09, .09, .15}
+var (
+	skillFrames       []int
+	skillHitlagStages = []float64{.09, .09, .15}
+	skillRadius       = []float64{6, 7, 8}
+)
 
 const skillHitmark = 23
 
@@ -42,7 +45,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   skillHitlagStages[counter] * 60,
 		CanBeDefenseHalted: true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), skillHitmark, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), skillRadius[counter], false, combat.TargettableEnemy, combat.TargettableGadget), skillHitmark, skillHitmark)
 
 	//2 if no hit, 3 if 1 hit, 4 if perfect
 	c.Core.QueueParticle("beidou", 2+float64(counter), attributes.Electro, skillHitmark+c.ParticleDelay)


### PR DESCRIPTION
barbara n1-n4 now has radius of 1 and centers on primary target
barbara charge now has radius of 3 and centers on primary target
beidou n1-n5 uses radii 2.0, 1.6, 2, 2, 1.8
beidou e now has radius of 6 with no counter, 7 with stage 1 counter, 8 with stage 2 counter
beidou q initial hit now has radius of 4

todo:

- [ ] barbara n4 has unknown/special radius
