### PR TITLE
fix xiao c6

### DIFF
--- a/internal/characters/xiao/cons.go
+++ b/internal/characters/xiao/cons.go
@@ -55,7 +55,10 @@ func (c *char) c6cb() combat.AttackCBFunc {
 		return nil
 	}
 	c.c6Count = 0
-	return func(_ combat.AttackCB) {
+	return func(a combat.AttackCB) {
+		if a.Target.Type() != combat.TargettableEnemy {
+			return
+		}
 		if !c.StatusIsActive(burstBuffKey) {
 			return
 		}

--- a/internal/characters/xiao/cons.go
+++ b/internal/characters/xiao/cons.go
@@ -4,7 +4,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/modifier"
@@ -51,44 +50,28 @@ const c6BuffKey = "xiao-c6"
 // Implements Xiao C6:
 // While under the effect of Bane of All Evil, hitting at least 2 opponents with Xiao's Plunge Attack will immediately grant him 1 charge of Lemniscatic Wind Cycling, and for the next 1s, he may use Lemniscatic Wind Cycling while ignoring its CD.
 // Adds an OnDamage event checker - if we record two or more instances of plunge damage, then activate C6
-func (c *char) c6() {
-	c.Core.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
-		atk := args[1].(*combat.AttackEvent)
-		if atk.Info.ActorIndex != c.Index {
-			return false
-		}
-		if !((atk.Info.Abil == "High Plunge") || (atk.Info.Abil == "Low Plunge")) {
-			return false
-		}
+func (c *char) c6cb() combat.AttackCBFunc {
+	if c.Base.Cons < 6 {
+		return nil
+	}
+	c.c6Count = 0
+	return func(_ combat.AttackCB) {
 		if !c.StatusIsActive(burstBuffKey) {
-			return false
+			return
 		}
-		// Stops after reaching 2 hits on a single plunge.
-		// Plunge frames are greater than duration of C6 so this will always refresh properly.
 		if c.StatusIsActive(c6BuffKey) {
-			//do nothing if buff still on
-			return false
+			return
 		}
-		if c.c6Src != atk.SourceFrame {
-			c.c6Src = atk.SourceFrame
-			c.c6Count = 0
-			return false
-		}
-
 		c.c6Count++
-
-		// Prevents activation more than once in a single plunge attack
 		if c.c6Count == 2 {
 			c.ResetActionCooldown(action.ActionSkill)
-
-			c.AddStatus(c6BuffKey, 60, true)
+			// 1.2s to cover 3 consecutive skills
+			c.AddStatus(c6BuffKey, 72, true)
 			c.Core.Log.NewEvent("Xiao C6 activated", glog.LogCharacterEvent, c.Index).
 				Write("new E charges", c.Tags["eCharge"]).
 				Write("expiry", c.Core.F+60)
 
 			c.c6Count = 0
-			return false
 		}
-		return false
-	}, "xiao-c6")
+	}
 }

--- a/internal/characters/xiao/plunge.go
+++ b/internal/characters/xiao/plunge.go
@@ -65,7 +65,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       highplunge[c.TalentLvlAttack()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), highPlungeHitmark, highPlungeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), highPlungeHitmark, highPlungeHitmark, c.c6cb())
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(highPlungeFrames),
@@ -110,7 +110,7 @@ func (c *char) LowPlungeAttack(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       lowplunge[c.TalentLvlAttack()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), lowPlungeHitmark, lowPlungeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), lowPlungeHitmark, lowPlungeHitmark, c.c6cb())
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(lowPlungeFrames),

--- a/internal/characters/xiao/xiao.go
+++ b/internal/characters/xiao/xiao.go
@@ -22,7 +22,6 @@ type char struct {
 	qStarted int
 	a4stacks int
 	a4buff   []float64
-	c6Src    int
 	c6Count  int
 }
 
@@ -57,9 +56,6 @@ func (c *char) Init() error {
 	}
 	if c.Base.Cons >= 4 {
 		c.c4()
-	}
-	if c.Base.Cons >= 6 {
-		c.c6()
 	}
 	return nil
 }


### PR DESCRIPTION
fixes #1064 
- xiao c6 required 3 hits to proc before
- xiao c6 didn't allow for 3 consecutive skills without charges being consumed before