### PR TITLE
bennett radius update

### DIFF
--- a/internal/characters/bennett/attack.go
+++ b/internal/characters/bennett/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{13, 9, 13, 25, 24}
-var attackHitlagHaltFrames = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
+var (
+	attackFrames           [][]int
+	attackHitmarks         = []int{13, 9, 13, 25, 24}
+	attackHitlagHaltFrames = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
+	attackRadius           = []float64{1.2, 1.2, 2.0, 1.82, 2.0}
+)
 
 const normalHitNum = 5
 
@@ -51,7 +54,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget),
+		combat.NewCircleHit(c.Core.Combat.Player(), attackRadius[c.NormalCounter], false, combat.TargettableEnemy, combat.TargettableGadget),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/bennett/charge.go
+++ b/internal/characters/bennett/charge.go
@@ -34,7 +34,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1, false, combat.TargettableEnemy, combat.TargettableGadget), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.2, false, combat.TargettableEnemy, combat.TargettableGadget), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/bennett/skill.go
+++ b/internal/characters/bennett/skill.go
@@ -9,8 +9,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var skillFrames [][]int
-var skillHoldHitmarks = [][]int{{45, 57}, {112, 121}}
+var (
+	skillFrames       [][]int
+	skillHoldHitmarks = [][]int{{45, 57}, {112, 121}}
+	skillHoldRadius   = []float64{2.5, 1.41} // Hold level 1 and 2 have the same width and length for radius estimation purposes
+)
 
 const skillPressHitmark = 16
 
@@ -84,7 +87,7 @@ func (c *char) skillPress() action.ActionInfo {
 		Mult:               skill[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), skillPressHitmark, skillPressHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.5, false, combat.TargettableEnemy, combat.TargettableGadget), skillPressHitmark, skillPressHitmark)
 
 	//25 % chance of 3 orbs
 	var count float64 = 2
@@ -131,7 +134,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ax,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget),
+				combat.NewCircleHit(c.Core.Combat.Player(), skillHoldRadius[level-1], false, combat.TargettableEnemy, combat.TargettableGadget),
 				0,
 				0,
 			)
@@ -140,7 +143,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 	if level == 2 {
 		ai.Mult = explosion[c.TalentLvlSkill()]
 		ai.HitlagHaltFrames = 0
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), 166, 166)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), skillHoldRadius[level-1], false, combat.TargettableEnemy, combat.TargettableGadget), 166, 166)
 	}
 
 	//user-specified c4 variant adds an additional attack that deals 135% of the second hit
@@ -148,7 +151,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 		ai.Mult = skillHold[level-1][1][c.TalentLvlSkill()] * 1.35
 		ai.Abil = "Passion Overload (C4)"
 		ai.HitlagHaltFrames = 0.12 * 60
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1, false, combat.TargettableEnemy, combat.TargettableGadget), 94, 94)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.5, false, combat.TargettableEnemy, combat.TargettableGadget), 94, 94)
 
 	}
 

--- a/internal/characters/bennett/skill.go
+++ b/internal/characters/bennett/skill.go
@@ -134,7 +134,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ax,
-				combat.NewCircleHit(c.Core.Combat.Player(), skillHoldRadius[level-1], false, combat.TargettableEnemy, combat.TargettableGadget),
+				combat.NewCircleHit(c.Core.Combat.Player(), skillHoldRadius[i], false, combat.TargettableEnemy, combat.TargettableGadget),
 				0,
 				0,
 			)
@@ -143,7 +143,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 	if level == 2 {
 		ai.Mult = explosion[c.TalentLvlSkill()]
 		ai.HitlagHaltFrames = 0
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), skillHoldRadius[level-1], false, combat.TargettableEnemy, combat.TargettableGadget), 166, 166)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3.5, false, combat.TargettableEnemy, combat.TargettableGadget), 166, 166)
 	}
 
 	//user-specified c4 variant adds an additional attack that deals 135% of the second hit


### PR DESCRIPTION
bennett n1-n5 now uses radii 1.2, 1.2, 2.0, 1.82, 2.0
bennett CA now uses radius 2.2
bennett hold E levels 1 and 2 now both use radii 2.5 and 1.41 for their first and second hit
bennett hold E level 2 explosion now uses radius 3.5
bennett c4 now uses radius 2.5