### PR TITLE
add travel to fischl's oz (e and c6 procs)

### DIFF
--- a/internal/characters/fischl/cons.go
+++ b/internal/characters/fischl/cons.go
@@ -32,7 +32,7 @@ func (c *char) c6() {
 		// Technically should have a separate snapshot for each attack info?
 		// ai.ModsLog = c.ozSnapshot.Info.ModsLog
 		// C4 uses Oz Snapshot
-		c.Core.QueueAttackWithSnap(ai, c.ozSnapshot.Snapshot, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), c.c6Travel)
+		c.Core.QueueAttackWithSnap(ai, c.ozSnapshot.Snapshot, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), c.ozTravel)
 		return false
 	}, "fischl-c6")
 }

--- a/internal/characters/fischl/cons.go
+++ b/internal/characters/fischl/cons.go
@@ -32,7 +32,7 @@ func (c *char) c6() {
 		// Technically should have a separate snapshot for each attack info?
 		// ai.ModsLog = c.ozSnapshot.Info.ModsLog
 		// C4 uses Oz Snapshot
-		c.Core.QueueAttackWithSnap(ai, c.ozSnapshot.Snapshot, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), 0)
+		c.Core.QueueAttackWithSnap(ai, c.ozSnapshot.Snapshot, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), c.c6Travel)
 		return false
 	}, "fischl-c6")
 }

--- a/internal/characters/fischl/fischl.go
+++ b/internal/characters/fischl/fischl.go
@@ -22,7 +22,7 @@ type char struct {
 	ozActive      bool // purely used for gscl conditional purposes
 	ozActiveUntil int  // used for oz ticks, a4, c1 and c6
 	ozTickSrc     int  // used for oz recast attacks
-	c6Travel      int
+	ozTravel      int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, p profile.CharacterProfile) error {
@@ -37,10 +37,10 @@ func NewChar(s *core.Core, w *character.CharWrapper, p profile.CharacterProfile)
 	c.ozActiveUntil = -1
 	c.ozTickSrc = -1
 
-	c.c6Travel = 10
-	travel, ok := p.Params["c6_travel"]
+	c.ozTravel = 10
+	travel, ok := p.Params["oz_travel"]
 	if ok {
-		c.c6Travel = travel
+		c.ozTravel = travel
 	}
 
 	w.Character = &c

--- a/internal/characters/fischl/fischl.go
+++ b/internal/characters/fischl/fischl.go
@@ -22,9 +22,10 @@ type char struct {
 	ozActive      bool // purely used for gscl conditional purposes
 	ozActiveUntil int  // used for oz ticks, a4, c1 and c6
 	ozTickSrc     int  // used for oz recast attacks
+	c6Travel      int
 }
 
-func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
+func NewChar(s *core.Core, w *character.CharWrapper, p profile.CharacterProfile) error {
 	c := char{}
 	c.Character = tmpl.NewWithWrapper(s, w)
 
@@ -35,6 +36,12 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.ozActive = false
 	c.ozActiveUntil = -1
 	c.ozTickSrc = -1
+
+	c.c6Travel = 10
+	travel, ok := p.Params["c6_travel"]
+	if ok {
+		c.c6Travel = travel
+	}
 
 	w.Character = &c
 

--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -152,7 +152,7 @@ func (c *char) ozTick(src int) func() {
 			Write("src", src)
 		// trigger damage
 		ae := c.ozSnapshot
-		c.Core.QueueAttackEvent(&ae, 0)
+		c.Core.QueueAttackEvent(&ae, c.ozTravel)
 		// check for orb
 		// Particle check is 67% for particle, from datamine
 		// TODO: this delay used to be 120


### PR DESCRIPTION
fixes #940 by adding a default travel of 10f to fischl's c6

TODO:
- [ ] update docs at some point after merge (fischl has oz_travel param now, defaults to 10)