### PR TITLE
add passive param to platform dependent weapons

### DIFF
--- a/internal/weapons/bow/predator/predator.go
+++ b/internal/weapons/bow/predator/predator.go
@@ -27,64 +27,71 @@ func (w *Weapon) Init() error      { return nil }
 func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile) (weapon.Weapon, error) {
 	w := &Weapon{}
 
-	mATK, mDMG := make([]float64, attributes.EndStatType), make([]float64, attributes.EndStatType)
-
-	if char.Base.Key == keys.Aloy {
-		mATK[attributes.ATK] = 66
-		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("predator-atk", -1),
-			AffectedStat: attributes.NoStat,
-			Amount: func() ([]float64, bool) {
-				return mATK, true
-			},
-		})
+	passive, ok := p.Params["passive"]
+	if !ok {
+		passive = 1
 	}
 
-	buffDmgP := .10
+	if passive == 1 {
+		mATK, mDMG := make([]float64, attributes.EndStatType), make([]float64, attributes.EndStatType)
 
-	stacks := 0
-	maxStacks := 2
-	const stackKey = "predator-stacks"
-	stackDuration := 360
+		if char.Base.Key == keys.Aloy {
+			mATK[attributes.ATK] = 66
+			char.AddStatMod(character.StatMod{
+				Base:         modifier.NewBase("predator-atk", -1),
+				AffectedStat: attributes.NoStat,
+				Amount: func() ([]float64, bool) {
+					return mATK, true
+				},
+			})
+		}
 
-	c.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
-		atk := args[1].(*combat.AttackEvent)
+		buffDmgP := .10
 
-		if atk.Info.ActorIndex != char.Index {
+		stacks := 0
+		maxStacks := 2
+		const stackKey = "predator-stacks"
+		stackDuration := 360
+
+		c.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
+			atk := args[1].(*combat.AttackEvent)
+
+			if atk.Info.ActorIndex != char.Index {
+				return false
+			}
+
+			if c.Player.Active() != char.Index {
+				return false
+			}
+
+			if atk.Info.Element != attributes.Cryo {
+				return false
+			}
+
+			if !char.StatusIsActive(stackKey) {
+				stacks = 0
+			}
+
+			if stacks < maxStacks {
+				stacks++
+			}
+
+			char.AddStatus(stackKey, stackDuration, true)
+
+			char.AddAttackMod(character.AttackMod{
+				Base: modifier.NewBaseWithHitlag("predator-dmg", stackDuration),
+				Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
+					if (atk.Info.AttackTag == combat.AttackTagNormal) || (atk.Info.AttackTag == combat.AttackTagExtra) {
+						mDMG[attributes.DmgP] = buffDmgP * float64(stacks)
+						return mDMG, true
+					}
+					return nil, false
+				},
+			})
+
 			return false
-		}
-
-		if c.Player.Active() != char.Index {
-			return false
-		}
-
-		if atk.Info.Element != attributes.Cryo {
-			return false
-		}
-
-		if !char.StatusIsActive(stackKey) {
-			stacks = 0
-		}
-
-		if stacks < maxStacks {
-			stacks++
-		}
-
-		char.AddStatus(stackKey, stackDuration, true)
-
-		char.AddAttackMod(character.AttackMod{
-			Base: modifier.NewBaseWithHitlag("predator-dmg", stackDuration),
-			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-				if (atk.Info.AttackTag == combat.AttackTagNormal) || (atk.Info.AttackTag == combat.AttackTagExtra) {
-					mDMG[attributes.DmgP] = buffDmgP * float64(stacks)
-					return mDMG, true
-				}
-				return nil, false
-			},
-		})
-
-		return false
-	}, fmt.Sprintf("predator-%v", char.Base.Key.String()))
+		}, fmt.Sprintf("predator-%v", char.Base.Key.String()))
+	}
 
 	return w, nil
 }

--- a/internal/weapons/sword/swordofdescension/swordofdescension.go
+++ b/internal/weapons/sword/swordofdescension/swordofdescension.go
@@ -38,54 +38,62 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	w := &Weapon{}
 	m := make([]float64, attributes.EndStatType)
 
-	if char.Base.Key < keys.TravelerDelim {
-		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBase("swordofdescension", -1),
-			AffectedStat: attributes.NoStat,
-			Amount: func() ([]float64, bool) {
-				m[attributes.ATK] = 66
-				return m, true
-			},
-		})
+	passive, ok := p.Params["passive"]
+	if !ok {
+		passive = 1
 	}
 
-	c.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
-		atk := args[1].(*combat.AttackEvent)
-		if atk.Info.ActorIndex != char.Index {
-			return false
+	if passive == 1 {
+		if char.Base.Key < keys.TravelerDelim {
+			char.AddStatMod(character.StatMod{
+				Base:         modifier.NewBase("swordofdescension", -1),
+				AffectedStat: attributes.NoStat,
+				Amount: func() ([]float64, bool) {
+					m[attributes.ATK] = 66
+					return m, true
+				},
+			})
 		}
-		// ignore if character not on field
-		if c.Player.Active() != char.Index {
-			return false
-		}
-		// Ignore if neither a charged nor normal attack
-		if atk.Info.AttackTag != combat.AttackTagNormal && atk.Info.AttackTag != combat.AttackTagExtra {
-			return false
-		}
-		// Ignore if icd is still up
-		if char.StatusIsActive(icdKey) {
-			return false
-		}
-		// Ignore 50% of the time, 1:1 ratio
-		if c.Rand.Float64() < 0.5 {
-			return false
-		}
-		char.AddStatus(icdKey, 600, true)
 
-		ai := combat.AttackInfo{
-			ActorIndex: char.Index,
-			Abil:       "Sword of Descension Proc",
-			AttackTag:  combat.AttackTagWeaponSkill,
-			ICDTag:     combat.ICDTagNone,
-			ICDGroup:   combat.ICDGroupDefault,
-			Element:    attributes.Physical,
-			Durability: 100,
-			Mult:       2.00,
-		}
-		trg := args[0].(combat.Target)
-		c.QueueAttack(ai, combat.NewCircleHit(trg, 2), 0, 1)
+		c.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
+			atk := args[1].(*combat.AttackEvent)
+			if atk.Info.ActorIndex != char.Index {
+				return false
+			}
+			// ignore if character not on field
+			if c.Player.Active() != char.Index {
+				return false
+			}
+			// Ignore if neither a charged nor normal attack
+			if atk.Info.AttackTag != combat.AttackTagNormal && atk.Info.AttackTag != combat.AttackTagExtra {
+				return false
+			}
+			// Ignore if icd is still up
+			if char.StatusIsActive(icdKey) {
+				return false
+			}
+			// Ignore 50% of the time, 1:1 ratio
+			if c.Rand.Float64() < 0.5 {
+				return false
+			}
+			char.AddStatus(icdKey, 600, true)
 
-		return false
-	}, fmt.Sprintf("swordofdescension-%v", char.Base.Key.String()))
+			ai := combat.AttackInfo{
+				ActorIndex: char.Index,
+				Abil:       "Sword of Descension Proc",
+				AttackTag:  combat.AttackTagWeaponSkill,
+				ICDTag:     combat.ICDTagNone,
+				ICDGroup:   combat.ICDGroupDefault,
+				Element:    attributes.Physical,
+				Durability: 100,
+				Mult:       2.00,
+			}
+			trg := args[0].(combat.Target)
+			c.QueueAttack(ai, combat.NewCircleHit(trg, 2), 0, 1)
+
+			return false
+		}, fmt.Sprintf("swordofdescension-%v", char.Base.Key.String()))
+	}
+
 	return w, nil
 }


### PR DESCRIPTION
fixes #949 

TODO: 
- [ ] update docs at some point after merge (predator and swordofdescension now have a "passive" param that defaults to 1 (passive enabled))