### PR TITLE
targeting and approximate hitbox radius update

### DIFF
--- a/internal/characters/albedo/attack.go
+++ b/internal/characters/albedo/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{12, 11, 17, 17, 27}
-var attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{12, 11, 17, 17, 27}
+	attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
+	attackRadius          = []float64{1.6, 2, 1.98, 2, 2}
+)
 
 const normalHitNum = 5
 
@@ -49,11 +52,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	//we don't need to use char queue here since each hit is single hit
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/albedo/burst.go
+++ b/internal/characters/albedo/burst.go
@@ -53,8 +53,11 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// TODO: no precise frame data for time between Blossoms
 	ai.Abil = "Rite of Progeniture: Tectonic Tide (Blossom)"
 	ai.Mult = burstPerBloom[c.TalentLvlBurst()]
+	x, y := c.Core.Combat.Player().Pos()
+	enemies := c.Core.Combat.EnemiesWithinRadius(x, y, 10)
 	for i := 0; i < hits; i++ {
-		c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHit(c.Core.Combat.Player(), 3), fatalBlossomHitmark+i*5)
+		ind := c.Core.Rand.Intn(len(enemies))
+		c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHit(c.Core.Combat.Enemy(enemies[ind]), 3), fatalBlossomHitmark+i*5)
 	}
 
 	//Party wide EM buff

--- a/internal/characters/albedo/burst.go
+++ b/internal/characters/albedo/burst.go
@@ -47,7 +47,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 
 	//TODO: damage frame
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), burstHitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 8), burstHitmark)
 
 	// Blossoms are generated on a slight delay from initial hit
 	// TODO: no precise frame data for time between Blossoms

--- a/internal/characters/albedo/charge.go
+++ b/internal/characters/albedo/charge.go
@@ -35,7 +35,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.2), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/albedo/skill.go
+++ b/internal/characters/albedo/skill.go
@@ -39,7 +39,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 	// TODO: damage frame
 	c.bloomSnapshot = c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHit(c.Core.Combat.Player(), 3), skillHitmark)
+	c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5), skillHitmark)
 
 	// snapshot for ticks
 	ai.Abil = "Abiogenesis: Solar Isotoma (Tick)"
@@ -100,7 +100,7 @@ func (c *char) skillHook() {
 		c.Core.QueueAttackWithSnap(
 			c.skillAttackInfo,
 			c.skillSnapshot,
-			combat.NewCircleHit(c.Core.Combat.Player(), 3),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3.4),
 			1,
 		)
 

--- a/internal/characters/aloy/aimed.go
+++ b/internal/characters/aloy/aimed.go
@@ -41,7 +41,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		HitlagOnHeadshotOnly: true,
 		IsDeployable:         true,
 	}
-	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), aimedHitmark, aimedHitmark+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), aimedHitmark, aimedHitmark+travel)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(aimedFrames),

--- a/internal/characters/aloy/attack.go
+++ b/internal/characters/aloy/attack.go
@@ -9,8 +9,10 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackHitmarks = [][]int{{11, 24}, {16}, {23}, {30}}
-var attackFrames [][]int
+var (
+	attackFrames   [][]int
+	attackHitmarks = [][]int{{11, 24}, {16}, {23}, {30}}
+)
 
 const normalHitNum = 4
 
@@ -50,7 +52,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		c.Core.QueueAttack(
 			ai,
-			combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 			attackHitmarks[c.NormalCounter][i],
 			attackHitmarks[c.NormalCounter][i]+travel)
 	}

--- a/internal/characters/aloy/burst.go
+++ b/internal/characters/aloy/burst.go
@@ -36,7 +36,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Mult:       burst[c.TalentLvlBurst()],
 	}
 	snap := c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), burstHitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6.5), burstHitmark)
 
 	c.SetCD(action.ActionBurst, 12*60)
 	c.ConsumeEnergy(2)

--- a/internal/characters/aloy/skill.go
+++ b/internal/characters/aloy/skill.go
@@ -66,7 +66,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		}
 		c.coilStacks()
 		// TODO: accurate snapshot timing, assumes snapshot on release and not on hit/bomb creation
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 0, travel)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4), 0, travel)
 	}, skillHitmark)
 
 	// Bomblets snapshot on cast
@@ -86,7 +86,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	// Queue up bomblets
 	for i := 0; i < bomblets; i++ {
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 0,
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 2), 0,
 			skillHitmark+travel+delay+((i+1)*6))
 	}
 

--- a/internal/characters/amber/aimed.go
+++ b/internal/characters/amber/aimed.go
@@ -54,11 +54,11 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		Mult:         aim[c.TalentLvlAttack()],
 		HitWeakPoint: weakspot == 1,
 	}
-	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), aimedHitmark, aimedHitmark+travel, c.a4)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), aimedHitmark, aimedHitmark+travel, c.a4)
 
 	if c.Base.Cons >= 1 {
 		ai.Mult = .2 * ai.Mult
-		c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), c1Hitmark, c1Hitmark+travel)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), c1Hitmark, c1Hitmark+travel)
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/amber/attack.go
+++ b/internal/characters/amber/attack.go
@@ -43,7 +43,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)

--- a/internal/characters/amber/bunny.go
+++ b/internal/characters/amber/bunny.go
@@ -30,7 +30,7 @@ func (c *char) makeBunny() {
 	snap := c.Snapshot(&ai)
 	b.ae = combat.AttackEvent{
 		Info:        ai,
-		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 3),
 		SourceFrame: c.Core.F,
 		Snapshot:    snap,
 	}

--- a/internal/characters/amber/burst.go
+++ b/internal/characters/amber/burst.go
@@ -41,13 +41,13 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	//TODO: properly implement random hits and hit box range. right now everything is just radius 3
 	for i := 24; i < 120; i += 24 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), burstStart+i)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2.6), burstStart+i)
 	}
 	for i := 36; i < 120; i += 36 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), burstStart+i)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2.6), burstStart+i)
 	}
 	for i := 12; i < 120; i += 12 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), burstStart+i)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2.6), burstStart+i)
 	}
 
 	if c.Base.Cons >= 6 {

--- a/internal/characters/ayaka/attack.go
+++ b/internal/characters/ayaka/attack.go
@@ -9,11 +9,14 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{8}, {10}, {16}, {8, 15, 22}, {27}}
-var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0, 0.03}, {0}}
-var attackHitlagFactor = [][]float64{{0.01}, {0.01}, {0.01}, {0, 0, 0.05}, {0.01}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false, true}, {false}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{8}, {10}, {16}, {8, 15, 22}, {27}}
+	attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0, 0.03}, {0}}
+	attackHitlagFactor    = [][]float64{{0.01}, {0.01}, {0.01}, {0, 0, 0.05}, {0.01}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, false, true}, {false}}
+	attackRadius          = []float64{1.6, 1.2, 2.8, 1.6, 0.8}
+)
 
 const normalHitNum = 5
 
@@ -39,8 +42,10 @@ func init() {
 func (c *char) Attack(p map[string]int) action.ActionInfo {
 	for i, mult := range attack[c.NormalCounter] {
 		icdGroup := combat.ICDGroupDefault
+		centerTarget := c.Core.Combat.Player()
 		if c.NormalCounter == 4 {
-			icdGroup = combat.ICDGroupPoleExtraAttack // N5 has a different ICDGroup
+			icdGroup = combat.ICDGroupPoleExtraAttack    // N5 has a different ICDGroup
+			centerTarget = c.Core.Combat.PrimaryTarget() // N5 is a bullet
 		}
 		ai := combat.AttackInfo{
 			Abil:               fmt.Sprintf("Normal %v", c.NormalCounter),
@@ -56,10 +61,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 			Mult:               mult[c.TalentLvlAttack()],
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(centerTarget, radius),
 				0,
 				0,
 				c.c1,

--- a/internal/characters/ayaka/burst.go
+++ b/internal/characters/ayaka/burst.go
@@ -34,7 +34,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	ai.Mult = burstBloom[c.TalentLvlBurst()]
 	ai.StrikeType = combat.StrikeTypeDefault
 	ai.Abil = "Soumetsu (Bloom)"
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark, burstHitmark+300, c.c4)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5), burstHitmark, burstHitmark+300, c.c4)
 
 	// C2 mini-frostflake bloom
 	var aiC2 combat.AttackInfo
@@ -43,15 +43,15 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		aiC2.Mult = burstBloom[c.TalentLvlBurst()] * .2
 		aiC2.Abil = "C2 Mini-Frostflake Seki no To (Bloom)"
 		// TODO: Not sure about the positioning/size...
-		c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.Player(), 2), burstHitmark, burstHitmark+300, c.c4)
-		c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.Player(), 2), burstHitmark, burstHitmark+300, c.c4)
+		c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3), burstHitmark, burstHitmark+300, c.c4)
+		c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3), burstHitmark, burstHitmark+300, c.c4)
 	}
 
 	for i := 0; i < 19; i++ {
 		ai.Mult = burstCut[c.TalentLvlBurst()]
 		ai.StrikeType = combat.StrikeTypeSlash
 		ai.Abil = "Soumetsu (Cutting)"
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark, burstHitmark+i*15, c.c4)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3), burstHitmark, burstHitmark+i*15, c.c4)
 
 		// C2 mini-frostflake cutting
 		if c.Base.Cons >= 2 {
@@ -59,8 +59,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			aiC2.StrikeType = combat.StrikeTypeSlash
 			aiC2.Abil = "C2 Mini-Frostflake Seki no To (Cutting)"
 			// TODO: Not sure about the positioning/size...
-			c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.Player(), 2), burstHitmark, burstHitmark+i*15, c.c4)
-			c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.Player(), 2), burstHitmark, burstHitmark+i*15, c.c4)
+			c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5), burstHitmark, burstHitmark+i*15, c.c4)
+			c.Core.QueueAttack(aiC2, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5), burstHitmark, burstHitmark+i*15, c.c4)
 		}
 	}
 

--- a/internal/characters/ayaka/charge.go
+++ b/internal/characters/ayaka/charge.go
@@ -35,7 +35,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i := 0; i < 3; i++ {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 2),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1),
 			chargeHitmarks[i],
 			chargeHitmarks[i],
 			c.c1,

--- a/internal/characters/ayaka/skill.go
+++ b/internal/characters/ayaka/skill.go
@@ -44,7 +44,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		},
 	})
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), 0, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4.5), 0, skillHitmark)
 
 	// 4 or 5, 1:1 ratio
 	var count float64 = 4

--- a/internal/characters/ayato/attack.go
+++ b/internal/characters/ayato/attack.go
@@ -9,11 +9,14 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{12}, {18}, {20}, {22, 25}, {41}}
-var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0}, {0.08}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false}, {true}}
-var shunsuikenFrames []int
+var (
+	shunsuikenFrames      []int
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{12}, {18}, {20}, {22, 25}, {41}}
+	attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0}, {0.08}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, false}, {true}}
+	attackRadius          = []float64{1.7, 1.7, 1.61, 1.64, 3.16}
+)
 
 const normalHitNum = 5
 const shunsuikenHitmark = 5
@@ -61,10 +64,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)
@@ -98,7 +102,7 @@ func (c *char) SoukaiKanka(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   0.03 * 60,
 		CanBeDefenseHalted: false,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, shunsuikenHitmark, c.generateParticles, c.skillStacks)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5.32), 0, shunsuikenHitmark, c.generateParticles, c.skillStacks)
 
 	defer c.AdvanceNormalIndex()
 

--- a/internal/characters/ayato/burst.go
+++ b/internal/characters/ayato/burst.go
@@ -70,12 +70,19 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			// log.Println(target)
 			//[1:14 PM] Aluminum | Harbinger of Jank: assuming uniform distribution and enemy at center:
 			//(radius_droplet + radius_enemy)^2 / radius_burst^2
-			if target == -1 && c.Core.Rand.Float64() > prob {
-				//no one getting hit
-				return
+			trg := c.Core.Combat.Enemy(target)
+			if target == -1 {
+				if c.Core.Rand.Float64() > prob {
+					// no one getting hit
+					return
+				} else {
+					// droplet is not targeted but randomly clips enemy
+					// TODO: enemies within radius?
+					trg = c.Core.Combat.Enemy(c.Core.Combat.RandomEnemyTarget())
+				}
 			}
 			//deal dmg
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 9), 0)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(trg, 2.5), 0)
 		}, delay+139)
 	}
 

--- a/internal/characters/ayato/charge.go
+++ b/internal/characters/ayato/charge.go
@@ -31,7 +31,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Mult:       ca[c.TalentLvlAttack()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/ayato/cons.go
+++ b/internal/characters/ayato/cons.go
@@ -72,8 +72,8 @@ func (c *char) c6() {
 			CanBeDefenseHalted: false,
 			IsDeployable:       true,
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 20, 20)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 22, 22)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5.32), 20, 20)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5.32), 22, 22)
 
 		c.Core.Log.NewEvent("ayato c6 proc'd", glog.LogCharacterEvent, c.Index)
 		c.c6ready = false

--- a/internal/characters/barbara/attack.go
+++ b/internal/characters/barbara/attack.go
@@ -13,6 +13,7 @@ import (
 var (
 	attackFrames   [][]int
 	attackHitmarks = []int{6, 11, 12, 32}
+	attackRadius   = []float64{1, 1, 1, 2}
 )
 
 const normalHitNum = 4
@@ -71,9 +72,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			done = true
 		}
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 		cb,

--- a/internal/characters/barbara/charge.go
+++ b/internal/characters/barbara/charge.go
@@ -75,7 +75,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 
 	// TODO: Not sure of snapshot timing
 	c.Core.QueueAttack(ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3),
 		chargeHitmark-windup,
 		chargeHitmark-windup,
 		cb,

--- a/internal/characters/barbara/skill.go
+++ b/internal/characters/barbara/skill.go
@@ -48,11 +48,10 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 
 	// 2 Droplets
-	// TODO: review barbara AOE size?
 	for _, hitmark := range skillHitmarks {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 1),
+			combat.NewCircleHit(c.Core.Combat.Player(), 3),
 			5,
 			hitmark,
 		) // need to confirm snapshot timing

--- a/internal/characters/beidou/attack.go
+++ b/internal/characters/beidou/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{23, 22, 45, 25, 43}
-var attackHitlagHaltFrame = []float64{.09, .12, .09, .09, .12}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{23, 22, 45, 25, 43}
+	attackHitlagHaltFrame = []float64{.09, .12, .09, .09, .12}
+	attackRadius          = []float64{2, 1.6, 2, 2, 1.8}
+)
 
 const normalHitNum = 5
 
@@ -40,10 +43,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 1),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/beidou/skill.go
+++ b/internal/characters/beidou/skill.go
@@ -8,8 +8,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/player/shield"
 )
 
-var skillFrames []int
-var skillHitlagStages = []float64{.09, .09, .15}
+var (
+	skillFrames       []int
+	skillHitlagStages = []float64{.09, .09, .15}
+	skillRadius       = []float64{6, 7, 8}
+)
 
 const skillHitmark = 23
 
@@ -42,7 +45,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   skillHitlagStages[counter] * 60,
 		CanBeDefenseHalted: true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), skillHitmark, skillHitmark)
+	radius := skillRadius[counter]
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), skillHitmark, skillHitmark)
 
 	//2 if no hit, 3 if 1 hit, 4 if perfect
 	c.Core.QueueParticle("beidou", 2+float64(counter), attributes.Electro, skillHitmark+c.ParticleDelay)

--- a/internal/characters/bennett/attack.go
+++ b/internal/characters/bennett/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{13, 9, 13, 25, 24}
-var attackHitlagHaltFrames = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
+var (
+	attackFrames           [][]int
+	attackHitmarks         = []int{13, 9, 13, 25, 24}
+	attackHitlagHaltFrames = []float64{0.03, 0.03, 0.06, 0.09, 0.12}
+	attackRadius           = []float64{1.2, 1.2, 2, 1.82, 2}
+)
 
 const normalHitNum = 5
 
@@ -49,10 +52,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 		Mult:               attack[c.NormalCounter][c.TalentLvlAttack()],
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/bennett/charge.go
+++ b/internal/characters/bennett/charge.go
@@ -35,7 +35,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.2), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/bennett/skill.go
+++ b/internal/characters/bennett/skill.go
@@ -9,8 +9,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var skillFrames [][]int
-var skillHoldHitmarks = [][]int{{45, 57}, {112, 121}}
+var (
+	skillFrames       [][]int
+	skillHoldHitmarks = [][]int{{45, 57}, {112, 121}}
+	skillHoldRadius   = []float64{2.5, 2.12}
+)
 
 const skillPressHitmark = 16
 
@@ -85,7 +88,7 @@ func (c *char) skillPress() action.ActionInfo {
 		Mult:               skill[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), skillPressHitmark, skillPressHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.5), skillPressHitmark, skillPressHitmark)
 
 	//25 % chance of 3 orbs
 	var count float64 = 2
@@ -130,10 +133,11 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 		ax := ai
 		ax.Mult = v[c.TalentLvlSkill()]
 		ax.HitlagHaltFrames = 0.09 * 60
+		radius := skillHoldRadius[i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ax,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)
@@ -143,7 +147,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 		ai.StrikeType = combat.StrikeTypeDefault
 		ai.Mult = explosion[c.TalentLvlSkill()]
 		ai.HitlagHaltFrames = 0
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 166, 166)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3.5), 166, 166)
 	}
 
 	//user-specified c4 variant adds an additional attack that deals 135% of the second hit
@@ -151,7 +155,7 @@ func (c *char) skillHold(level int, c4Active bool) action.ActionInfo {
 		ai.Mult = skillHold[level-1][1][c.TalentLvlSkill()] * 1.35
 		ai.Abil = "Passion Overload (C4)"
 		ai.HitlagHaltFrames = 0.12 * 60
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 94, 94)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.5), 94, 94)
 
 	}
 

--- a/internal/characters/candace/attack.go
+++ b/internal/characters/candace/attack.go
@@ -20,8 +20,7 @@ var (
 		{combat.StrikeTypeSlash, combat.StrikeTypeSlash},
 		{combat.StrikeTypeSpear},
 	}
-	// {{radius 2.5 circle}, {x=2.2 z=3.0 box}, {radius 2.5 fanAngle 270 circle, radius 2.5 fanAngle 270 circle}, {x=2.2 z=7.0 box}}
-	attackRadius = []float64{2.5, 1.5, 2.5, 3.5}
+	attackRadius = []float64{2.5, 1.86, 2.5, 3.67}
 )
 
 const normalHitNum = 4
@@ -56,11 +55,12 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackHitlagDefHalt[c.NormalCounter][i],
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.Core.QueueAttack(
 			ai,
 			combat.NewCircleHit(
 				c.Core.Combat.Player(),
-				attackRadius[c.NormalCounter],
+				radius,
 			),
 			attackHitmarks[c.NormalCounter][i],
 			attackHitmarks[c.NormalCounter][i],

--- a/internal/characters/candace/charge.go
+++ b/internal/characters/candace/charge.go
@@ -39,7 +39,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.8),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8),
 		0,
 		chargeHitmark,
 	)

--- a/internal/characters/candace/skill.go
+++ b/internal/characters/candace/skill.go
@@ -13,7 +13,7 @@ var (
 	skillHitmarks = []int{16, 91}
 	skillCDStarts = []int{14, 89}
 	skillCD       = []int{360, 540}
-	skillRadius   = []float64{4, 2.25}
+	skillRadius   = []float64{2.7, 4}
 )
 
 func init() {
@@ -64,12 +64,12 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		c.Core.QueueParticle("candace", 3, attributes.Hydro, c.ParticleDelay+hitmark)
 		ai.Abil = "Sacred Rite: Heron's Sanctum Charged Up (E)"
 	}
-
+	radius := skillRadius[chargeLevel]
 	c.Core.QueueAttack(
 		ai,
 		combat.NewCircleHit(
 			c.Core.Combat.Player(),
-			skillRadius[chargeLevel],
+			radius,
 		),
 		hitmark,
 		hitmark,

--- a/internal/characters/chongyun/attack.go
+++ b/internal/characters/chongyun/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{26, 24, 41, 53}
-var attackHitlagHaltFrame = []float64{.1, .09, .12, .12}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{26, 24, 41, 53}
+	attackHitlagHaltFrame = []float64{.1, .09, .12, .12}
+	attackRadius          = []float64{2, 2, 2, 1.8}
+)
 
 const normalHitNum = 4
 
@@ -39,9 +42,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 1),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/chongyun/burst.go
+++ b/internal/characters/chongyun/burst.go
@@ -36,12 +36,12 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	// Spirit Blade 1-3
 	for _, hitmark := range burstHitmarks {
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), hitmark, hitmark)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3.5), hitmark, hitmark)
 	}
 
 	// extra Spirit Blade at C6
 	if c.Base.Cons >= 6 {
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmarkC6, burstHitmarkC6)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3.5), burstHitmarkC6, burstHitmarkC6)
 	}
 
 	c.SetCD(action.ActionBurst, 720)

--- a/internal/characters/chongyun/skill.go
+++ b/internal/characters/chongyun/skill.go
@@ -46,7 +46,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   0.09 * 60,
 		CanBeDefenseHalted: false,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 0, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.5), 0, skillHitmark)
 
 	c.Core.QueueParticle("chongyun", 4, attributes.Cryo, skillHitmark+c.ParticleDelay)
 
@@ -87,7 +87,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	c.a4Snap = &combat.AttackEvent{
 		Info:     ai,
 		Snapshot: snap,
-		Pattern:  combat.NewCircleHit(c.Core.Combat.Player(), 3),
+		Pattern:  combat.NewCircleHit(c.Core.Combat.Player(), 3.5),
 	}
 	c.a4Snap.Callbacks = append(c.a4Snap.Callbacks, cb)
 

--- a/internal/characters/collei/aimed.go
+++ b/internal/characters/collei/aimed.go
@@ -49,7 +49,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 	}
 
 	c.Core.QueueAttack(ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		a.CanQueueAfter,
 		a.CanQueueAfter+travel,
 	)

--- a/internal/characters/collei/asc.go
+++ b/internal/characters/collei/asc.go
@@ -79,7 +79,7 @@ func (c *char) a1Ticks(startFrame int, snap combat.Snapshot) {
 	c.Core.QueueAttackWithSnap(
 		c.a1AttackInfo(),
 		snap,
-		combat.NewCircleHit(c.Core.Combat.Player(), 5),
+		combat.NewCircleHit(c.Core.Combat.Player(), 2),
 		0,
 	)
 	c.Core.Tasks.Add(func() {

--- a/internal/characters/collei/attack.go
+++ b/internal/characters/collei/attack.go
@@ -41,7 +41,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)

--- a/internal/characters/collei/burst.go
+++ b/internal/characters/collei/burst.go
@@ -37,7 +37,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 5),
+		combat.NewCircleHit(c.Core.Combat.Player(), 5.5),
 		explosionHitmark,
 		explosionHitmark,
 	)
@@ -84,7 +84,7 @@ func (c *char) burstTicks(snap combat.Snapshot) {
 	c.Core.QueueAttackWithSnap(
 		ai,
 		snap,
-		combat.NewCircleHit(c.Core.Combat.Player(), 5),
+		combat.NewCircleHit(c.Core.Combat.Player(), 4),
 		0,
 	)
 	c.Core.Tasks.Add(func() {

--- a/internal/characters/collei/cons.go
+++ b/internal/characters/collei/cons.go
@@ -60,7 +60,7 @@ func (c *char) c4() {
 	}
 }
 
-func (c *char) c6() {
+func (c *char) c6(t combat.Target) {
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Forest of Falling Arrows (C6)",
@@ -74,7 +74,7 @@ func (c *char) c6() {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(t, 4),
 		0,
 		22,
 	)

--- a/internal/characters/collei/skill.go
+++ b/internal/characters/collei/skill.go
@@ -48,12 +48,12 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	var c6Cb func(a combat.AttackCB)
 	if c.Base.Cons >= 6 {
 		c6Triggered := false
-		c6Cb = func(_ combat.AttackCB) {
+		c6Cb = func(a combat.AttackCB) {
 			if c6Triggered {
 				return
 			}
 			c6Triggered = true
-			c.c6()
+			c.c6(a.Target)
 		}
 	}
 	for _, hitmark := range skillHitmarks {

--- a/internal/characters/cyno/attack.go
+++ b/internal/characters/cyno/attack.go
@@ -14,6 +14,7 @@ var (
 	attackHitmarks        = [][]int{{14}, {17}, {13, 22}, {27}}
 	attackHitlagHaltFrame = [][]float64{{0.01}, {0.06}, {0, 0.02}, {0.04}}
 	attackDefHalt         = [][]bool{{false}, {true}, {false, true}, {true}}
+	attackRadius          = []float64{1.8, 1.62, 2.11, 2.3}
 )
 
 const normalHitNum = 4
@@ -55,9 +56,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 2 {
 			ai.StrikeType = combat.StrikeTypeSpear
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.Core.QueueAttack(
 			ai,
-			c.attackPattern(c.NormalCounter),
+			combat.NewCircleHit(c.Core.Combat.Player(), radius),
 			attackHitmarks[c.NormalCounter][i],
 			attackHitmarks[c.NormalCounter][i],
 		)
@@ -73,26 +75,6 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 }
 
-func (c *char) attackPattern(attackIndex int) combat.AttackPattern {
-	switch attackIndex {
-	case 0:
-		return combat.NewCircleHit(c.Core.Combat.Player(), 1.8)
-	case 1:
-		return combat.NewCircleHit(
-			c.Core.Combat.Player(),
-			1.35,
-		) // supposed to be box x=1.8,z=2.7
-	case 2:
-		return combat.NewCircleHit(
-			c.Core.Combat.Player(),
-			1.8,
-		) // both hits supposed to be box x=2.2,z=3.6
-	case 3:
-		return combat.NewCircleHit(c.Core.Combat.Player(), 2.3)
-	}
-	panic("unreachable code")
-}
-
 const burstHitNum = 5
 
 var (
@@ -100,6 +82,7 @@ var (
 	attackBHitmarks        = [][]int{{12}, {14}, {18}, {5, 14}, {40}}
 	attackBHitlagHaltFrame = [][]float64{{0.01}, {0.01}, {0.03}, {0.01, 0.03}, {0.05}}
 	attackBDefHalt         = [][]bool{{false}, {false}, {false}, {false, false}, {true}}
+	attackBRadius          = []float64{2, 2, 3.25, 2.5, 3.5}
 )
 
 func init() {
@@ -144,8 +127,9 @@ func (c *char) attackB(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 2 || c.NormalCounter == 4 {
 			ai.StrikeType = combat.StrikeTypeBlunt
 		}
+		radius := attackBRadius[c.normalBCounter]
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(ai, c.attackBPattern(c.normalBCounter), 0, 0)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), 0, 0)
 		}, attackBHitmarks[c.normalBCounter][i])
 	}
 
@@ -163,26 +147,4 @@ func (c *char) attackB(p map[string]int) action.ActionInfo {
 		CanQueueAfter:   attackBHitmarks[c.normalBCounter][len(attackBHitmarks[c.normalBCounter])-1],
 		State:           action.NormalAttackState,
 	}
-}
-
-func (c *char) attackBPattern(attackIndex int) combat.AttackPattern {
-	switch attackIndex {
-	case 0:
-		return combat.NewCircleHit(c.Core.Combat.Player(), 2)
-	case 1:
-		return combat.NewCircleHit(c.Core.Combat.Player(), 2)
-	case 2:
-		return combat.NewCircleHit(
-			c.Core.Combat.Player(),
-			3.0,
-		) // supposed to be box x=2.5,z=6.0
-	case 3: // both hits are 2.5m radius circles
-		return combat.NewCircleHit(
-			c.Core.Combat.Player(),
-			2.5,
-		)
-	case 4:
-		return combat.NewCircleHit(c.Core.Combat.Player(), 3.5)
-	}
-	panic("unreachable code")
 }

--- a/internal/characters/cyno/charge.go
+++ b/internal/characters/cyno/charge.go
@@ -42,7 +42,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.5),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8),
 		0,
 		chargeHitmark,
 	)
@@ -90,7 +90,7 @@ func (c *char) chargeB(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 5),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8),
 		0,
 		chargeBHitmark,
 	)

--- a/internal/characters/cyno/cons.go
+++ b/internal/characters/cyno/cons.go
@@ -160,7 +160,7 @@ func (c *char) c6() {
 
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.3),
 			0,
 			0,
 		)

--- a/internal/characters/cyno/skill.go
+++ b/internal/characters/cyno/skill.go
@@ -49,7 +49,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 1),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1),
 		skillHitmark,
 		skillHitmark,
 	)

--- a/internal/characters/diluc/attack.go
+++ b/internal/characters/diluc/attack.go
@@ -13,6 +13,7 @@ var (
 	attackFrames          [][]int
 	attackHitmarks        = []int{24, 39, 26, 49}
 	attackHitlagHaltFrame = []float64{.1, .09, .09, .12}
+	attackRadius          = []float64{2, 1.8, 2, 1.8}
 )
 
 const normalHitNum = 4
@@ -46,10 +47,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 1),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/diluc/burst.go
+++ b/internal/characters/diluc/burst.go
@@ -29,13 +29,13 @@ func (c *char) phoenixDMG(ai combat.AttackInfo, dot int, explode int) func() {
 		// DoT does max 7 hits + explosion, roughly every 13 frame? blows up at 210 frames
 		// DoT
 		for i := 0; i < dot; i++ {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, i*12)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 8.94), 0, i*12)
 		}
 		// Explosion
 		if explode > 0 {
 			ai.Abil = "Dawn (Explode)"
 			ai.Mult = burstExplode[c.TalentLvlBurst()]
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, 98)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 9.43), 0, 98)
 		}
 	}
 }
@@ -84,7 +84,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			CanBeDefenseHalted: true,
 		}
 
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, 1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 8.54), 0, 1)
 
 		ai.StrikeType = combat.StrikeTypeDefault
 		// both initial hit, DoT and explosion all have 50 durability

--- a/internal/characters/diluc/skill.go
+++ b/internal/characters/diluc/skill.go
@@ -15,6 +15,7 @@ var (
 	skillFrames       [][]int
 	skillHitmarks     = []int{24, 28, 46}
 	skillHitlagStages = []float64{.12, .12, .16}
+	skillRadius       = []float64{2.3, 2.2, 2.65}
 )
 
 func init() {
@@ -93,10 +94,10 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   skillHitlagStages[c.eCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
-
+	radius := skillRadius[c.eCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		hitmark,
 		hitmark,
 	)

--- a/internal/characters/diona/aimed.go
+++ b/internal/characters/diona/aimed.go
@@ -68,7 +68,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 	}
 
 	c.Core.QueueAttack(ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		a.CanQueueAfter,
 		a.CanQueueAfter+travel,
 	)

--- a/internal/characters/diona/attack.go
+++ b/internal/characters/diona/attack.go
@@ -49,7 +49,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)

--- a/internal/characters/diona/burst.go
+++ b/internal/characters/diona/burst.go
@@ -33,7 +33,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       burst[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0, burstStart)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 0, burstStart)
 
 	ai.Abil = "Signature Mix (Tick)"
 	ai.Mult = burstDot[c.TalentLvlBurst()]
@@ -50,7 +50,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		//ticks every 2s, first tick at t=2s (relative to field start), then t=4,6,8,10,12; lasts for 12.5s from field start
 		for i := 0; i < 6; i++ {
 			c.Core.Tasks.Add(func() {
-				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0)
+				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 6.5), 0)
 				// c.Core.Log.NewEvent("diona healing", core.LogCharacterEvent, c.Index, "+heal", hpplus, "max hp", maxhp, "heal amount", heal)
 				c.Core.Player.Heal(player.HealInfo{
 					Caller:  c.Index,

--- a/internal/characters/diona/skill.go
+++ b/internal/characters/diona/skill.go
@@ -128,6 +128,6 @@ func (c *char) pawsPewPew(f, travel, pawCount int) {
 	for i := 0; i < pawCount; i++ {
 		done := false
 		cb := pawCB(done)
-		c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), 0, travel+f-5+i, cb)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), 0, travel+f-5+i, cb)
 	}
 }

--- a/internal/characters/eula/attack.go
+++ b/internal/characters/eula/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{30}, {19}, {25, 42}, {17}, {29, 56}}
-var attackHitlagHaltFrame = [][]float64{{0.09}, {.12}, {0, .09}, {.09}, {0, .12}}
-var attackDefHalt = [][]bool{{true}, {true}, {false, true}, {true}, {false, true}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{30}, {19}, {25, 42}, {17}, {29, 56}}
+	attackHitlagHaltFrame = [][]float64{{0.09}, {.12}, {0, .09}, {.09}, {0, .12}}
+	attackDefHalt         = [][]bool{{true}, {true}, {false, true}, {true}, {false, true}}
+	attackRadius          = []float64{2, 2, 2, 2, 1.8}
+)
 
 const normalHitNum = 5
 
@@ -43,10 +46,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/eula/burst.go
+++ b/internal/characters/eula/burst.go
@@ -48,7 +48,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 50,
 		Mult:       burstInitial[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 8), burstHitmark, burstHitmark)
 
 	// A4: When Glacial Illumination is cast, the CD of Icetide Vortex is reset and Eula gains 1 stack of Grimheart.
 	if c.grimheartStacks < 2 {
@@ -110,7 +110,7 @@ func (c *char) triggerBurst() {
 		Write("stacks", c.burstCounter).
 		Write("mult", ai.Mult)
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), lightfallHitmark, lightfallHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6.5), lightfallHitmark, lightfallHitmark)
 	c.Core.Status.Delete(burstKey)
 	c.burstCounter = 0
 }

--- a/internal/characters/eula/skill.go
+++ b/internal/characters/eula/skill.go
@@ -109,7 +109,7 @@ func (c *char) pressSkill(p map[string]int) action.ActionInfo {
 			c.particleDone = true
 		}
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), skillPressHitmark, skillPressHitmark, cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3.5), skillPressHitmark, skillPressHitmark, cb)
 
 	c.SetCDWithDelay(action.ActionSkill, 60*4, 16)
 
@@ -151,7 +151,7 @@ func (c *char) holdSkill(p map[string]int) action.ActionInfo {
 			c.particleDone = true
 		}
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), skillHoldHitmark, skillHoldHitmark, energyCB)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5.5), skillHoldHitmark, skillHoldHitmark, energyCB)
 
 	v := c.currentGrimheartStacks()
 
@@ -199,7 +199,7 @@ func (c *char) holdSkill(p map[string]int) action.ActionInfo {
 			//per shizuka first swirl is not affected by hitlag?
 			c.Core.QueueAttack(
 				icewhirlAI,
-				combat.NewCircleHit(c.Core.Combat.Player(), 1.5),
+				combat.NewCircleHit(c.Core.Combat.Player(), 3.5),
 				icewhirlHitmarks[i],
 				icewhirlHitmarks[i],
 				shredCB,
@@ -209,7 +209,7 @@ func (c *char) holdSkill(p map[string]int) action.ActionInfo {
 				//spacing it out for stacks
 				c.Core.QueueAttack(
 					icewhirlAI,
-					combat.NewCircleHit(c.Core.Combat.Player(), 1.5),
+					combat.NewCircleHit(c.Core.Combat.Player(), 3.5),
 					0,
 					0,
 					shredCB,
@@ -234,7 +234,7 @@ func (c *char) holdSkill(p map[string]int) action.ActionInfo {
 			Mult:       burstExplodeBase[c.TalentLvlBurst()] * 0.5,
 		}
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(aiA1, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), a1Hitmark-(skillHoldHitmark+1), a1Hitmark-(skillHoldHitmark+1))
+			c.Core.QueueAttack(aiA1, combat.NewCircleHit(c.Core.Combat.Player(), 6.5), a1Hitmark-(skillHoldHitmark+1), a1Hitmark-(skillHoldHitmark+1))
 		}, skillHoldHitmark+1)
 	}
 

--- a/internal/characters/fischl/aimed.go
+++ b/internal/characters/fischl/aimed.go
@@ -41,7 +41,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		IsDeployable:         true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), aimedHitmark, aimedHitmark+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), aimedHitmark, aimedHitmark+travel)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(aimedFrames),

--- a/internal/characters/fischl/attack.go
+++ b/internal/characters/fischl/attack.go
@@ -44,7 +44,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)
@@ -64,7 +64,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		}
 		c.Core.QueueAttack(
 			ai,
-			combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 			attackHitmarks[c.NormalCounter],
 			attackHitmarks[c.NormalCounter]+travel,
 		)

--- a/internal/characters/fischl/cons.go
+++ b/internal/characters/fischl/cons.go
@@ -32,7 +32,7 @@ func (c *char) c6() {
 		// Technically should have a separate snapshot for each attack info?
 		// ai.ModsLog = c.ozSnapshot.Info.ModsLog
 		// C4 uses Oz Snapshot
-		c.Core.QueueAttackWithSnap(ai, c.ozSnapshot.Snapshot, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), c.ozTravel)
+		c.Core.QueueAttackWithSnap(ai, c.ozSnapshot.Snapshot, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), c.ozTravel)
 		return false
 	}, "fischl-c6")
 }

--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -125,7 +125,7 @@ func (c *char) queueOz(src string, ozSpawn int) {
 		c.ozSnapshot = combat.AttackEvent{
 			Info:        ai,
 			Snapshot:    snap,
-			Pattern:     combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+			Pattern:     combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 			SourceFrame: c.Core.F,
 		}
 		c.Core.Tasks.Add(c.ozTick(c.Core.F), 60)

--- a/internal/characters/ganyu/aimed.go
+++ b/internal/characters/ganyu/aimed.go
@@ -69,12 +69,12 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 				Write("expiry", c.a1Expiry)
 		}
 
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), travel)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), travel)
 
 		ai.Abil = "Frost Flake Bloom"
 		ai.Mult = ffb[c.TalentLvlAttack()]
 		ai.HitWeakPoint = false
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2), travel+bloom)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5), travel+bloom)
 
 		// first shot/bloom do not benefit from a1
 		c.a1Expiry = c.Core.F + 60*5

--- a/internal/characters/ganyu/attack.go
+++ b/internal/characters/ganyu/attack.go
@@ -45,7 +45,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)

--- a/internal/characters/ganyu/burst.go
+++ b/internal/characters/ganyu/burst.go
@@ -106,12 +106,19 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			// log.Println(target)
 			//[1:14 PM] Aluminum | Harbinger of Jank: assuming uniform distribution and enemy at center:
 			//(radius_icicle + radius_enemy)^2 / radius_burst^2
-			if target == -1 && c.Core.Rand.Float64() > prob {
-				//no one getting hit
-				return
+			trg := c.Core.Combat.Enemy(target)
+			if target == -1 {
+				if c.Core.Rand.Float64() > prob {
+					// no one getting hit
+					return
+				} else {
+					// icicle is not targeted but randomly clips enemy
+					// TODO: enemies with radius?
+					trg = c.Core.Combat.Enemy(c.Core.Combat.RandomEnemyTarget())
+				}
 			}
 			//deal dmg
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 9), 0)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(trg, 2.5), 0)
 		}, delay)
 
 	}

--- a/internal/characters/ganyu/skill.go
+++ b/internal/characters/ganyu/skill.go
@@ -29,12 +29,12 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	snap := c.Snapshot(&ai)
 	//flower damage immediately
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2), 13)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 4), 13)
 	//we get the orbs right away
 	c.Core.QueueParticle("ganyu", 2, attributes.Cryo, c.ParticleDelay)
 
 	//flower damage is after 6 seconds
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2), 373)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 4), 373)
 	c.Core.QueueParticle("ganyu", 2, attributes.Cryo, 373+c.ParticleDelay)
 
 	//add cooldown to sim

--- a/internal/characters/gorou/aimed.go
+++ b/internal/characters/gorou/aimed.go
@@ -41,7 +41,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		IsDeployable:         true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), aimedHitmark, aimedHitmark+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), aimedHitmark, aimedHitmark+travel)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(aimedFrames),

--- a/internal/characters/gorou/attack.go
+++ b/internal/characters/gorou/attack.go
@@ -46,7 +46,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)

--- a/internal/characters/heizou/attack.go
+++ b/internal/characters/heizou/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{12}, {13}, {21}, {13, 19, 27}, {31}}
-var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0, 0.09}, {0.12}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false, true}, {true}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{12}, {13}, {21}, {13, 19, 27}, {31}}
+	attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.06}, {0, 0, 0.09}, {0.12}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, false, true}, {true}}
+	attackRadius          = []float64{1.8, 1.8, 2.2, 1.8, 2.4}
+)
 
 const normalHitNum = 5
 
@@ -56,10 +59,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
+		radius := attackRadius[c.NormalCounter]
 		// multihit on N4 only has hitlag on last hit so no need for char queue here
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.Player(), radius),
 			attackHitmarks[c.NormalCounter][i],
 			attackHitmarks[c.NormalCounter][i],
 		)

--- a/internal/characters/heizou/burst.go
+++ b/internal/characters/heizou/burst.go
@@ -53,7 +53,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		NoImpulse:  true,
 	}
 	// should only hit enemies
-	ap := combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4)
+	ap := combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6)
 	ap.SkipTargets[combat.TargettableGadget] = true
 	c.Core.QueueAttack(auraCheck, ap, burstHitmark, burstHitmark, burstCB)
 
@@ -70,7 +70,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 	//TODO: does heizou burst snapshot?
 	//TODO: heizou burst travel time parameter
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6), burstHitmark, burstHitmark)
 
 	//TODO: Check CD with or without delay, check energy consume frame
 	c.SetCD(action.ActionBurst, 12*60)

--- a/internal/characters/heizou/charge.go
+++ b/internal/characters/heizou/charge.go
@@ -37,7 +37,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	}
 
 	// TODO: check snapshot delay
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.3), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.28), chargeHitmark, chargeHitmark)
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),
 		AnimationLength: chargeFrames[action.InvalidAction],

--- a/internal/characters/heizou/skill.go
+++ b/internal/characters/heizou/skill.go
@@ -67,12 +67,12 @@ func (c *char) skillRelease(p map[string]int, delay int) action.ActionInfo {
 			HitlagHaltFrames:   skillHitlagHaltFrame * 60,
 			CanBeDefenseHalted: false,
 		}
-		AoE := 0.3
+		radius := 2.92
 		if c.decStack == 4 {
 			ai.Abil = "Heartstopper Strike (Max Stacks)"
 			ai.Mult += convicBonus[c.TalentLvlSkill()]
 			ai.HitlagHaltFrames = skillHitlagMaxStackHaltFrame * 60
-			AoE = 1
+			radius = 3.61
 		}
 
 		skillCB := func(a combat.AttackCB) {
@@ -80,7 +80,7 @@ func (c *char) skillRelease(p map[string]int, delay int) action.ActionInfo {
 			c.a4()
 		}
 
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), AoE), hitDelay, hitDelay, skillCB)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), hitDelay, hitDelay, skillCB)
 		c.SetCD(action.ActionSkill, 10*60)
 
 		count := 2.0

--- a/internal/characters/hutao/attack.go
+++ b/internal/characters/hutao/attack.go
@@ -9,15 +9,19 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{12}, {9}, {17}, {22}, {16, 26}, {23}}
-var attackHitlagHaltFrame = [][]float64{{0.01}, {0.01}, {0.01}, {0.02}, {0.02, 0.02}, {0.04}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {true}, {false, true}, {true}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{12}, {9}, {17}, {22}, {16, 26}, {23}}
+	attackHitlagHaltFrame = [][]float64{{0.01}, {0.01}, {0.01}, {0.02}, {0.02, 0.02}, {0.04}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {true}, {false, true}, {true}}
+	attackRadius          = [][]float64{{1.8}, {1.68}, {2}, {1.8}, {1.8, 1.8}, {2.3}}
 
-var ppAttackFrames [][]int
-var ppAttackHitmarks = [][]int{{12}, {9}, {17}, {22}, {15, 26}, {27}}
-var ppAttackHitlagHaltFrame = [][]float64{{0.01}, {0.01}, {0.01}, {0.02}, {0.02, 0.02}, {0.04}}
-var ppAttackDefHalt = [][]bool{{true}, {true}, {true}, {true}, {false, true}, {true}}
+	ppAttackFrames          [][]int
+	ppAttackHitmarks        = [][]int{{12}, {9}, {17}, {22}, {15, 26}, {27}}
+	ppAttackHitlagHaltFrame = [][]float64{{0.01}, {0.01}, {0.01}, {0.02}, {0.02, 0.02}, {0.04}}
+	ppAttackDefHalt         = [][]bool{{true}, {true}, {true}, {true}, {false, true}, {true}}
+	ppAttackRadius          = [][]float64{{2.3}, {1.78}, {2.6}, {2.2}, {2.3, 1.94}, {2.8}}
+)
 
 const normalHitNum = 6
 
@@ -86,10 +90,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 1 {
 			ai.StrikeType = combat.StrikeTypeSpear
 		}
+		radius := attackRadius[c.NormalCounter][i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)
@@ -126,10 +131,11 @@ func (c *char) ppAttack(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 1 {
 			ai.StrikeType = combat.StrikeTypeSpear
 		}
+		radius := ppAttackRadius[c.NormalCounter][i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 				c.ppParticles,

--- a/internal/characters/hutao/burst.go
+++ b/internal/characters/hutao/burst.go
@@ -61,7 +61,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 50,
 		Mult:       mult,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0, burstHitmark, bbcb, c.burstHealCB)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6), 0, burstHitmark, bbcb, c.burstHealCB)
 
 	c.ConsumeEnergy(68)
 	c.SetCDWithDelay(action.ActionBurst, 900, 62)

--- a/internal/characters/hutao/charge.go
+++ b/internal/characters/hutao/charge.go
@@ -53,7 +53,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 		IsDeployable:       true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), 0, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), 0, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),
@@ -80,7 +80,7 @@ func (c *char) ppChargeAttack(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 		IsDeployable:       true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), 0, ppChargeHitmark, c.ppParticles, c.applyBB)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.8), 0, ppChargeHitmark, c.ppParticles, c.applyBB)
 
 	//frames changes if previous action is normal
 	prevState := -1

--- a/internal/characters/itto/attack.go
+++ b/internal/characters/itto/attack.go
@@ -9,10 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackHitmarks = []int{23, 25, 16, 48}
-var attackHitlagHaltFrame = []float64{0.08, 0.08, 0.10, 0.10}
-
-var attackFrames [][][]int
+var (
+	attackFrames          [][][]int
+	attackHitmarks        = []int{23, 25, 16, 48}
+	attackHitlagHaltFrame = []float64{0.08, 0.08, 0.10, 0.10}
+	attackRadius          = [][]float64{{2.5, 2.5, 2.5, 3.4}, {3.5, 3.5, 3.5, 4.43}}
+)
 
 const normalHitNum = 4
 
@@ -90,11 +92,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	// check burst status for radius
 	// TODO: proper hitbox
-	radius := 1.0
+	attackIndex := 0
 	if c.StatModIsActive(burstBuffKey) {
-		radius = 2
+		attackIndex = 1
 	}
-
+	radius := attackRadius[attackIndex][c.NormalCounter]
 	// TODO: hitmark is not getting adjusted for atk speed
 	c.Core.QueueAttack(
 		ai,

--- a/internal/characters/itto/skill.go
+++ b/internal/characters/itto/skill.go
@@ -74,7 +74,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	c.Core.Tasks.Add(func() { c.addStrStack("ushi-hit", 1) }, skillRelease+travel)
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3.5),
 		skillRelease,
 		skillRelease+travel,
 		cb,

--- a/internal/characters/jean/attack.go
+++ b/internal/characters/jean/attack.go
@@ -10,9 +10,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/player"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{13, 6, 17, 37, 25}
-var attackHitlagHaltFrame = []float64{.03, .03, .06, .06, .1}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{13, 6, 17, 37, 25}
+	attackHitlagHaltFrame = []float64{.03, .03, .06, .06, .1}
+	attackRadius          = []float64{1.5, 2.2, 2.8, 1.6, 1.6}
+)
 
 const normalHitNum = 5
 
@@ -51,10 +54,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	c.Core.Tasks.Add(func() {
 		snap := c.Snapshot(&ai)
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 0.4), 0)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), radius), 0)
 
 		//check for healing
 		if c.Core.Rand.Float64() < 0.5 {

--- a/internal/characters/jean/burst.go
+++ b/internal/characters/jean/burst.go
@@ -46,7 +46,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	snap := c.Snapshot(&ai)
 
 	// initial hit at 40f
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstStart)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 6), burstStart)
 
 	// field status
 	c.Core.Status.Add("jean-q", 600+burstStart)
@@ -57,11 +57,11 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	ai.Mult = burstEnter[c.TalentLvlBurst()]
 	// first enter is at frame 55
 	for i := 0; i < enter; i++ {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), 55+i*delay)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6), 55+i*delay)
 	}
 
 	// handle In/Out damage on field expiry
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), 600+burstStart)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6), 600+burstStart)
 
 	//heal on cast
 	hpplus := snap.Stats[attributes.Heal]

--- a/internal/characters/jean/charge.go
+++ b/internal/characters/jean/charge.go
@@ -33,7 +33,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Mult:       charge[c.TalentLvlAttack()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.4), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.8), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/jean/skill.go
+++ b/internal/characters/jean/skill.go
@@ -42,7 +42,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		c.c1(&snap)
 	}
 
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1), hitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2.86), hitmark)
 
 	var count float64 = 2
 	if c.Core.Rand.Float64() < 2.0/3.0 {

--- a/internal/characters/kaeya/attack.go
+++ b/internal/characters/kaeya/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{14, 9, 14, 23, 30}
-var attackHitlagHaltFrame = []float64{.03, .03, .06, .06, 0.1}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{14, 9, 14, 23, 30}
+	attackHitlagHaltFrame = []float64{.03, .03, .06, .06, 0.1}
+	attackRadius          = []float64{1.7, 1.5, 1.39, 1.82, 1.8}
+)
 
 const normalHitNum = 5
 
@@ -49,9 +52,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), .3),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/kaeya/charge.go
+++ b/internal/characters/kaeya/charge.go
@@ -35,7 +35,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.2), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/kaeya/skill.go
+++ b/internal/characters/kaeya/skill.go
@@ -59,7 +59,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			c.Core.Log.NewEvent("kaeya a4 proc", glog.LogCharacterEvent, c.Index)
 		}
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), 0, skillHitmark, cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4.47), 0, skillHitmark, cb)
 
 	// 2 or 3, 1:2 ratio
 	var count float64 = 2

--- a/internal/characters/kazuha/attack.go
+++ b/internal/characters/kazuha/attack.go
@@ -9,11 +9,14 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{13}, {11}, {16, 25}, {15}, {15, 19, 27}}
-var attackHitlagHaltFrame = [][]float64{{.03}, {.03}, {.01, .05}, {.06}, {0, 0, 0}}
-var attackHitlagFactor = [][]float64{{.01}, {.01}, {.01, .01}, {.01}, {.05, .05, .05}}
-var attackDefHalt = [][]bool{{true}, {true}, {false, true}, {true}, {true, false, true}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{13}, {11}, {16, 25}, {15}, {15, 19, 27}}
+	attackHitlagHaltFrame = [][]float64{{.03}, {.03}, {.01, .05}, {.06}, {0, 0, 0}}
+	attackHitlagFactor    = [][]float64{{.01}, {.01}, {.01, .01}, {.01}, {.05, .05, .05}}
+	attackDefHalt         = [][]bool{{true}, {true}, {false, true}, {true}, {true, false, true}}
+	attackRadius          = []float64{1.5, 1.5, 1.5, 1.5, 2.2}
+)
 
 const normalHitNum = 5
 
@@ -52,10 +55,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/kazuha/burst.go
+++ b/internal/characters/kazuha/burst.go
@@ -27,7 +27,7 @@ func init() {
 func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.qAbsorb = attributes.NoElement
-	c.qAbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5)
+	c.qAbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 8)
 
 	ai := combat.AttackInfo{
 		ActorIndex:         c.Index,
@@ -44,7 +44,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: false,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 0, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 9), 0, burstHitmark)
 
 	//apply dot and check for absorb
 	ai.Abil = "Kazuha Slash (Dot)"
@@ -74,9 +74,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			c.Core.Tasks.Add(func() {
 				if c.qAbsorb != attributes.NoElement {
 					aiAbsorb.Element = c.qAbsorb
-					c.Core.QueueAttackWithSnap(aiAbsorb, snapAbsorb, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0)
+					c.Core.QueueAttackWithSnap(aiAbsorb, snapAbsorb, combat.NewCircleHit(c.Core.Combat.Player(), 9), 0)
 				}
-				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0)
+				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 9), 0)
 			}, (burstFirstTick-(burstHitmark+1))+117*i)
 		}
 		// C2:

--- a/internal/characters/kazuha/charge.go
+++ b/internal/characters/kazuha/charge.go
@@ -35,7 +35,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.2), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/kazuha/kazuha.go
+++ b/internal/characters/kazuha/kazuha.go
@@ -34,9 +34,6 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.SkillCon = 3
 	c.NormalHitNum = normalHitNum
 
-	c.a1AbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5)
-	c.qAbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5)
-
 	w.Character = &c
 
 	return nil

--- a/internal/characters/kazuha/plunge.go
+++ b/internal/characters/kazuha/plunge.go
@@ -70,7 +70,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 			Mult:           plunge[c.TalentLvlAttack()],
 			IgnoreInfusion: true,
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.3), hitmark, hitmark)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), hitmark, hitmark)
 	}
 
 	//aoe dmg
@@ -87,7 +87,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 		IgnoreInfusion: true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), hitmark, hitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4.5), hitmark, hitmark)
 
 	// a1 if applies
 	if c.a1Absorb != attributes.NoElement {
@@ -104,7 +104,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 			IgnoreInfusion: true,
 		}
 
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), hitmark-1, hitmark-1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4.5), hitmark-1, hitmark-1)
 		c.a1Absorb = attributes.NoElement
 	}
 

--- a/internal/characters/kazuha/skill.go
+++ b/internal/characters/kazuha/skill.go
@@ -36,7 +36,14 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	hold := p["hold"]
 
 	c.a1Absorb = attributes.NoElement
-	c.a1AbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.5)
+
+	radius := 5.0
+
+	if hold >= 1 {
+		radius = 9
+	}
+
+	c.a1AbsorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), radius)
 
 	// why is the same code written twice..
 	if hold == 0 {
@@ -57,7 +64,7 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       skill[c.TalentLvlSkill()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 0, skillPressHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0, skillPressHitmark)
 
 	c.Core.QueueParticle("kazuha", 3, attributes.Anemo, skillPressHitmark+c.ParticleDelay)
 
@@ -98,7 +105,7 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 		Mult:       skillHold[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 0, skillHoldHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 9), 0, skillHoldHitmark)
 
 	c.Core.QueueParticle("kazuha", 4, attributes.Anemo, skillHoldHitmark+c.ParticleDelay)
 

--- a/internal/characters/keqing/attack.go
+++ b/internal/characters/keqing/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{11}, {11}, {15}, {12, 22}, {26}}
-var attackHitlagHaltFrame = [][]float64{{.03}, {.03}, {.06}, {0, .03}, {0}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, true}, {false}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{11}, {11}, {15}, {12, 22}, {26}}
+	attackHitlagHaltFrame = [][]float64{{.03}, {.03}, {.06}, {0, .03}, {0}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, true}, {false}}
+	attackRadius          = []float64{1.33, 1.5, 1.8, 1.5, 0.8}
+)
 
 const normalHitNum = 5
 
@@ -37,7 +40,10 @@ func init() {
 }
 
 func (c *char) Attack(p map[string]int) action.ActionInfo {
-
+	centerTarget := c.Core.Combat.Player()
+	if c.NormalCounter == 4 {
+		centerTarget = c.Core.Combat.PrimaryTarget() // N5 is a bullet
+	}
 	for i, mult := range attack[c.NormalCounter] {
 		ai := combat.AttackInfo{
 			ActorIndex:         c.Index,
@@ -53,10 +59,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(centerTarget, radius),
 				0,
 				0,
 			)

--- a/internal/characters/keqing/burst.go
+++ b/internal/characters/keqing/burst.go
@@ -39,19 +39,19 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       burstInitial[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 8), burstHitmark, burstHitmark)
 
 	//8 hits
 	ai.Abil = "Starward Sword (Consecutive Slash)"
 	ai.Mult = burstDot[c.TalentLvlBurst()]
 	for i := 82; i < 162; i += 11 {
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), i, i)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 8), i, i)
 	}
 
 	//final
 	ai.Abil = "Starward Sword (Last Attack)"
 	ai.Mult = burstFinal[c.TalentLvlBurst()]
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), 197, 197)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 8), 197, 197)
 
 	if c.Base.Cons >= 6 {
 		c.c6("burst")

--- a/internal/characters/keqing/charge.go
+++ b/internal/characters/keqing/charge.go
@@ -9,8 +9,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var chargeFrames []int
-var chargeHitmarks = []int{22, 24}
+var (
+	chargeFrames   []int
+	chargeHitmarks = []int{22, 24}
+	chargeRadius   = []float64{2.2, 2.3}
+)
 
 func init() {
 	chargeFrames = frames.InitAbilSlice(36)
@@ -31,11 +34,11 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Element:    attributes.Physical,
 		Durability: 25,
 	}
-
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), chargeHitmarks[i], chargeHitmarks[i])
+		radius := chargeRadius[i]
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	if c.Core.Status.Duration(stilettoKey) > 0 {
@@ -55,7 +58,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 			Mult:       skillCA[c.TalentLvlSkill()],
 		}
 		for i := 0; i < 2; i++ {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), chargeHitmarks[i], chargeHitmarks[i])
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.5), chargeHitmarks[i], chargeHitmarks[i])
 		}
 
 		// TODO: Particle timing?

--- a/internal/characters/keqing/skill.go
+++ b/internal/characters/keqing/skill.go
@@ -53,7 +53,7 @@ func (c *char) skillFirst(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: false,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), skillHitmark, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.6), skillHitmark, skillHitmark)
 
 	if c.Base.Cons >= 6 {
 		c.c6("skill")
@@ -79,10 +79,13 @@ const skillRecastHitmark = 27
 func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 	// C1 DMG happens before Recast DMG
 	if c.Base.Cons >= 1 {
-		//2 tick dmg at start to end
+		// 2 tick dmg at start to end
 		hits, ok := p["c1"]
 		if !ok {
-			hits = 1 //default 1 hit
+			hits = 1 // default 1 hit
+		}
+		if hits > 2 {
+			hits = 2
 		}
 		ai := combat.AttackInfo{
 			Abil:       "Stellar Restoration (C1)",
@@ -96,7 +99,11 @@ func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 			Mult:       .5,
 		}
 		// TODO: this should be 1st hit on cast and 2nd at end
-		for i := 0; i < hits; i++ {
+		// First hit centers on primary target
+		if hits >= 1 {
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 2), skillRecastHitmark, skillRecastHitmark)
+		}
+		if hits == 2 {
 			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), skillRecastHitmark, skillRecastHitmark)
 		}
 	}
@@ -113,7 +120,7 @@ func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 		Mult:       skillPress[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), skillRecastHitmark, skillRecastHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), skillRecastHitmark, skillRecastHitmark)
 
 	//add electro infusion
 	c.a1()

--- a/internal/characters/klee/attack.go
+++ b/internal/characters/klee/attack.go
@@ -15,6 +15,7 @@ var (
 	attackFramesWithLag   [][]int
 	attackHitmarks        = []int{16, 23, 37}
 	attackHitmarksWithLag []int
+	attackRadius          = []float64{1, 1, 1.5}
 )
 
 const normalHitNum = 3
@@ -98,9 +99,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		if done {
 			return
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), radius),
 			0,
 			travel,
 			c.a1,

--- a/internal/characters/klee/burst.go
+++ b/internal/characters/klee/burst.go
@@ -56,16 +56,16 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				return
 			}
 			//wave 1 = 1
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 0)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5), 0)
 			//wave 2 = 1 + 30% chance of 1
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 12)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5), 12)
 			if c.Core.Rand.Float64() < 0.3 {
-				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 12)
+				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5), 12)
 			}
 			//wave 3 = 1 + 50% chance of 1
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 24)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5), 24)
 			if c.Core.Rand.Float64() < 0.5 {
-				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 24)
+				c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5), 24)
 			}
 		}, start)
 	}

--- a/internal/characters/klee/charge.go
+++ b/internal/characters/klee/charge.go
@@ -60,7 +60,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	c.Core.QueueAttackWithSnap(
 		ai,
 		snap,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3),
 		chargeHitmark-windup+travel,
 	)
 

--- a/internal/characters/klee/cons.go
+++ b/internal/characters/klee/cons.go
@@ -32,7 +32,7 @@ func (c *char) c1(delay int) {
 		CanBeDefenseHalted: true,
 		IsDeployable:       true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, delay)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5), 0, delay)
 }
 
 func (c *char) c2(a combat.AttackCB) {

--- a/internal/characters/klee/skill.go
+++ b/internal/characters/klee/skill.go
@@ -120,14 +120,14 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		}
 		for i, data := range bounceAttacks {
 			c.Core.QueueAttackWithSnap(data.ai, data.snap,
-				combat.NewCircleHit(c.Core.Combat.Player(), 2),
+				combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4),
 				bounceHitmarks[i]-cooldownDelay,
 				c.a1,
 			)
 		}
 		for _, data := range mineAttacks {
 			c.Core.QueueAttackWithSnap(data.ai, data.snap,
-				combat.NewCircleHit(c.Core.Combat.Player(), 1),
+				combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 2),
 				mineHitmark-cooldownDelay,
 				c.c2,
 			)

--- a/internal/characters/kokomi/attack.go
+++ b/internal/characters/kokomi/attack.go
@@ -50,10 +50,15 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 	ai.FlatDmg = c.burstDmgBonus(ai.AttackTag)
 
+	radius := 0.7
+	if c.Core.Status.Duration(burstKey) > 0 {
+		radius = 1.2
+	}
+
 	// TODO: Assume that this is not dynamic (snapshot on projectile release)
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)

--- a/internal/characters/kokomi/burst.go
+++ b/internal/characters/kokomi/burst.go
@@ -14,7 +14,10 @@ import (
 
 var burstFrames []int
 
-const burstHitmark = 49
+const (
+	burstHitmark = 49
+	burstKey     = "kokomiburst"
+)
 
 func init() {
 	burstFrames = frames.InitAbilSlice(78) // Q -> D/J
@@ -50,7 +53,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark, burstHitmark)
 
-	c.Core.Status.Add("kokomiburst", 10*60)
+	c.Core.Status.Add(burstKey, 10*60)
 
 	// update jellyfish flat damage
 	c.skillFlatDmg = c.burstDmgBonus(combat.AttackTagElementalArt)

--- a/internal/characters/kokomi/charge.go
+++ b/internal/characters/kokomi/charge.go
@@ -45,7 +45,12 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		windup = 14
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), chargeHitmark-windup, chargeHitmark-windup)
+	radius := 3.5
+	if c.Core.Status.Duration(burstKey) > 0 {
+		radius = 4
+	}
+
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), radius), chargeHitmark-windup, chargeHitmark-windup)
 
 	return action.ActionInfo{
 		Frames:          func(next action.Action) int { return chargeFrames[next] - windup },

--- a/internal/characters/kokomi/cons.go
+++ b/internal/characters/kokomi/cons.go
@@ -30,7 +30,7 @@ func (c *char) c1(f, travel int) {
 	ai.FlatDmg = 0.3 * c.MaxHP()
 
 	// TODO: Is this snapshotted/dynamic?
-	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), f, f+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.2), f, f+travel)
 }
 
 // C4 (Energy piece only) handling

--- a/internal/characters/kokomi/skill.go
+++ b/internal/characters/kokomi/skill.go
@@ -64,7 +64,7 @@ func (c *char) createSkillSnapshot() *combat.AttackEvent {
 
 	return (&combat.AttackEvent{
 		Info:        ai,
-		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 5),
+		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 6),
 		SourceFrame: c.Core.F,
 		Snapshot:    snap,
 	})

--- a/internal/characters/kuki/attack.go
+++ b/internal/characters/kuki/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{12, 13, 13, 23}
-var attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06, 0.10}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{12, 13, 13, 23}
+	attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06, 0.10}
+	attackRadius          = []float64{1.5, 1.5, 3.42, 2.2}
+)
 
 const normalHitNum = 4
 
@@ -46,10 +49,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
+	radius := attackRadius[c.NormalCounter]
 	// no multihits so no need for char queue here
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), .3),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/kuki/burst.go
+++ b/internal/characters/kuki/burst.go
@@ -40,9 +40,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	interval := 2 * 60 / 7
 
 	// C1: Gyoei Narukami Kariyama Rite's AoE is increased by 50%.
-	var r float64 = 2
+	var r float64 = 4
 	if c.Base.Cons >= 1 {
-		r = 3.5
+		r = 6
 	}
 
 	for i := burstStart; i < count*interval+burstStart; i += interval {

--- a/internal/characters/kuki/charge.go
+++ b/internal/characters/kuki/charge.go
@@ -39,7 +39,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 			CanBeDefenseHalted: chargeDefHalt[i],
 		}
 		// only the last multihit has hitlag so no need for char queue here
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.8), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/kuki/cons.go
+++ b/internal/characters/kuki/cons.go
@@ -20,6 +20,7 @@ func (c *char) c4() {
 	const c4IcdKey = "kuki-c4-icd"
 	c.Core.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
 		ae := args[1].(*combat.AttackEvent)
+		trg := args[0].(combat.Target)
 		//ignore if C4 on icd
 		if c.StatusIsActive(c4IcdKey) {
 			return false
@@ -52,7 +53,7 @@ func (c *char) c4() {
 		}
 
 		//Particle check is 45% for particle
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 5, 5)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(trg, 2), 5, 5)
 		if c.Core.Rand.Float64() < .45 {
 			c.Core.QueueParticle("kuki", 1, attributes.Electro, 100) // TODO: idk the particle timing yet fml (or probability)
 		}

--- a/internal/characters/kuki/skill.go
+++ b/internal/characters/kuki/skill.go
@@ -51,7 +51,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       skill[c.TalentLvlSkill()],
 		FlatDmg:    c.Stat(attributes.EM) * 0.25,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), skillHitmark, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), skillHitmark, skillHitmark)
 
 	// C2: Grass Ring of Sanctification's duration is increased by 3s.
 	skilldur := 720
@@ -97,7 +97,7 @@ func (c *char) bellTick() func() {
 			Mult:       skilldot[c.TalentLvlSkill()],
 			FlatDmg:    c.Stat(attributes.EM) * 0.25,
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), 2, 2)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), 2, 2)
 
 		//A4 is considered here
 		c.Core.Player.Heal(player.HealInfo{

--- a/internal/characters/lisa/attack.go
+++ b/internal/characters/lisa/attack.go
@@ -43,7 +43,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 
 	c.Core.QueueAttack(ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/lisa/burst.go
+++ b/internal/characters/lisa/burst.go
@@ -85,7 +85,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				c.Core.QueueAttackWithSnap(
 					ai,
 					snap,
-					combat.NewDefSingleTarget(c.Core.Combat.Enemy(ind).Key()),
+					combat.NewCircleHit(c.Core.Combat.Enemy(ind), 1),
 					0,
 					c.a4,
 				)

--- a/internal/characters/lisa/charge.go
+++ b/internal/characters/lisa/charge.go
@@ -61,7 +61,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 			t.SetTag(conductiveTag, count+1)
 		}
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmark-windup, chargeHitmark-windup, cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 10), chargeHitmark-windup, chargeHitmark-windup, cb)
 
 	return action.ActionInfo{
 		Frames:          func(next action.Action) int { return chargeFrames[next] - windup },

--- a/internal/characters/lisa/skill.go
+++ b/internal/characters/lisa/skill.go
@@ -73,7 +73,7 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 		}
 	}
 
-	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), 0, skillPressHitmark, cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1), 0, skillPressHitmark, cb)
 
 	c.SetCDWithDelay(action.ActionSkill, 60, 17)
 

--- a/internal/characters/lisa/skill.go
+++ b/internal/characters/lisa/skill.go
@@ -128,7 +128,10 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 
 	//[8:31 PM] ArchedNosi | Lisa Unleashed: yeah 4-5 50/50 with Hold
 	//[9:13 PM] ArchedNosi | Lisa Unleashed: @gimmeabreak actually wait, xd i noticed i misread my sheet, Lisa Hold E always gens 5 orbs
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 0, skillHoldHitmark, c1cb)
+	x, y := c.Core.Combat.Player().Pos()
+	for _, v := range c.Core.Combat.EnemiesWithinRadius(x, y, 10) {
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Enemy(v), 0.2), 0, skillHoldHitmark, c1cb)
+	}
 
 	// count := 4
 	// if c.Core.Rand.Float64() < 0.5 {

--- a/internal/characters/mona/asc.go
+++ b/internal/characters/mona/asc.go
@@ -38,7 +38,7 @@ func (c *char) a1() func() {
 				Durability: 25,
 				Mult:       0.5 * skill[c.TalentLvlSkill()],
 			}
-			c.Core.QueueAttack(aiExplode, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, 0)
+			c.Core.QueueAttack(aiExplode, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0, 0)
 		}, 120)
 		// queue up next A1 check because Mona's still dashing
 		// different Phantoms coexist and don't overwrite each other

--- a/internal/characters/mona/attack.go
+++ b/internal/characters/mona/attack.go
@@ -9,8 +9,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{11, 14, 25, 27}
+var (
+	attackFrames   [][]int
+	attackHitmarks = []int{11, 14, 25, 27}
+	attackRadius   = []float64{1, 1, 1, 2}
+)
 
 const normalHitNum = 4
 
@@ -42,10 +45,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       attack[c.NormalCounter][c.TalentLvlAttack()],
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 		c.c2,

--- a/internal/characters/mona/burst.go
+++ b/internal/characters/mona/burst.go
@@ -53,7 +53,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		c.Core.Log.NewEvent("mona bubble on target", glog.LogCharacterEvent, c.Index).
 			Write("char", c.Index)
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), -1, burstHitmark, cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 10), -1, burstHitmark, cb)
 
 	//queue a 0 damage attack to break bubble after 8 sec if bubble not broken yet
 	aiBreak := combat.AttackInfo{
@@ -67,7 +67,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 0,
 		Mult:       0,
 	}
-	c.Core.QueueAttack(aiBreak, combat.NewCircleHit(c.Core.Combat.Player(), 4), -1, burstHitmark+480)
+	c.Core.QueueAttack(aiBreak, combat.NewCircleHit(c.Core.Combat.Player(), 10), -1, burstHitmark+480)
 
 	c.SetCD(action.ActionBurst, 15*60)
 	c.ConsumeEnergy(5)

--- a/internal/characters/mona/charge.go
+++ b/internal/characters/mona/charge.go
@@ -41,7 +41,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		windup = 0
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.3), chargeHitmark-windup, chargeHitmark-windup)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3), chargeHitmark-windup, chargeHitmark-windup)
 
 	return action.ActionInfo{
 		Frames:          func(next action.Action) int { return chargeFrames[next] - windup },

--- a/internal/characters/mona/cons.go
+++ b/internal/characters/mona/cons.go
@@ -72,6 +72,7 @@ func (c *char) c1() {
 // When a Normal Attack hits, there is a 20% chance that it will be automatically followed by a Charged Attack.
 // This effect can only occur once every 5s.
 func (c *char) c2(a combat.AttackCB) {
+	trg := a.Target
 	if c.Base.Cons < 2 {
 		return
 	}
@@ -94,7 +95,7 @@ func (c *char) c2(a combat.AttackCB) {
 		Mult:       charge[c.TalentLvlAttack()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.3), 0, 0)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(trg, 3), 0, 0)
 }
 
 // C4:

--- a/internal/characters/mona/skill.go
+++ b/internal/characters/mona/skill.go
@@ -54,7 +54,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	// tick every 1s
 	for i := skillHitmarks[hold]; i < 300; i += 60 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2), i)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), i)
 	}
 
 	// Explosion
@@ -70,7 +70,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       skill[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(aiExplode, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, skillHitmarks[hold]+313)
+	c.Core.QueueAttack(aiExplode, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0, skillHitmarks[hold]+313)
 
 	var count float64 = 3
 	if c.Core.Rand.Float64() < .33 {

--- a/internal/characters/nilou/attack.go
+++ b/internal/characters/nilou/attack.go
@@ -14,7 +14,7 @@ const normalHitNum = 3
 var (
 	attackFrames   [][]int
 	attackHitmarks = []int{12, 9, 17}
-	attackRadius   = []float64{1.1, 1.5, 2.1}
+	attackRadius   = []float64{1.33, 1.5, 2.1}
 
 	attackHitlagHaltFrame = []float64{0.03, 0.03, 0.06}
 	attackDefHalt         = []bool{true, true, true}
@@ -55,10 +55,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagFactor:       0.01,
 		CanBeDefenseHalted: attackDefHalt[c.NormalCounter],
 	}
+	radius := attackRadius[c.NormalCounter]
 	// no multihits so no need for char queue here
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), attackRadius[c.NormalCounter]),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/nilou/skill.go
+++ b/internal/characters/nilou/skill.go
@@ -15,10 +15,11 @@ var (
 
 	swordDanceFrames   [][]int
 	swordDanceHitMarks = []int{14, 12, 35}
-	swordDanceRadius   = []float64{1.1, 1.8, 2}
+	swordDanceRadius   = []float64{1.41, 1.8, 2}
 
 	whirlingStepsFrames   [][]int
 	whirlingStepsHitMarks = []int{21, 29, 43}
+	whirlingStepsRadius   = []float64{2.7, 2.7, 2.93}
 )
 
 type NilouSkillType int
@@ -181,9 +182,10 @@ func (c *char) SwordDance(p map[string]int) action.ActionInfo {
 			travel = t
 		}
 	}
+	radius := swordDanceRadius[s]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), swordDanceRadius[s]),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		swordDanceHitMarks[s]+travel,
 		swordDanceHitMarks[s]+travel,
 		c.c4cb(),
@@ -222,9 +224,10 @@ func (c *char) WhirlingSteps(p map[string]int) action.ActionInfo {
 	if s == 2 {
 		ai.Abil = "Water Wheel"
 	}
+	radius := whirlingStepsRadius[s]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2.7),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		whirlingStepsHitMarks[s],
 		whirlingStepsHitMarks[s],
 		c.c4cb(),

--- a/internal/characters/ningguang/attack.go
+++ b/internal/characters/ningguang/attack.go
@@ -79,9 +79,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		done = true
 	}
 
-	r := 0.1
+	r := 0.5
 	if c.Base.Cons >= 1 {
-		r = 2
+		r = 3.5
 	}
 
 	nextAttack := attackOptions[c.prevAttack][c.Core.Rand.Intn(2)]
@@ -104,7 +104,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	for i := 0; i < 2; i++ {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), r),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), r),
 			attackHitmarks[nextAttack],
 			attackHitmarks[nextAttack]+travel,
 			cb,

--- a/internal/characters/ningguang/burst.go
+++ b/internal/characters/ningguang/burst.go
@@ -51,7 +51,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	for i := 0; i < jade; i++ {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 			0,
 			burstHitmarks[i]+travel,
 		)
@@ -67,7 +67,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			c.Core.QueueAttackWithSnap(
 				ai,
 				c.skillSnapshot,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 				burstHitmarks[len(burstHitmarks)-1]+30+travel,
 			) // TODO: figure out jade screen hitmarks
 		}

--- a/internal/characters/ningguang/charge.go
+++ b/internal/characters/ningguang/charge.go
@@ -106,7 +106,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.5),
 		chargeHitmarks[chargeType]-windup,
 		chargeHitmarks[chargeType]-windup+travel,
 	)
@@ -132,7 +132,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i := 0; i < c.jadeCount; i++ {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 			jadeHitmarks[chargeType]-windup,
 			jadeHitmarks[chargeType]-windup+travel,
 		)

--- a/internal/characters/ningguang/skill.go
+++ b/internal/characters/ningguang/skill.go
@@ -38,7 +38,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	c.Core.Tasks.Add(func() {
 		c.skillSnapshot = c.Snapshot(&ai)
-		c.Core.QueueAttackWithSnap(ai, c.skillSnapshot, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0)
+		c.Core.QueueAttackWithSnap(ai, c.skillSnapshot, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5), 0)
 	}, skillHitmark)
 
 	//put skill on cd first then check for construct/c2

--- a/internal/characters/noelle/attack.go
+++ b/internal/characters/noelle/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{28, 25, 20, 42}
-var attackHitlagHaltFrame = []float64{0.10, 0.10, 0.09, 0.15}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{28, 25, 20, 42}
+	attackHitlagHaltFrame = []float64{0.10, 0.10, 0.09, 0.15}
+	attackRadius          = [][]float64{{2, 2, 2, 1.8}, {5.2, 5.2, 5.2, 3.51}}
+)
 
 const normalHitNum = 4
 
@@ -39,9 +42,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
-	r := 0.3
+	burstIndex := 0
 	if c.StatModIsActive(burstBuffKey) {
-		r = 2
+		burstIndex = 1
 		if c.NormalCounter == 2 {
 			//q-n3 has different hit lag
 			ai.HitlagHaltFrames = 0.1 * 60
@@ -50,11 +53,12 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	// TODO: don't forget this when implementing her CA
 	done := false
 	cb := c.skillHealCB(done)
+	radius := attackRadius[burstIndex][c.NormalCounter]
 	// need char queue because of potential hitlag from C4
 	c.QueueCharTask(func() {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), r),
+			combat.NewCircleHit(c.Core.Combat.Player(), radius),
 			0,
 			0,
 			cb,

--- a/internal/characters/noelle/burst.go
+++ b/internal/characters/noelle/burst.go
@@ -116,7 +116,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		ai.Mult = burstskill[c.TalentLvlBurst()]
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 4.5),
+			combat.NewCircleHit(c.Core.Combat.Player(), 4),
 			0,
 			0,
 			cb,

--- a/internal/characters/qiqi/attack.go
+++ b/internal/characters/qiqi/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{11}, {10}, {9, 20}, {8, 18}, {16}}
-var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.03, 0.03}, {0.03, 0.03}, {0.12}}
-var attackHitlagFactor = [][]float64{{0.01}, {0.01}, {0.05, 0.05}, {0.05, 0.05}, {0.01}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{11}, {10}, {9, 20}, {8, 18}, {16}}
+	attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.03, 0.03}, {0.03, 0.03}, {0.12}}
+	attackHitlagFactor    = [][]float64{{0.01}, {0.01}, {0.05, 0.05}, {0.05, 0.05}, {0.01}}
+	attackRadius          = []float64{1.2, 1.3, 1.6, 1.6, 2.2}
+)
 
 const normalHitNum = 5
 
@@ -53,10 +56,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: true,
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/qiqi/burst.go
+++ b/internal/characters/qiqi/burst.go
@@ -37,7 +37,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Mult:       burstDmg[c.TalentLvlBurst()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 7), burstHitmark, burstHitmark)
 
 	c.SetCD(action.ActionBurst, 20*60)
 	c.ConsumeEnergy(8)

--- a/internal/characters/qiqi/charge.go
+++ b/internal/characters/qiqi/charge.go
@@ -9,8 +9,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var chargeFrames []int
-var chargeHitmarks = []int{15, 29}
+var (
+	chargeFrames   []int
+	chargeHitmarks = []int{15, 29}
+	chargeRadius   = []float64{2, 2.8}
+)
 
 func init() {
 	chargeFrames = frames.InitAbilSlice(76) // CA -> N1
@@ -36,7 +39,8 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	for i, mult := range charge {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		ai.Abil = fmt.Sprintf("Charge %v", i)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.3), chargeHitmarks[i], chargeHitmarks[i])
+		radius := chargeRadius[i]
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/qiqi/skill.go
+++ b/internal/characters/qiqi/skill.go
@@ -85,7 +85,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		tickAE := &combat.AttackEvent{
 			Info:        aiTick,
 			Snapshot:    snapTick,
-			Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 2),
+			Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 2.5),
 			SourceFrame: c.Core.F,
 		}
 
@@ -94,7 +94,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		c.Core.Tasks.Add(c.skillDmgTickTask(src, tickAE, 60), 57+7)
 
 		// Apply damage needs to take place after above takes place to ensure stats are handled correctly
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2.5), 0)
 	}, skillHitmark)
 
 	c.SetCDWithDelay(action.ActionSkill, 1800, 3) // 30s * 60

--- a/internal/characters/raiden/attack.go
+++ b/internal/characters/raiden/attack.go
@@ -11,12 +11,14 @@ import (
 
 const normalHitNum = 5
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{14}, {9}, {14}, {14, 27}, {34}}
-
-// same between polearm and burst attacks so just use these arrays for both
-var attackHitlagHaltFrame = [][]float64{{0.02}, {0.02}, {0.02}, {0, 0}, {0.02}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, false}, {true}}
+var (
+	attackFrames   [][]int
+	attackHitmarks = [][]int{{14}, {9}, {14}, {14, 27}, {34}}
+	// same between polearm and burst attacks so just use these arrays for both
+	attackHitlagHaltFrame = [][]float64{{0.02}, {0.02}, {0.02}, {0, 0}, {0.02}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, false}, {true}}
+	attackRadius          = []float64{1.66, 2.5, 2.19, 2.8, 3}
+)
 
 func init() {
 	// NA cancels (polearm)
@@ -58,8 +60,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
 		ai.Mult = mult[c.TalentLvlAttack()]
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), 0, 0)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), 0, 0)
 		}, attackHitmarks[c.NormalCounter][i])
 	}
 
@@ -74,8 +77,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 }
 
-var swordFrames [][]int
-var swordHitmarks = [][]int{{12}, {13}, {11}, {22, 33}, {33}}
+var (
+	swordFrames   [][]int
+	swordHitmarks = [][]int{{12}, {13}, {11}, {22, 33}, {33}}
+	swordRadius   = [][]float64{{3.06}, {5.39}, {2.68}, {6.41, 4.8}, {6.15}}
+)
 
 func init() {
 	// NA cancels (burst)
@@ -121,8 +127,9 @@ func (c *char) swordAttack(p map[string]int) action.ActionInfo {
 		if c.Base.Cons >= 2 {
 			ai.IgnoreDefPercent = .6
 		}
+		radius := swordRadius[c.NormalCounter][i]
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, 0, c.burstRestorefunc, c.c6)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), 0, 0, c.burstRestorefunc, c.c6)
 		}, swordHitmarks[c.NormalCounter][i])
 	}
 

--- a/internal/characters/raiden/burst.go
+++ b/internal/characters/raiden/burst.go
@@ -72,7 +72,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	if c.Base.Cons >= 2 {
 		ai.IgnoreDefPercent = 0.6
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 7.63), burstHitmark, burstHitmark)
 
 	c.SetCD(action.ActionBurst, 18*60)
 	c.ConsumeEnergy(8)

--- a/internal/characters/raiden/charge.go
+++ b/internal/characters/raiden/charge.go
@@ -39,7 +39,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Mult:               charge[c.TalentLvlAttack()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.78), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),
@@ -86,7 +86,7 @@ func (c *char) swordCharge(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 5),
+				combat.NewCircleHit(c.Core.Combat.Player(), 5.48),
 				0,
 				0,
 				c.burstRestorefunc,

--- a/internal/characters/raiden/skill.go
+++ b/internal/characters/raiden/skill.go
@@ -41,7 +41,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       skill[c.TalentLvlSkill()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), skillHitmark, skillHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), skillHitmark, skillHitmark)
 
 	// Add pre-damage mod
 	mult := skillBurstBonus[c.TalentLvlSkill()]
@@ -124,7 +124,7 @@ func (c *char) eyeOnDamage() {
 		if c.Base.Cons >= 2 && c.StatusIsActive(burstKey) {
 			ai.IgnoreDefPercent = 0.6
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 5, 5)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4), 5, 5)
 
 		c.eyeICD = c.Core.F + 54 //0.9 sec icd
 		return false

--- a/internal/characters/razor/attack.go
+++ b/internal/characters/razor/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{25, 16, 13, 38}
-var attackHitlagHaltFrame = []float64{0.1, 0.1, 0.1, 0.15}
-var attackHitlagFactor = []float64{0.01, 0.01, 0.05, 0.01}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{25, 16, 13, 38}
+	attackHitlagHaltFrame = []float64{0.1, 0.1, 0.1, 0.15}
+	attackHitlagFactor    = []float64{0.01, 0.01, 0.05, 0.01}
+	attackRadius          = []float64{2, 2.19, 2, 2}
+)
 
 const normalHitNum = 4
 
@@ -40,10 +43,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter],
 		CanBeDefenseHalted: true,
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.5),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/razor/burst.go
+++ b/internal/characters/razor/burst.go
@@ -45,7 +45,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(c.Core.Combat.Player(), 5),
 		burstHitmark,
 		burstHitmark,
 	)
@@ -105,7 +105,7 @@ func (c *char) wolfBurst() {
 
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.5),
+			combat.NewCircleHit(c.Core.Combat.Player(), 2.4),
 			1,
 			1,
 		)

--- a/internal/characters/razor/cons.go
+++ b/internal/characters/razor/cons.go
@@ -73,6 +73,7 @@ func (c *char) c6() {
 		if c.Core.Player.Active() != c.Index {
 			return false
 		}
+		trg := args[0].(combat.Target)
 		atk := args[1].(*combat.AttackEvent)
 		if atk.Info.AttackTag != combat.AttackTagNormal {
 			return false
@@ -97,7 +98,7 @@ func (c *char) c6() {
 		}
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.5),
+			combat.NewCircleHit(trg, 1.5),
 			1,
 			1,
 		)

--- a/internal/characters/razor/skill.go
+++ b/internal/characters/razor/skill.go
@@ -90,9 +90,14 @@ func (c *char) SkillPress(burstActive int) action.ActionInfo {
 		c4cb = c.c4cb
 	}
 
+	radius := 2.4
+	if c.StatusIsActive(burstBuffKey) {
+		radius = 3
+	}
+
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		skillPressHitmarks[burstActive],
 		skillPressHitmarks[burstActive],
 		c4cb,

--- a/internal/characters/rosaria/attack.go
+++ b/internal/characters/rosaria/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{9}, {13}, {19, 28}, {32}, {26, 40}}
-var attackHitlagHaltFrame = [][]float64{{0.06}, {0.06}, {0, 0.03}, {0.09}, {0.06, 0.06}}
-var attackDefHalt = [][]bool{{true}, {true}, {false, true}, {true}, {false, true}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{9}, {13}, {19, 28}, {32}, {26, 40}}
+	attackHitlagHaltFrame = [][]float64{{0.06}, {0.06}, {0, 0.03}, {0.09}, {0.06, 0.06}}
+	attackDefHalt         = [][]bool{{true}, {true}, {false, true}, {true}, {false, true}}
+	attackRadius          = [][]float64{{2.5}, {2.5}, {2.11, 2.11}, {2.3}, {2.5, 1.8}}
+)
 
 const normalHitNum = 5
 
@@ -57,10 +60,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 2 {
 			ai.StrikeType = combat.StrikeTypeSpear
 		}
+		radius := attackRadius[c.NormalCounter][i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/rosaria/burst.go
+++ b/internal/characters/rosaria/burst.go
@@ -44,7 +44,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// Hit 1 comes out on frame 15
 	// 2nd hit comes after lance drop animation finishes
 	// center on player
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), 15, 15, c.c6)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3.5), 15, 15, c.c6)
 
 	ai.Abil = "Rites of Termination (Hit 2)"
 	ai.StrikeType = combat.StrikeTypeDefault
@@ -63,7 +63,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// lance lands at 56f if we exclude hitlag (60f was with hitlag)
 	c.QueueCharTask(func() {
 		// Hit 2
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, 0, c.c6)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6), 0, 0, c.c6)
 
 		// Burst status
 		c.Core.Status.Add("rosariaburst", dur)
@@ -82,7 +82,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 		// DoT every 2 seconds after lance lands
 		for i := 120; i < dur; i += 120 {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, i, c.c6)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6.5), 0, i, c.c6)
 		}
 	}, 56)
 

--- a/internal/characters/rosaria/charge.go
+++ b/internal/characters/rosaria/charge.go
@@ -36,7 +36,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		IsDeployable:       true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/rosaria/skill.go
+++ b/internal/characters/rosaria/skill.go
@@ -45,7 +45,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		c.c4completed = false
 		c4cb = c.c4
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), skillHitmark, skillHitmark, c4cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.24), skillHitmark, skillHitmark, c4cb)
 
 	// A1 activation
 	// When Rosaria strikes an opponent from behind using Ravaging Confession, Rosaria's CRIT RATE increases by 12% for 5s.
@@ -83,7 +83,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 	c.QueueCharTask(func() {
 		//second hit is 14 frames after the first (if we exclude hitlag)
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 0, 0)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.8), 0, 0)
 		// Particles are emitted after the second hit lands
 		c.Core.QueueParticle("rosaria", 3, attributes.Cryo, c.ParticleDelay)
 	}, skillHitmark+14)

--- a/internal/characters/sara/aimed.go
+++ b/internal/characters/sara/aimed.go
@@ -62,7 +62,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		aimedHitmarks[skillActive],
 		aimedHitmarks[skillActive]+travel,
 	)
@@ -84,7 +84,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		//TODO: snapshot?
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 2),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6),
 			aimedHitmarks[skillActive],
 			aimedHitmarks[skillActive]+travel+90,
 			c.a4,

--- a/internal/characters/sara/attack.go
+++ b/internal/characters/sara/attack.go
@@ -47,7 +47,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)

--- a/internal/characters/sara/burst.go
+++ b/internal/characters/sara/burst.go
@@ -74,7 +74,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	if waveClusterHits%10 == 1 {
 		// Actual hit procs after the full cast duration, or 50 frames
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstStart, burstInitialHitmark, c1cb)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6), burstStart, burstInitialHitmark, c1cb)
 	}
 	if waveAttackProcs%10 == 1 {
 		c.attackBuff(burstInitialHitmark)
@@ -93,7 +93,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		waveAttackProc := int((waveAttackProcs % PowInt(10, waveN+2)) / PowInt(10, waveN+2-1))
 		if waveHits > 0 {
 			for j := 0; j < waveHits; j++ {
-				c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstStart, burstClusterHitmark+18*waveN, c1cb)
+				c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 3), burstStart, burstClusterHitmark+18*waveN, c1cb)
 			}
 		}
 		if waveAttackProc == 1 {

--- a/internal/characters/sara/skill.go
+++ b/internal/characters/sara/skill.go
@@ -50,7 +50,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			Mult:       0.3 * skill[c.TalentLvlSkill()],
 		}
 		// TODO: not sure of snapshot? timing
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 50, c2Hitmark, c.a4)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6), 50, c2Hitmark, c.a4)
 		c.attackBuff(c2Hitmark)
 	}
 

--- a/internal/characters/sayu/attack.go
+++ b/internal/characters/sayu/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{23}, {29}, {14, 26}, {35}}
-var attackHitlagHaltFrame = [][]float64{{0.1}, {0.1}, {0, 0.08}, {0.08}}
-var attackDefHalt = [][]bool{{true}, {true}, {false, true}, {true}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{23}, {29}, {14, 26}, {35}}
+	attackHitlagHaltFrame = [][]float64{{0.1}, {0.1}, {0, 0.08}, {0.08}}
+	attackDefHalt         = [][]bool{{true}, {true}, {false, true}, {true}}
+	attackRadius          = [][]float64{{2.03}, {2}, {2.15, 2}, {2.65}}
+)
 
 const normalHitNum = 4
 
@@ -41,10 +44,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
+		radius := attackRadius[c.NormalCounter][i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/sayu/burst.go
+++ b/internal/characters/sayu/burst.go
@@ -37,7 +37,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames: 0.02 * 60,
 	}
 	snap := c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 4.5), burstHitmark)
 
 	// heal
 	atk := snap.BaseAtk*(1+snap.Stats[attributes.ATKP]) + snap.Stats[attributes.ATK]
@@ -121,7 +121,7 @@ func (c *char) createBurstSnapshot() *combat.AttackEvent {
 
 	return (&combat.AttackEvent{
 		Info:        ai,
-		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 5), // including A4
+		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 3.5), // including A4
 		SourceFrame: c.Core.F,
 		Snapshot:    snap,
 	})

--- a/internal/characters/sayu/skill.go
+++ b/internal/characters/sayu/skill.go
@@ -76,7 +76,7 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 		Mult:       skillPress[c.TalentLvlSkill()],
 	}
 	snap := c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), skillPressDoTHitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), skillPressDoTHitmark)
 
 	// Fuufuu Whirlwind Kick Press DMG
 	ai = combat.AttackInfo{
@@ -93,7 +93,7 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 		HitlagFactor:     0.05,
 	}
 	snap = c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), skillPressKickHitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2.5), skillPressKickHitmark)
 
 	c.Core.QueueParticle("sayu-skill", 2, attributes.Anemo, skillPressKickHitmark+c.ParticleDelay)
 
@@ -113,7 +113,7 @@ func (c *char) skillShortHold(p map[string]int) action.ActionInfo {
 
 	c.eAbsorb = attributes.NoElement
 	c.eAbsorbTag = combat.ICDTagNone
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.2)
 
 	// 1 DoT Tick
 	d := c.createSkillHoldSnapshot()
@@ -145,7 +145,7 @@ func (c *char) skillShortHold(p map[string]int) action.ActionInfo {
 		HitlagFactor:     0.05,
 	}
 	snap := c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), skillShortHoldKickHitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), skillShortHoldKickHitmark)
 
 	c.Core.QueueParticle("sayu-skill", 2, attributes.Anemo, skillShortHoldKickHitmark+c.ParticleDelay)
 
@@ -166,7 +166,7 @@ func (c *char) skillHold(p map[string]int, duration int) action.ActionInfo {
 
 	c.eAbsorb = attributes.NoElement
 	c.eAbsorbTag = combat.ICDTagNone
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.2)
 
 	// ticks
 	d := c.createSkillHoldSnapshot()
@@ -203,7 +203,7 @@ func (c *char) skillHold(p map[string]int, duration int) action.ActionInfo {
 		HitlagFactor:     0.05,
 	}
 	snap := c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), (skillHoldKickHitmark-600)+duration)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 3), (skillHoldKickHitmark-600)+duration)
 
 	c.Core.QueueParticle("sayu-skill", 2, attributes.Anemo, (skillHoldKickHitmark-600)+duration+c.ParticleDelay)
 
@@ -238,7 +238,7 @@ func (c *char) createSkillHoldSnapshot() *combat.AttackEvent {
 
 	return (&combat.AttackEvent{
 		Info:        ai,
-		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 0.5),
+		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 3),
 		SourceFrame: c.Core.F,
 		Snapshot:    snap,
 	})
@@ -301,7 +301,7 @@ func (c *char) rollAbsorb() {
 				Durability: 25,
 				Mult:       skillAbsorb[c.TalentLvlSkill()],
 			}
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 1, 1)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 1, 1)
 		case combat.AttackTagElementalArtHold:
 			// Kick Elemental DMG
 			ai := combat.AttackInfo{
@@ -315,7 +315,7 @@ func (c *char) rollAbsorb() {
 				Durability: 25,
 				Mult:       skillAbsorbEnd[c.TalentLvlSkill()],
 			}
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 1, 1)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 1, 1)
 		}
 
 		return false

--- a/internal/characters/shenhe/attack.go
+++ b/internal/characters/shenhe/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{14}, {17}, {19}, {14, 18}, {26}}
-var attackHitlagHaltFrame = [][]float64{{0.02}, {0.02}, {0.02}, {0, 0.02}, {0.1}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {false, true}, {true}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{14}, {17}, {19}, {14, 18}, {26}}
+	attackHitlagHaltFrame = [][]float64{{0.02}, {0.02}, {0.02}, {0, 0.02}, {0.1}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, true}, {true}}
+	attackRadius          = []float64{2.5, 2.5, 2.5, 2.11, 3}
+)
 
 const normalHitNum = 5
 
@@ -56,8 +59,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 3 {
 			ai.StrikeType = combat.StrikeTypeSpear
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 0, 0)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), 0, 0)
 		}, attackHitmarks[c.NormalCounter][i])
 	}
 

--- a/internal/characters/shenhe/burst.go
+++ b/internal/characters/shenhe/burst.go
@@ -41,7 +41,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       burst[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 8), burstHitmark, burstHitmark)
 
 	// duration is 12 second (extended by c2 by 6s)
 	count := 6
@@ -68,8 +68,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		snap := c.Snapshot(&ai)
 		for i := 0; i < count; i++ {
 			hitmark := 82 + i*117
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), hitmark)
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), hitmark+30+burstTickOffset[i])
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 7), hitmark)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 7), hitmark+30+burstTickOffset[i])
 		}
 	}, burstStart)
 

--- a/internal/characters/shenhe/charge.go
+++ b/internal/characters/shenhe/charge.go
@@ -39,7 +39,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		IsDeployable:       true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/shenhe/skill.go
+++ b/internal/characters/shenhe/skill.go
@@ -66,7 +66,7 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 		IsDeployable:       true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), skillPressHitmark, skillPressHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), skillPressHitmark, skillPressHitmark)
 
 	// Skill actually moves you in game - actual catch is anywhere from 90-110 frames, take 100 as an average
 	c.Core.QueueParticle("shenhe", 3, attributes.Cryo, skillPressHitmark+c.ParticleDelay)
@@ -95,7 +95,7 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 		Mult:       skillHold[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), skillHoldHitmark, skillHoldHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), skillHoldHitmark, skillHoldHitmark)
 
 	// Particle spawn timing is a bit later than press E
 	c.Core.QueueParticle("shenhe", 4, attributes.Cryo, skillHoldHitmark+c.ParticleDelay)

--- a/internal/characters/sucrose/attack.go
+++ b/internal/characters/sucrose/attack.go
@@ -9,8 +9,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{17, 18, 28, 28}
+var (
+	attackFrames   [][]int
+	attackHitmarks = []int{17, 18, 28, 28}
+	attackRadius   = []float64{1, 1, 1, 2}
+)
 
 const normalHitNum = 4
 
@@ -43,10 +46,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       attack[c.NormalCounter][c.TalentLvlAttack()],
 	}
-
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/sucrose/burst.go
+++ b/internal/characters/sucrose/burst.go
@@ -28,7 +28,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	// reset location
 	c.qAbsorb = attributes.NoElement
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.77)
 
 	c.Core.Status.Add("sucroseburst", duration)
 	ai := combat.AttackInfo{
@@ -69,12 +69,12 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 
 	for i := 137; i <= duration+5; i += 113 {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5), i, cb)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 8), i, cb)
 
 		c.Core.Tasks.Add(func() {
 			if c.qAbsorb != attributes.NoElement {
 				aiAbs.Element = c.qAbsorb
-				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5), 0)
+				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 8), 0)
 			}
 			//check if absorbed
 		}, i)

--- a/internal/characters/sucrose/charge.go
+++ b/internal/characters/sucrose/charge.go
@@ -42,7 +42,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		windup = 15
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.3), chargeHitmark-windup, chargeHitmark-windup)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4.08), chargeHitmark-windup, chargeHitmark-windup)
 
 	if c.Base.Cons >= 4 {
 		c.c4()

--- a/internal/characters/sucrose/skill.go
+++ b/internal/characters/sucrose/skill.go
@@ -41,7 +41,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		c.Core.QueueParticle("sucrose", 4, attributes.Anemo, c.ParticleDelay)
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0, 42, cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6), 0, 42, cb)
 
 	//reduce charge by 1
 	c.SetCDWithDelay(action.ActionSkill, 900, 9)

--- a/internal/characters/tartaglia/aimed.go
+++ b/internal/characters/tartaglia/aimed.go
@@ -56,7 +56,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		aimedHitmark,
 		aimedHitmark+travel,
 		// TODO: what's the ordering on these 2 callbacks?

--- a/internal/characters/tartaglia/attack.go
+++ b/internal/characters/tartaglia/attack.go
@@ -64,7 +64,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 	)
@@ -83,6 +83,7 @@ var (
 	meleeFrames           [][]int
 	meleeHitmarks         = [][]int{{8}, {6}, {16}, {7}, {7}, {4, 20}}
 	meleeHitlagHaltFrames = [][]float64{{0.03}, {0.03}, {0.06}, {0.06}, {0.06}, {0.03, 0.12}}
+	meleeRadius           = [][]float64{{1.8}, {1.8}, {2.0}, {2.0}, {2.2}, {1.89, 2.2}}
 )
 
 func init() {
@@ -141,10 +142,11 @@ func (c *char) meleeAttack(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 5 && i == 0 {
 			ai.StrikeType = combat.StrikeTypeSpear
 		}
+		radius := meleeRadius[c.NormalCounter][i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), .5),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 				c.meleeApplyRiptide, // riptide can trigger on the same hit that applies

--- a/internal/characters/tartaglia/burst.go
+++ b/internal/characters/tartaglia/burst.go
@@ -52,6 +52,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	cancels := burstRangedFrames
 	hitmark := burstRangedHitmark
 	cb := c.rangedBurstApplyRiptide
+	radius := 6.0
 
 	if c.StatusIsActive(meleeKey) {
 		ai.Abil = "Melee Stance: Light of Obliteration"
@@ -60,6 +61,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		cancels = burstMeleeFrames
 		hitmark = burstMeleeHitmark
 		cb = c.rtBlastCallback
+		radius = 8
 		if c.Base.Cons >= 6 {
 			c.mlBurstUsed = true
 		}
@@ -69,7 +71,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		}, 4)
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), hitmark, hitmark, cb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), hitmark, hitmark, cb)
 
 	if c.StatusIsActive(meleeKey) {
 		c.ConsumeEnergy(71)

--- a/internal/characters/tartaglia/charge.go
+++ b/internal/characters/tartaglia/charge.go
@@ -58,7 +58,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		ai.Mult = mult[c.TalentLvlSkill()]
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 1),
+			combat.NewCircleHit(c.Core.Combat.Player(), 2.2),
 			chargeHitmarks[i],
 			chargeHitmarks[i],
 			c.meleeApplyRiptide, // call back for applying riptide

--- a/internal/characters/tartaglia/riptide.go
+++ b/internal/characters/tartaglia/riptide.go
@@ -123,7 +123,7 @@ func (c *char) rtFlashTick(t *enemy.Enemy) {
 
 	// proc 3 hits
 	for i := 1; i <= 3; i++ {
-		c.Core.QueueAttack(ai, combat.NewCircleHit(t, 0.5), 1, 1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(t, 3), 1, 1)
 	}
 
 	c.Core.Log.NewEvent(
@@ -179,7 +179,7 @@ func (c *char) rtSlashTick(t *enemy.Enemy) {
 		Mult:       rtSlash[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(t, 2), 1, 1)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(t, 3), 1, 1)
 
 	c.Core.Log.NewEvent(
 		"riptide slash ticked",
@@ -227,7 +227,7 @@ func (c *char) rtBlastCallback(a combat.AttackCB) {
 		Mult:       rtBlast[c.TalentLvlBurst()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 1, 1)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(t, 5), 1, 1)
 
 	c.Core.Log.NewEvent(
 		"riptide blast triggered",
@@ -268,7 +268,7 @@ func (c *char) onDefeatTargets() {
 				Durability: 50,
 				Mult:       rtBurst[c.TalentLvlAttack()],
 			}
-			c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, 0)
+			c.Core.QueueAttack(ai, combat.NewCircleHit(t, 5), 0, 0)
 		}, 5)
 		// TODO: re-index riptide expiry frame array if needed
 		if c.Base.Cons >= 2 {

--- a/internal/characters/tartaglia/skill.go
+++ b/internal/characters/tartaglia/skill.go
@@ -131,7 +131,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		hitmark = skillDashHitmark
 		cdDelay = 0
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), hitmark, hitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), hitmark, hitmark)
 
 	src := c.eCast
 	c.QueueCharTask(func() {

--- a/internal/characters/thoma/attack.go
+++ b/internal/characters/thoma/attack.go
@@ -14,6 +14,7 @@ var (
 	attackHitmarks        = [][]int{{13}, {18}, {10, 23}, {20}}
 	attackHitlagHaltFrame = [][]float64{{0.06}, {0.09}, {0, 0}, {0}}
 	attackDefHalt         = [][]bool{{true}, {true}, {false, false}, {false}}
+	attackRadius          = []float64{2, 2, 2.18, 3.43}
 )
 
 const normalHitNum = 4
@@ -58,10 +59,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 3 {
 			ai.StrikeType = combat.StrikeTypeSpear
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/thoma/burst.go
+++ b/internal/characters/thoma/burst.go
@@ -42,7 +42,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// damage component not final
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(c.Core.Combat.Player(), 4),
 		burstHitmark,
 		burstHitmark,
 	)
@@ -153,6 +153,6 @@ func (c *char) summonFieryCollapse() {
 		c.genShield("Thoma Burst", shieldamt, true)
 		done = true
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), 0, 11, shieldCb)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4.59), 0, 11, shieldCb)
 	c.AddStatus(burstICDKey, 60, true)
 }

--- a/internal/characters/thoma/charge.go
+++ b/internal/characters/thoma/charge.go
@@ -36,7 +36,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		IsDeployable:       true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/thoma/skill.go
+++ b/internal/characters/thoma/skill.go
@@ -53,7 +53,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	// damage component not final
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(c.Core.Combat.Player(), 3),
 		skillHitmark,
 		skillHitmark,
 	)

--- a/internal/characters/tighnari/aimed.go
+++ b/internal/characters/tighnari/aimed.go
@@ -59,7 +59,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		IsDeployable:         true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), .1), aimedHitmark, aimedHitmark+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), aimedHitmark, aimedHitmark+travel)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(aimedFrames),
@@ -113,7 +113,7 @@ func (c *char) WreathAimed(p map[string]int) action.ActionInfo {
 		HitlagOnHeadshotOnly: true,
 		IsDeployable:         true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), .1), aimedWreathHitmark-skip, aimedWreathHitmark+travel-skip)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), aimedWreathHitmark-skip, aimedWreathHitmark+travel-skip)
 	c.Core.Tasks.Add(c.a1, aimedWreathHitmark-skip+1)
 
 	ai = combat.AttackInfo{
@@ -134,7 +134,7 @@ func (c *char) WreathAimed(p map[string]int) action.ActionInfo {
 			c.Core.QueueAttackWithSnap(
 				ai,
 				snap,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1),
 				wreathTravel,
 			)
 		}
@@ -154,7 +154,7 @@ func (c *char) WreathAimed(p map[string]int) action.ActionInfo {
 			c.Core.QueueAttackWithSnap(
 				ai,
 				snap,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1),
 				wreathTravel,
 			)
 		}

--- a/internal/characters/tighnari/attack.go
+++ b/internal/characters/tighnari/attack.go
@@ -44,7 +44,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 			attackHitmarks[c.NormalCounter][i],
 			attackHitmarks[c.NormalCounter][i]+travel,
 		)

--- a/internal/characters/tighnari/burst.go
+++ b/internal/characters/tighnari/burst.go
@@ -43,7 +43,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	for i := 0; i < 6; i++ {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1),
 			burstRelease,
 			burstHitmarks[i]+travel,
 		)
@@ -54,7 +54,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	for i := 0; i < 6; i++ {
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1),
 			burstHitmarks[i]+travel,
 			burstSecondHitmarks[i]+travel,
 		)

--- a/internal/characters/tighnari/skill.go
+++ b/internal/characters/tighnari/skill.go
@@ -45,7 +45,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 2),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6),
 		skillRelease,
 		skillRelease+travel,
 	)

--- a/internal/characters/traveleranemo/attack.go
+++ b/internal/characters/traveleranemo/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][][]int
-var attackHitmarks = [][]int{{13, 13, 16, 30, 25}, {16, 10, 19, 23, 14}}
-var attackHitlagHaltFrame = [][]float64{{0.03, 0.03, 0.06, 0.09, 0.12}, {0.03, 0.03, 0.06, 0.06, 0.10}}
-var a1Hitmark = []int{19, 21}
+var (
+	attackFrames          [][][]int
+	attackHitmarks        = [][]int{{13, 13, 16, 30, 25}, {16, 10, 19, 23, 14}}
+	attackHitlagHaltFrame = [][]float64{{0.03, 0.03, 0.06, 0.09, 0.12}, {0.03, 0.03, 0.06, 0.06, 0.10}}
+	a1Hitmark             = []int{19, 21}
+	attackRadius          = [][]float64{{1.3, 1.7, 1.33, 1.7, 1.75}, {1.6, 1.3, 1.5, 1.5, 1.6}}
+)
 
 const normalHitNum = 5
 
@@ -71,9 +74,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.gender][c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
+	radius := attackRadius[c.gender][c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.gender][c.NormalCounter],
 		attackHitmarks[c.gender][c.NormalCounter],
 	)
@@ -94,7 +98,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+				combat.NewCircleHit(c.Core.Combat.Player(), 1),
 				0,
 				0,
 			)

--- a/internal/characters/traveleranemo/burst.go
+++ b/internal/characters/traveleranemo/burst.go
@@ -38,7 +38,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.qAbsorb = attributes.NoElement
 	c.qICDTag = combat.ICDTagNone
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.77)
 
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -73,7 +73,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 
 	for i := 0; i < 9; i++ {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), 94+30*i, cb)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 2.12), 94+30*i, cb)
 
 		c.Core.Tasks.Add(func() {
 			if c.qAbsorb != attributes.NoElement {
@@ -82,7 +82,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				if c.Base.Cons >= 6 {
 					cbAbs = c6cb(c.qAbsorb)
 				}
-				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.Player(), 5), 0, cbAbs)
+				c.Core.QueueAttackWithSnap(aiAbs, snapAbs, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 1.77), 0, cbAbs)
 			}
 			//check if infused
 		}, 94+30*i)

--- a/internal/characters/traveleranemo/charge.go
+++ b/internal/characters/traveleranemo/charge.go
@@ -47,7 +47,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		ai.Abil = fmt.Sprintf("Charge %v", i)
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 2),
+			combat.NewCircleHit(c.Core.Combat.Player(), 2.2),
 			chargeHitmarks[c.gender][i],
 			chargeHitmarks[c.gender][i],
 		)

--- a/internal/characters/traveleranemo/skill.go
+++ b/internal/characters/traveleranemo/skill.go
@@ -59,7 +59,7 @@ func (c *char) SkillPress() action.ActionInfo {
 		Durability: 25,
 		Mult:       skillInitialStorm[c.TalentLvlSkill()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), hitmark, hitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6), hitmark, hitmark)
 
 	c.Core.QueueParticle(c.Base.Key.String(), 2, attributes.Anemo, hitmark+c.ParticleDelay)
 	c.SetCDWithDelay(action.ActionSkill, 5*60, hitmark-5)
@@ -76,7 +76,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 
 	c.eAbsorb = attributes.NoElement
 	c.eICDTag = combat.ICDTagNone
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 0.1)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 3)
 
 	aiCut := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -106,13 +106,13 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 	hitmark := firstTick
 	for i := 0; i < holdTicks; i += 1 {
 
-		c.Core.QueueAttack(aiCut, combat.NewCircleHit(c.Core.Combat.Player(), 1), hitmark, hitmark)
+		c.Core.QueueAttack(aiCut, combat.NewCircleHit(c.Core.Combat.Player(), 1.7), hitmark, hitmark)
 		if i > 1 {
 			c.Core.Tasks.Add(func() {
 				if c.eAbsorb != attributes.NoElement {
 					aiMaxCutAbs.Element = c.eAbsorb
 					aiMaxCutAbs.ICDTag = c.eICDTag
-					c.Core.QueueAttack(aiMaxCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 0, 0)
+					c.Core.QueueAttack(aiMaxCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 3.6), 0, 0)
 				}
 				//check if absorbed
 			}, hitmark)
@@ -121,7 +121,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 				if c.eAbsorb != attributes.NoElement {
 					aiCutAbs.Element = c.eAbsorb
 					aiCutAbs.ICDTag = c.eICDTag
-					c.Core.QueueAttack(aiCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.5), 0, 0)
+					c.Core.QueueAttack(aiCutAbs, combat.NewCircleHit(c.Core.Combat.Player(), 1.7), 0, 0)
 				}
 				//check if absorbed
 			}, hitmark)
@@ -177,7 +177,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 		c.SetCDWithDelay(action.ActionSkill, 5*60, hitmark-5)
 	}
 
-	c.Core.QueueAttack(aiStorm, combat.NewCircleHit(c.Core.Combat.Player(), 2), hitmark, hitmark)
+	c.Core.QueueAttack(aiStorm, combat.NewCircleHit(c.Core.Combat.Player(), 6), hitmark, hitmark)
 	c.Core.Tasks.Add(func() {
 		if c.eAbsorb != attributes.NoElement {
 			aiStormAbs.Element = c.eAbsorb

--- a/internal/characters/travelerdendro/attack.go
+++ b/internal/characters/travelerdendro/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][][]int
-var attackHitmarks = [][]int{{13, 13, 16, 30, 25}, {16, 10, 19, 23, 14}}
-var attackHitlagHaltFrame = [][]float64{{0.03, 0.03, 0.06, 0.09, 0.12}, {0.03, 0.03, 0.06, 0.06, 0.10}}
+var (
+	attackFrames          [][][]int
+	attackHitmarks        = [][]int{{13, 13, 16, 30, 25}, {16, 10, 19, 23, 14}}
+	attackHitlagHaltFrame = [][]float64{{0.03, 0.03, 0.06, 0.09, 0.12}, {0.03, 0.03, 0.06, 0.06, 0.10}}
+	attackRadius          = [][]float64{{1.3, 1.7, 1.33, 1.7, 1.75}, {1.6, 1.3, 1.5, 1.5, 1.6}}
+)
 
 const normalHitNum = 5
 
@@ -70,9 +73,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.gender][c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
+	radius := attackRadius[c.gender][c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.gender][c.NormalCounter],
 		attackHitmarks[c.gender][c.NormalCounter],
 	)

--- a/internal/characters/travelerdendro/charge.go
+++ b/internal/characters/travelerdendro/charge.go
@@ -47,7 +47,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		ai.Abil = fmt.Sprintf("Charge %v", i)
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 2),
+			combat.NewCircleHit(c.Core.Combat.Player(), 2.2),
 			chargeHitmarks[c.gender][i],
 			chargeHitmarks[c.gender][i],
 		)

--- a/internal/characters/travelerelectro/attack.go
+++ b/internal/characters/travelerelectro/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][][]int
-var attackHitmarks = [][]int{{13, 13, 16, 30, 25}, {16, 10, 19, 23, 14}}
-var attackHitlagHaltFrame = [][]float64{{0.03, 0.03, 0.06, 0.09, 0.12}, {0.03, 0.03, 0.06, 0.06, 0.10}}
+var (
+	attackFrames          [][][]int
+	attackHitmarks        = [][]int{{13, 13, 16, 30, 25}, {16, 10, 19, 23, 14}}
+	attackHitlagHaltFrame = [][]float64{{0.03, 0.03, 0.06, 0.09, 0.12}, {0.03, 0.03, 0.06, 0.06, 0.10}}
+	attackRadius          = [][]float64{{1.3, 1.7, 1.33, 1.7, 1.75}, {1.6, 1.3, 1.5, 1.5, 1.6}}
+)
 
 const normalHitNum = 5
 
@@ -70,9 +73,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.gender][c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
+	radius := attackRadius[c.gender][c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.gender][c.NormalCounter],
 		attackHitmarks[c.gender][c.NormalCounter],
 	)

--- a/internal/characters/travelerelectro/burst.go
+++ b/internal/characters/travelerelectro/burst.go
@@ -115,8 +115,11 @@ func (c *char) burstProc() {
 		// Use burst snapshot, update target & source frame
 		atk := *c.burstAtk
 		atk.SourceFrame = c.Core.F
-		//attack is 2 (or 2.5 for enhanced) aoe centered on target
-		atk.Pattern = combat.NewCircleHit(t, 2)
+		radius := 2.0
+		if c.Base.Cons >= 6 && c.burstC6WillGiveEnergy {
+			radius = 2.5
+		}
+		atk.Pattern = combat.NewCircleHit(t, radius)
 
 		// C2 - Violet Vehemence
 		// When Falling Thunder created by Bellowing Thunder hits an opponent, it will decrease their Electro RES by 15% for 8s.

--- a/internal/characters/travelerelectro/charge.go
+++ b/internal/characters/travelerelectro/charge.go
@@ -47,7 +47,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		ai.Abil = fmt.Sprintf("Charge %v", i)
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 2),
+			combat.NewCircleHit(c.Core.Combat.Player(), 2.2),
 			chargeHitmarks[c.gender][i],
 			chargeHitmarks[c.gender][i],
 		)

--- a/internal/characters/travelerelectro/skill.go
+++ b/internal/characters/travelerelectro/skill.go
@@ -99,7 +99,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 
 	for i := 0; i < hits; i++ {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 0.3), skillHitmark, particlesCB, amuletCB)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.3), skillHitmark, particlesCB, amuletCB)
 	}
 
 	// try to pick up amulets

--- a/internal/characters/travelergeo/attack.go
+++ b/internal/characters/travelergeo/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][][]int
-var attackHitmarks = [][]int{{13, 13, 16, 30, 25}, {16, 10, 19, 23, 14}}
-var attackHitlagHaltFrame = [][]float64{{0.03, 0.03, 0.06, 0.09, 0.12}, {0.03, 0.03, 0.06, 0.06, 0.10}}
-var a4Hitmark = []int{18, 20}
+var (
+	attackFrames          [][][]int
+	attackHitmarks        = [][]int{{13, 13, 16, 30, 25}, {16, 10, 19, 23, 14}}
+	attackHitlagHaltFrame = [][]float64{{0.03, 0.03, 0.06, 0.09, 0.12}, {0.03, 0.03, 0.06, 0.06, 0.10}}
+	a4Hitmark             = []int{18, 20}
+	attackRadius          = [][]float64{{1.3, 1.7, 1.33, 1.7, 1.75}, {1.6, 1.3, 1.5, 1.5, 1.6}}
+)
 
 const normalHitNum = 5
 
@@ -71,9 +74,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.gender][c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
+	radius := attackRadius[c.gender][c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.gender][c.NormalCounter],
 		attackHitmarks[c.gender][c.NormalCounter],
 	)
@@ -94,7 +98,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+				combat.NewCircleHit(c.Core.Combat.Player(), 2.4),
 				0,
 				0,
 			)

--- a/internal/characters/travelergeo/burst.go
+++ b/internal/characters/travelergeo/burst.go
@@ -83,7 +83,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	//1.1 sec duration, tick every .25
 	for i := 0; i < hits; i++ {
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark+(i+1)*15, c4cb)
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 6), burstHitmark+(i+1)*15, c4cb)
 	}
 
 	c.Core.Tasks.Add(func() {

--- a/internal/characters/travelergeo/charge.go
+++ b/internal/characters/travelergeo/charge.go
@@ -47,7 +47,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		ai.Abil = fmt.Sprintf("Charge %v", i)
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 2),
+			combat.NewCircleHit(c.Core.Combat.Player(), 2.2),
 			chargeHitmarks[c.gender][i],
 			chargeHitmarks[c.gender][i],
 		)

--- a/internal/characters/travelergeo/skill.go
+++ b/internal/characters/travelergeo/skill.go
@@ -74,7 +74,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		IsDeployable:       true,
 	}
 	// TODO: check snapshot timing
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 24, skillHitmark[short_hold])
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 24, skillHitmark[short_hold])
 
 	var count float64 = 3
 	if c.Core.Rand.Float64() < 0.33 {
@@ -131,7 +131,7 @@ func (s *stone) OnDestruct() {
 			CanBeDefenseHalted: true,
 			IsDeployable:       true,
 		}
-		s.char.Core.QueueAttack(ai, combat.NewCircleHit(s.char.Core.Combat.Player(), 2), 0, 0)
+		s.char.Core.QueueAttack(ai, combat.NewCircleHit(s.char.Core.Combat.Player(), 3), 0, 0)
 	}
 }
 

--- a/internal/characters/venti/aimed.go
+++ b/internal/characters/venti/aimed.go
@@ -41,7 +41,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		IsDeployable:         true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), .1), aimedHitmark, aimedHitmark+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), aimedHitmark, aimedHitmark+travel)
 	if c.Base.Cons >= 1 {
 		c.c1(ai, travel)
 	}

--- a/internal/characters/venti/attack.go
+++ b/internal/characters/venti/attack.go
@@ -46,7 +46,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		ai.Mult = mult[c.TalentLvlAttack()]
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 			attackHitmarks[c.NormalCounter][i],
 			attackHitmarks[c.NormalCounter][i]+travel,
 		)

--- a/internal/characters/venti/burst.go
+++ b/internal/characters/venti/burst.go
@@ -20,7 +20,7 @@ func init() {
 func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// reset location
 	c.qAbsorb = attributes.NoElement
-	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.1)
+	c.absorbCheckLocation = combat.NewCircleHit(c.Core.Combat.Player(), 1.77)
 
 	//8 second duration, tick every .4 second
 	ai := combat.AttackInfo{
@@ -54,7 +54,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	// starts at 106 with 24f interval between ticks. 20 total
 	for i := 0; i < 20; i++ {
 		c.Core.Tasks.Add(func() {
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4), 0, cb)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 4), 0, cb)
 		}, 106+24*i)
 	}
 	// Infusion usually occurs after 4 ticks of anemo according to KQM library
@@ -84,7 +84,7 @@ func (c *char) burstAbsorbedTicks() {
 
 	// ticks at 24f. 15 total
 	for i := 0; i < 15; i++ {
-		c.Core.QueueAttackWithSnap(c.aiAbsorb, c.snapAbsorb, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4), i*24, cb)
+		c.Core.QueueAttackWithSnap(c.aiAbsorb, c.snapAbsorb, combat.NewCircleHit(c.Core.Combat.Player(), 6), i*24, cb)
 	}
 }
 

--- a/internal/characters/venti/skill.go
+++ b/internal/characters/venti/skill.go
@@ -49,11 +49,13 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	cd := 360
 	cdstart := 21
 	hitmark := 51
+	radius := 3.0
 	var count float64 = 3
 	if p["hold"] != 0 {
 		cd = 900
 		cdstart = 34
 		hitmark = 74
+		radius = 6
 		count = 4
 		ai.Mult = skillHold[c.TalentLvlSkill()]
 
@@ -65,7 +67,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		}
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), 0, hitmark, c.c2)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), 0, hitmark, c.c2)
 	c.Core.QueueParticle("venti", count, attributes.Anemo, hitmark+c.ParticleDelay)
 
 	c.SetCDWithDelay(action.ActionSkill, cd, cdstart)

--- a/internal/characters/xiangling/attack.go
+++ b/internal/characters/xiangling/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{12}, {8}, {11, 18}, {5, 15, 24, 29}, {21}}
-var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.03, 0}, {0, 0, 0, 0.03}, {0.09}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{12}, {8}, {11, 18}, {5, 15, 24, 29}, {21}}
+	attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0.03, 0}, {0, 0, 0, 0.03}, {0.09}}
+	attackRadius          = [][]float64{{1.61}, {1.83}, {1.83, 1.76}, {1.76, 1.76, 1.76, 1.76}, {1.83}}
+)
 
 const normalHitNum = 5
 
@@ -49,10 +52,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: true,
 		}
+		radius := attackRadius[c.NormalCounter][i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/xiangling/attack.go
+++ b/internal/characters/xiangling/attack.go
@@ -16,7 +16,10 @@ var (
 	attackRadius          = [][]float64{{1.61}, {1.83}, {1.83, 1.76}, {1.76, 1.76, 1.76, 1.76}, {1.83}}
 )
 
-const normalHitNum = 5
+const (
+	normalHitNum = 5
+	c2Debuff     = "xiangling-c2"
+)
 
 func init() {
 	attackFrames = make([][]int, normalHitNum)
@@ -36,7 +39,11 @@ func init() {
 }
 
 func (c *char) Attack(p map[string]int) action.ActionInfo {
-
+	done := false
+	var c2CB func(a combat.AttackCB)
+	if c.Base.Cons >= 2 && c.NormalCounter == 4 {
+		c2CB = c.c2(done)
+	}
 	for i, mult := range attack[c.NormalCounter] {
 		ai := combat.AttackInfo{
 			ActorIndex:         c.Index,
@@ -59,26 +66,9 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
+				c2CB,
 			)
 		}, attackHitmarks[c.NormalCounter][i])
-	}
-
-	//if n = 5, add explosion for c2
-	if c.Base.Cons >= 2 && c.NormalCounter == 4 {
-		//No icd, no attack tag, 25 durability
-		ai := combat.AttackInfo{
-			ActorIndex: c.Index,
-			Abil:       "Oil Meets Fire (C2)",
-			AttackTag:  combat.AttackTagNone,
-			ICDTag:     combat.ICDTagNone,
-			ICDGroup:   combat.ICDGroupDefault,
-			StrikeType: combat.StrikeTypeDefault,
-			Element:    attributes.Pyro,
-			Durability: 25,
-			Mult:       .75,
-		}
-		//TODO: explosion frames
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 120, 120)
 	}
 
 	defer c.AdvanceNormalIndex()

--- a/internal/characters/xiangling/burst.go
+++ b/internal/characters/xiangling/burst.go
@@ -9,8 +9,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var burstFrames []int
-var burstHitmarks = []int{18, 33, 56} // initial 3 hits
+var (
+	burstFrames   []int
+	burstHitmarks = []int{18, 33, 56} // initial 3 hits
+	burstRadius   = []float64{2.5, 2.5, 3}
+)
 
 func init() {
 	burstFrames = frames.InitAbilSlice(80)
@@ -33,8 +36,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 			CanBeDefenseHalted: true,
 			Mult:               pyronadoInitial[i][c.TalentLvlBurst()],
 		}
+		radius := burstRadius[i]
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(initialHit, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), 0, 0)
+			c.Core.QueueAttack(initialHit, combat.NewCircleHit(c.Core.Combat.Player(), radius), 0, 0)
 		}, burstHitmarks[i])
 	}
 

--- a/internal/characters/xiangling/charge.go
+++ b/internal/characters/xiangling/charge.go
@@ -36,7 +36,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		Mult:               nc[c.TalentLvlAttack()],
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/xiangling/cons.go
+++ b/internal/characters/xiangling/cons.go
@@ -3,6 +3,7 @@ package xiangling
 import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/enemy"
 	"github.com/genshinsim/gcsim/pkg/modifier"
@@ -21,6 +22,43 @@ func (c *char) c1(a combat.AttackCB) {
 		Ele:   attributes.Pyro,
 		Value: -0.15,
 	})
+}
+
+func (c *char) c2(done bool) combat.AttackCBFunc {
+	return func(atk combat.AttackCB) {
+		if done {
+			return
+		}
+		trg, ok := atk.Target.(*enemy.Enemy)
+		if !ok {
+			return
+		}
+		if !trg.StatusIsActive(c2Debuff) {
+			trg.QueueEnemyTask(c.c2Explode(c.Core.F, trg), 120)
+			trg.AddStatus(c2Debuff, 120, true)
+		}
+		done = true
+	}
+}
+func (c *char) c2Explode(src int, trg *enemy.Enemy) func() {
+	return func() {
+		ai := combat.AttackInfo{
+			ActorIndex: c.Index,
+			Abil:       "Oil Meets Fire (C2)",
+			AttackTag:  combat.AttackTagNone,
+			ICDTag:     combat.ICDTagNone,
+			ICDGroup:   combat.ICDGroupDefault,
+			StrikeType: combat.StrikeTypeDefault,
+			Element:    attributes.Pyro,
+			Durability: 25,
+			Mult:       .75,
+		}
+
+		c.Core.QueueAttack(ai, combat.NewCircleHit(trg, 2), 0, 0)
+
+		c.Core.Log.NewEvent("Triggered Xiangling C2 explosion", glog.LogCharacterEvent, c.Index).
+			Write("src", src)
+	}
 }
 
 func (c *char) c6(dur int) {

--- a/internal/characters/xiangling/guoba.go
+++ b/internal/characters/xiangling/guoba.go
@@ -67,10 +67,12 @@ func (p *panda) breath() {
 		done = true
 		p.Core.QueueParticle("xiangling", 1, attributes.Pyro, p.c.ParticleDelay)
 	}
+	// assume A1
+	radius := 6.0
 	p.Core.QueueAttackWithSnap(
 		p.ai,
 		p.snap,
-		combat.NewCircleHit(p, 0.5),
+		combat.NewCircleHit(p, radius),
 		10,
 		p.c.c1,
 		part,

--- a/internal/characters/xiao/attack.go
+++ b/internal/characters/xiao/attack.go
@@ -9,18 +9,21 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{4, 17}, {15}, {15}, {14, 31}, {16}, {39}}
-var attackHitlagHaltFrame = [][]float64{{0, 0.01}, {0.01}, {0.01}, {0.02, 0.02}, {0.02}, {0.04}}
-var attackDefHalt = [][]bool{{false, true}, {true}, {true}, {false, true}, {true}, {true}}
-var attackStrikeTypes = [][]combat.StrikeType{
-	{combat.StrikeTypeSlash, combat.StrikeTypeSpear},
-	{combat.StrikeTypeSlash},
-	{combat.StrikeTypeSlash},
-	{combat.StrikeTypeSlash, combat.StrikeTypeSlash},
-	{combat.StrikeTypeSpear},
-	{combat.StrikeTypeSlash},
-}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{4, 17}, {15}, {15}, {14, 31}, {16}, {39}}
+	attackHitlagHaltFrame = [][]float64{{0, 0.01}, {0.01}, {0.01}, {0.02, 0.02}, {0.02}, {0.04}}
+	attackDefHalt         = [][]bool{{false, true}, {true}, {true}, {false, true}, {true}, {true}}
+	attackRadius          = [][][]float64{{{1.8, 1.52}, {1.6}, {1.6}, {1.6, 1.8}, {1.68}, {2}}, {{2, 1.7}, {1.8}, {1.8}, {1.8, 2}, {1.81}, {2.4}}}
+	attackStrikeTypes     = [][]combat.StrikeType{
+		{combat.StrikeTypeSlash, combat.StrikeTypeSpear},
+		{combat.StrikeTypeSlash},
+		{combat.StrikeTypeSlash},
+		{combat.StrikeTypeSlash, combat.StrikeTypeSlash},
+		{combat.StrikeTypeSpear},
+		{combat.StrikeTypeSlash},
+	}
+)
 
 const normalHitNum = 6
 
@@ -64,10 +67,16 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
+
+		burstIndex := 0
+		if c.StatusIsActive(burstBuffKey) {
+			burstIndex = 1
+		}
+		radius := attackRadius[burstIndex][c.NormalCounter][i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/xiao/charge.go
+++ b/internal/characters/xiao/charge.go
@@ -40,7 +40,12 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmark, chargeHitmark)
+	radius := 3.0
+	if c.StatusIsActive(burstBuffKey) {
+		radius = 3.2
+	}
+
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/xiao/plunge.go
+++ b/internal/characters/xiao/plunge.go
@@ -54,6 +54,11 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 		c.plungeCollision(collisionHitmark)
 	}
 
+	highPlungeRadius := 5.0
+	if c.StatusIsActive(burstBuffKey) {
+		highPlungeRadius = 6
+	}
+
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "High Plunge",
@@ -65,7 +70,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       highplunge[c.TalentLvlAttack()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), highPlungeHitmark, highPlungeHitmark, c.c6cb())
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), highPlungeRadius), highPlungeHitmark, highPlungeHitmark, c.c6cb())
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(highPlungeFrames),
@@ -99,6 +104,11 @@ func (c *char) LowPlungeAttack(p map[string]int) action.ActionInfo {
 		c.plungeCollision(collisionHitmark)
 	}
 
+	lowPlungeRadius := 3.0
+	if c.StatusIsActive(burstBuffKey) {
+		lowPlungeRadius = 4
+	}
+
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Low Plunge",
@@ -110,7 +120,7 @@ func (c *char) LowPlungeAttack(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       lowplunge[c.TalentLvlAttack()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), lowPlungeHitmark, lowPlungeHitmark, c.c6cb())
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), lowPlungeRadius), lowPlungeHitmark, lowPlungeHitmark, c.c6cb())
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(lowPlungeFrames),
@@ -134,5 +144,5 @@ func (c *char) plungeCollision(delay int) {
 		Durability: 0,
 		Mult:       plunge[c.TalentLvlAttack()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), delay, delay)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), delay, delay)
 }

--- a/internal/characters/xiao/skill.go
+++ b/internal/characters/xiao/skill.go
@@ -47,7 +47,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       skill[c.TalentLvlSkill()],
 	}
 	snap := c.Snapshot(&ai)
-	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.Player(), 2), skillHitmark)
+	c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), skillHitmark)
 
 	// apply A4 0.25s after cast
 	c.Core.Tasks.Add(func() {

--- a/internal/characters/xingqiu/attack.go
+++ b/internal/characters/xingqiu/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{10}, {13}, {9, 19}, {17}, {18, 39}}
-var attackHitlagHaltFrames = []float64{0.03, 0.03, 0.06, 0.06, 0.1}
+var (
+	attackFrames           [][]int
+	attackHitmarks         = [][]int{{10}, {13}, {9, 19}, {17}, {18, 39}}
+	attackHitlagHaltFrames = []float64{0.03, 0.03, 0.06, 0.06, 0.1}
+	attackRadius           = [][]float64{{1.5}, {1.5}, {1.5, 1.5}, {1.12}, {1.12, 2}}
+)
 
 const normalHitNum = 5
 
@@ -52,10 +55,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		ax := ai
 		ax.Abil = fmt.Sprintf("Normal %v", c.NormalCounter)
 		ax.Mult = mult[c.TalentLvlAttack()]
+		radius := attackRadius[c.NormalCounter][i]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ax,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/xingqiu/burst.go
+++ b/internal/characters/xingqiu/burst.go
@@ -128,7 +128,7 @@ func (c *char) summonSwordWave() {
 
 	for i := 0; i < c.numSwords; i++ {
 		//TODO: this snapshot timing is off? perhaps should be 0?
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 20, 20, c2cb, c6cb)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), 20, 20, c2cb, c6cb)
 		c6cb = nil
 		c.burstCounter++
 	}

--- a/internal/characters/xingqiu/charge.go
+++ b/internal/characters/xingqiu/charge.go
@@ -33,7 +33,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 
 	for i, mult := range ca {
 		ai.Mult = mult[c.TalentLvlAttack()]
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), chargeHitmarks[i], chargeHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2.2), chargeHitmarks[i], chargeHitmarks[i])
 	}
 
 	return action.ActionInfo{

--- a/internal/characters/xingqiu/orbital.go
+++ b/internal/characters/xingqiu/orbital.go
@@ -74,6 +74,6 @@ func (c *char) orbitalTickTask(src int) func() {
 		//queue up next instance
 		c.QueueCharTask(c.orbitalTickTask(src), 135)
 
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), -1, 1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1.2), -1, 1)
 	}
 }

--- a/internal/characters/xingqiu/skill.go
+++ b/internal/characters/xingqiu/skill.go
@@ -7,8 +7,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var skillFrames []int
-var skillHitmarks = []int{12, 31}
+var (
+	skillFrames   []int
+	skillHitmarks = []int{12, 31}
+	skillRadius   = []float64{3, 2.85}
+)
 
 func init() {
 	skillFrames = frames.InitAbilSlice(67)
@@ -45,8 +48,9 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 				ax.Mult = ax.Mult * 1.5
 			}
 		}
+		radius := skillRadius[i]
 		c.QueueCharTask(func() {
-			c.Core.QueueAttack(ax, combat.NewCircleHit(c.Core.Combat.Player(), 1), 0, 0)
+			c.Core.QueueAttack(ax, combat.NewCircleHit(c.Core.Combat.Player(), radius), 0, 0)
 		}, skillHitmarks[i])
 	}
 

--- a/internal/characters/xinyan/attack.go
+++ b/internal/characters/xinyan/attack.go
@@ -9,9 +9,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = []int{25, 27, 47, 35}
-var attackHitlagHaltFrame = []float64{.1, .1, .12, .12}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = []int{25, 27, 47, 35}
+	attackHitlagHaltFrame = []float64{.1, .1, .12, .12}
+	attackRadius          = []float64{2, 1.6, 2, 2}
+)
 
 const normalHitNum = 4
 
@@ -39,9 +42,10 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter] * 60,
 		CanBeDefenseHalted: true,
 	}
+	radius := attackRadius[c.NormalCounter]
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.5),
+		combat.NewCircleHit(c.Core.Combat.Player(), radius),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter],
 	)

--- a/internal/characters/xinyan/burst.go
+++ b/internal/characters/xinyan/burst.go
@@ -49,12 +49,12 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 	// 1st DoT
 	c.QueueCharTask(func() {
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 0, 0)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), 0, 0)
 		ai.CanBeDefenseHalted = false // only the first DoT has hitlag
 		// 2nd DoT onwards
 		c.QueueCharTask(func() {
 			for i := 0; i < 6; i++ {
-				c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), i*17, i*17)
+				c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), i*17, i*17)
 			}
 		}, 17)
 	}, burstDoT1Hitmark)

--- a/internal/characters/xinyan/skill.go
+++ b/internal/characters/xinyan/skill.go
@@ -60,7 +60,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			c.updateShield(1, defFactor)
 		}, skillShieldStart)
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.5), skillHitmark, skillHitmark, cb, c.c4)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), skillHitmark, skillHitmark, cb, c.c4)
 
 	c.SetCDWithDelay(action.ActionSkill, 18*60, 13)
 	c.Core.QueueParticle("xinyan", 4, attributes.Pyro, skillHitmark+c.ParticleDelay)
@@ -96,7 +96,7 @@ func (c *char) shieldDot(src int) func() {
 			Durability: 25,
 			Mult:       skillDot[c.TalentLvlSkill()],
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 1, 1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 1, 1)
 
 		c.Core.Tasks.Add(c.shieldDot(src), 2*60)
 	}

--- a/internal/characters/yaemiko/attack.go
+++ b/internal/characters/yaemiko/attack.go
@@ -46,7 +46,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 
 	// TODO: does it snapshot?
-	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), 0, attackHitmarks[c.NormalCounter]+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4.12), 0, attackHitmarks[c.NormalCounter]+travel)
 
 	defer c.AdvanceNormalIndex()
 

--- a/internal/characters/yaemiko/burst.go
+++ b/internal/characters/yaemiko/burst.go
@@ -33,11 +33,11 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 25,
 		Mult:       burst[0][c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 7), burstHitmark, burstHitmark)
 
 	ai.Abil = "Tenko Thunderbolt"
 	ai.Mult = burst[1][c.TalentLvlBurst()]
-	c.kitsuneBurst(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5))
+	c.kitsuneBurst(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 7))
 
 	c.ConsumeEnergy(2)
 	c.SetCD(action.ActionBurst, 22*60)

--- a/internal/characters/yaemiko/charge.go
+++ b/internal/characters/yaemiko/charge.go
@@ -43,7 +43,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	// TODO: check snapshot delay
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.3),
+		combat.NewCircleHit(c.Core.Combat.Player(), 1.41),
 		0,
 		chargeHitmark-windup,
 	)

--- a/internal/characters/yaemiko/kitsune.go
+++ b/internal/characters/yaemiko/kitsune.go
@@ -142,7 +142,7 @@ func (c *char) kitsuneTick(totem *kitsune) func() {
 			c.Core.QueueParticle("yaemiko", 1, attributes.Electro, c.ParticleDelay)
 		}
 
-		c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.Enemy(c.Core.Combat.RandomEnemyTarget()).Key()), 1, 1, cb)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Enemy(c.Core.Combat.RandomEnemyTarget()), 0.5), 1, 1, cb)
 		// tick per ~2.9s seconds
 		c.Core.Tasks.Add(c.kitsuneTick(totem), 176)
 	}

--- a/internal/characters/yanfei/asc.go
+++ b/internal/characters/yanfei/asc.go
@@ -30,6 +30,7 @@ func (c *char) a4() {
 	c.Core.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
 		atk := args[1].(*combat.AttackEvent)
 		crit := args[3].(bool)
+		trg := args[0].(combat.Target)
 		if atk.Info.ActorIndex != c.Index {
 			return false
 		}
@@ -56,7 +57,7 @@ func (c *char) a4() {
 			HitlagFactor:       0.05,
 			CanBeDefenseHalted: defhalt,
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), 10, 10)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(trg, 3.5), 10, 10)
 
 		return false
 	}, "yanfei-a4")

--- a/internal/characters/yanfei/attack.go
+++ b/internal/characters/yanfei/attack.go
@@ -70,7 +70,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.75),
 		attackHitmarks[c.NormalCounter],
 		attackHitmarks[c.NormalCounter]+travel,
 		addSeal,

--- a/internal/characters/yanfei/burst.go
+++ b/internal/characters/yanfei/burst.go
@@ -71,7 +71,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, burstHitmark, addSeal)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6.5), 0, burstHitmark, addSeal)
 
 	c.Core.Tasks.Add(c.burstAddSealHook(), 60)
 

--- a/internal/characters/yanfei/charge.go
+++ b/internal/characters/yanfei/charge.go
@@ -8,7 +8,10 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/glog"
 )
 
-var chargeFrames []int
+var (
+	chargeFrames []int
+	chargeRadius = []float64{2.5, 3, 3.5, 4, 4}
+)
 
 const chargeHitmark = 63
 
@@ -50,9 +53,9 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 	if c.Core.Player.CurrentState() == action.Idle || c.Core.Player.CurrentState() == action.SwapState {
 		windup = 0
 	}
-
+	radius := chargeRadius[c.sealCount]
 	// TODO: Not sure of snapshot timing
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), chargeHitmark-windup, chargeHitmark-windup)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), radius), chargeHitmark-windup, chargeHitmark-windup)
 
 	c.Core.Log.NewEvent("yanfei charge attack consumed seals", glog.LogCharacterEvent, c.Index).
 		Write("current_seals", c.sealCount)

--- a/internal/characters/yanfei/skill.go
+++ b/internal/characters/yanfei/skill.go
@@ -51,7 +51,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       skill[c.TalentLvlSkill()],
 	}
 	// TODO: Not sure of snapshot timing
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, skillHitmark, addSeal)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3.5), 0, skillHitmark, addSeal)
 
 	c.Core.QueueParticle("yanfei", 3, attributes.Pyro, skillHitmark+c.ParticleDelay)
 

--- a/internal/characters/yelan/aimed.go
+++ b/internal/characters/yelan/aimed.go
@@ -48,7 +48,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 			Durability: 25,
 			FlatDmg:    barb[c.TalentLvlAttack()] * c.MaxHP(),
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), aimedBarbHitmark, aimedBarbHitmark+travel)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 6), aimedBarbHitmark, aimedBarbHitmark+travel)
 
 		return action.ActionInfo{
 			Frames:          frames.NewAbilFunc(aimedBarbFrames),
@@ -70,7 +70,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 		Mult:         aimed[c.TalentLvlAttack()],
 		HitWeakPoint: weakspot == 1,
 	}
-	c.Core.QueueAttack(ai, combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget), aimedHitmark, aimedHitmark+travel)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), aimedHitmark, aimedHitmark+travel)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(aimedFrames),

--- a/internal/characters/yelan/attack.go
+++ b/internal/characters/yelan/attack.go
@@ -53,7 +53,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			}
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 4),
 				attackHitmarks[c.NormalCounter][i],
 				attackHitmarks[c.NormalCounter][i]+travel,
 			)
@@ -74,7 +74,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			ai.Mult = mult[c.TalentLvlAttack()]
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 				attackHitmarks[c.NormalCounter][i],
 				attackHitmarks[c.NormalCounter][i]+travel,
 			)

--- a/internal/characters/yelan/burst.go
+++ b/internal/characters/yelan/burst.go
@@ -42,7 +42,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	//triggered on normal attack or yelan's skill
 
 	//Initial hit
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6), burstHitmark, burstHitmark)
 
 	//TODO: check if we need to add f to this
 	c.Core.Tasks.Add(func() {
@@ -83,7 +83,7 @@ func (c *char) exquisiteThrowSkillProc() {
 	}
 	for i := 0; i < 3; i++ {
 		//TODO: probably snapshots before hitmark
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), burstDiceHitmarks[i], burstDiceHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), burstDiceHitmarks[i], burstDiceHitmarks[i])
 	}
 }
 
@@ -102,14 +102,14 @@ func (c *char) summonExquisiteThrow() {
 	}
 	for i := 0; i < 3; i++ {
 		//TODO: probably snapshots before hitmark
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), burstDiceHitmarks[i], burstDiceHitmarks[i])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), burstDiceHitmarks[i], burstDiceHitmarks[i])
 	}
 	if c.Base.Cons >= 2 && c.c2icd <= c.Core.F {
 		ai.Abil = "Yelan C2 Proc"
 		ai.FlatDmg = 14.0 / 100 * c.MaxHP()
 		c.c2icd = c.Core.F + 1.8*60
 		//TODO: frames timing on this?
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), burstDiceHitmarks[3], burstDiceHitmarks[3])
+		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), burstDiceHitmarks[3], burstDiceHitmarks[3])
 	}
 
 	c.burstDiceICD = c.Core.F + 60

--- a/internal/characters/yoimiya/aimed.go
+++ b/internal/characters/yoimiya/aimed.go
@@ -79,7 +79,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 	}
 	c.Core.QueueAttack(
 		ai,
-		combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+		combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 		aimedHitmarks[kindling],
 		aimedHitmarks[kindling]+travel,
 	)
@@ -105,7 +105,7 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 			// add a bit of extra delay for kindling arrows
 			c.Core.QueueAttack(
 				ai,
-				combat.NewDefSingleTarget(c.Core.Combat.DefaultTarget),
+				combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.6),
 				aimedHitmarks[kindling],
 				aimedHitmarks[kindling]+kindling_travel,
 			)

--- a/internal/characters/yoimiya/attack.go
+++ b/internal/characters/yoimiya/attack.go
@@ -64,7 +64,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		totalMV += mult[c.TalentLvlAttack()]
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5),
 			attackHitmarks[c.NormalCounter][i],
 			attackHitmarks[c.NormalCounter][i]+travel,
 			particleCB,
@@ -87,7 +87,7 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		// TODO: frames?
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.6),
 			0,
 			attackHitmarks[c.NormalCounter][0]+travel+5,
 		)

--- a/internal/characters/yoimiya/burst.go
+++ b/internal/characters/yoimiya/burst.go
@@ -41,7 +41,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(
 		ai,
-		combat.NewCircleHit(c.Core.Combat.Player(), 5),
+		combat.NewCircleHit(c.Core.Combat.Player(), 6),
 		0,
 		burstHitmark,
 		c.applyAB, // callback to apply Aurous Blaze
@@ -130,7 +130,7 @@ func (c *char) burstHook() {
 			Durability: 25,
 			Mult:       burstExplode[c.TalentLvlBurst()],
 		}
-		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 3), 0, 1)
+		c.Core.QueueAttack(ai, combat.NewCircleHit(trg, 3), 0, 1)
 
 		trg.AddStatus(abIcdKey, 120, true) // trigger Aurous Blaze ICD
 

--- a/internal/characters/yunjin/attack.go
+++ b/internal/characters/yunjin/attack.go
@@ -9,10 +9,13 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackHitmarks = [][]int{{15}, {13}, {8, 23}, {11, 23}, {15}}
-var attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0, 0.03}, {0, 0.03}, {0.04}}
-var attackDefHalt = [][]bool{{true}, {true}, {false, true}, {false, false}, {true}}
+var (
+	attackFrames          [][]int
+	attackHitmarks        = [][]int{{15}, {13}, {8, 23}, {11, 23}, {15}}
+	attackHitlagHaltFrame = [][]float64{{0.03}, {0.03}, {0, 0.03}, {0, 0.03}, {0.04}}
+	attackDefHalt         = [][]bool{{true}, {true}, {false, true}, {false, false}, {true}}
+	attackRadius          = []float64{2, 2, 2, 1.89, 2.4}
+)
 
 const normalHitNum = 5
 
@@ -53,10 +56,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 			HitlagHaltFrames:   attackHitlagHaltFrame[c.NormalCounter][i] * 60,
 			CanBeDefenseHalted: attackDefHalt[c.NormalCounter][i],
 		}
+		radius := attackRadius[c.NormalCounter]
 		c.QueueCharTask(func() {
 			c.Core.QueueAttack(
 				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+				combat.NewCircleHit(c.Core.Combat.Player(), radius),
 				0,
 				0,
 			)

--- a/internal/characters/yunjin/burst.go
+++ b/internal/characters/yunjin/burst.go
@@ -37,7 +37,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Durability: 50,
 		Mult:       burstDmg[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 6), burstHitmark, burstHitmark)
 
 	// Reset number of burst triggers to 30
 	for _, char := range c.Core.Player.Chars() {

--- a/internal/characters/yunjin/charge.go
+++ b/internal/characters/yunjin/charge.go
@@ -37,7 +37,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 		IsDeployable:       true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/yunjin/skill.go
+++ b/internal/characters/yunjin/skill.go
@@ -69,6 +69,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 
 	// Particle should spawn after hit
 	hitDelay := skillHitmarks[animIdx]
+	radius := 4.0
 	switch chargeLevel {
 	case 0:
 		ai.HitlagHaltFrames = 0.06 * 60
@@ -82,14 +83,16 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		}
 		ai.Abil = "Opening Flourish Level 1 (E)"
 		ai.HitlagHaltFrames = 0.09 * 60
+		radius = 6
 	case 2:
 		c.Core.QueueParticle("yunjin", 3, attributes.Geo, c.ParticleDelay+hitDelay)
 		ai.Durability = 100
 		ai.Abil = "Opening Flourish Level 2 (E)"
 		ai.HitlagHaltFrames = 0.12 * 60
+		radius = 8
 	}
 
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 1), hitDelay, hitDelay)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), radius), hitDelay, hitDelay)
 
 	// Add shield until skill unleashed (treated as frame when attack hits)
 	c.Core.Player.Shields.Add(&shield.Tmpl{

--- a/internal/characters/zhongli/attack.go
+++ b/internal/characters/zhongli/attack.go
@@ -9,11 +9,14 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 )
 
-var attackFrames [][]int
-var attackEarliestCancel = []int{11, 9, 8, 16, 4, 29}
-var attackHitmarks = [][]int{{11}, {9}, {8}, {16}, {11, 18, 23, 29}, {29}}
-var attackHitlagHaltFrame = [][]float64{{0.02}, {0.02}, {0.02}, {0.02}, {0, 0, 0, 0}, {0.02}}
-var attackDefHalt = [][]bool{{true}, {true}, {true}, {true}, {false, false, false, false}, {true}}
+var (
+	attackFrames          [][]int
+	attackEarliestCancel  = []int{11, 9, 8, 16, 4, 29}
+	attackHitmarks        = [][]int{{11}, {9}, {8}, {16}, {11, 18, 23, 29}, {29}}
+	attackHitlagHaltFrame = [][]float64{{0.02}, {0.02}, {0.02}, {0.02}, {0, 0, 0, 0}, {0.02}}
+	attackDefHalt         = [][]bool{{true}, {true}, {true}, {true}, {false, false, false, false}, {true}}
+	attackRadius          = []float64{2.04, 2, 0.9, 1.7, 2.06, 2.06}
+)
 
 const normalHitNum = 6
 
@@ -64,10 +67,11 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 		if c.NormalCounter == 1 || c.NormalCounter == 4 {
 			ai.StrikeType = combat.StrikeTypeSlash
 		}
+		radius := attackRadius[c.NormalCounter]
 		//the multihit part generates no hitlag so this is fine
 		c.Core.QueueAttack(
 			ai,
-			combat.NewCircleHit(c.Core.Combat.Player(), 0.1),
+			combat.NewCircleHit(c.Core.Combat.Player(), radius),
 			attackHitmarks[c.NormalCounter][i],
 			attackHitmarks[c.NormalCounter][i],
 		)

--- a/internal/characters/zhongli/burst.go
+++ b/internal/characters/zhongli/burst.go
@@ -32,7 +32,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		Mult:       burst[c.TalentLvlBurst()],
 		FlatDmg:    0.33 * c.MaxHP(),
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 5), burstHitmark, burstHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 7.5), burstHitmark, burstHitmark)
 
 	if c.Base.Cons >= 2 {
 		c.addJadeShield()

--- a/internal/characters/zhongli/charge.go
+++ b/internal/characters/zhongli/charge.go
@@ -37,7 +37,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		CanBeDefenseHalted: true,
 		IsDeployable:       true,
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 0.1), chargeHitmark, chargeHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.8), chargeHitmark, chargeHitmark)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(chargeFrames),

--- a/internal/characters/zhongli/skill.go
+++ b/internal/characters/zhongli/skill.go
@@ -71,7 +71,7 @@ func (c *char) skillHold(max int, createStele bool) action.ActionInfo {
 		Mult:       skillHold[c.TalentLvlSkill()],
 		FlatDmg:    0.019 * c.MaxHP(),
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 2), 0, skillHoldHitmark)
+	c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 10), 0, skillHoldHitmark)
 
 	//create a stele if less than zhongli's max stele count and desired by player
 	if (c.steleCount < c.maxStele) && createStele {

--- a/internal/characters/zhongli/stele.go
+++ b/internal/characters/zhongli/stele.go
@@ -63,7 +63,7 @@ func (c *char) newStele(dur int, max int) {
 	c.steleSnapshot = combat.AttackEvent{
 		Info:        aiSnap,
 		Snapshot:    snap,
-		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 1),
+		Pattern:     combat.NewCircleHit(c.Core.Combat.Player(), 5.66),
 		SourceFrame: c.Core.F,
 	}
 

--- a/internal/weapons/bow/skyward/skyward.go
+++ b/internal/weapons/bow/skyward/skyward.go
@@ -77,7 +77,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			Durability: 100,
 			Mult:       1.25,
 		}
-		c.QueueAttack(ai, combat.NewCircleHit(trg, 2), 0, 1)
+		c.QueueAttack(ai, combat.NewCircleHit(trg, 3), 0, 1)
 
 		char.AddStatus(icdKey, cd, true)
 

--- a/internal/weapons/bow/viridescent/viridescent.go
+++ b/internal/weapons/bow/viridescent/viridescent.go
@@ -80,7 +80,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		char.AddStatus(icdKey, cd, true)
 
 		return false
-	}, fmt.Sprintf("veridescent-%v", char.Base.Key.String()))
+	}, fmt.Sprintf("viridescent-%v", char.Base.Key.String()))
 
 	return w, nil
 }

--- a/internal/weapons/catalyst/perception/perception.go
+++ b/internal/weapons/catalyst/perception/perception.go
@@ -58,7 +58,7 @@ func (w *Weapon) chain(count int, c *core.Core, char *character.CharWrapper) fun
 		}
 
 		cb := w.chain(count+1, c, char)
-		c.QueueAttackWithSnap(w.ai, w.snap, combat.NewDefSingleTarget(c.Combat.Enemy(next).Key()), 10, cb)
+		c.QueueAttackWithSnap(w.ai, w.snap, combat.NewCircleHit(c.Combat.Enemy(next), 0.6), 10, cb)
 	}
 }
 

--- a/internal/weapons/claymore/prototype/prototype.go
+++ b/internal/weapons/claymore/prototype/prototype.go
@@ -58,7 +58,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 				Mult:       atk,
 			}
 			trg := args[0].(combat.Target)
-			c.QueueAttack(ai, combat.NewCircleHit(trg, .6), 0, 1)
+			c.QueueAttack(ai, combat.NewCircleHit(trg, 3), 0, 1)
 		}
 		return false
 	}, fmt.Sprintf("forstbearer-%v", char.Base.Key.String()))

--- a/internal/weapons/claymore/sealord/sealord.go
+++ b/internal/weapons/claymore/sealord/sealord.go
@@ -74,7 +74,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			Mult:       tunaDmg,
 		}
 		trg := args[0].(combat.Target)
-		c.QueueAttack(ai, combat.NewCircleHit(trg, 1), 0, 1)
+		c.QueueAttack(ai, combat.NewCircleHit(trg, 3), 0, 1)
 
 		return false
 	}, fmt.Sprintf("sealord-%v", char.Base.Key.String()))

--- a/internal/weapons/claymore/skyward/skyward.go
+++ b/internal/weapons/claymore/skyward/skyward.go
@@ -83,7 +83,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			Mult:       dmg,
 		}
 		trg := args[0].(combat.Target)
-		c.QueueAttack(ai, combat.NewCircleHit(trg, 1), 0, 1)
+		c.QueueAttack(ai, combat.NewCircleHit(trg, 0.07), 0, 1)
 		return false
 	}, fmt.Sprintf("skyward-pride-%v", char.Base.Key.String()))
 	return w, nil

--- a/internal/weapons/claymore/starsilver/starsilver.go
+++ b/internal/weapons/claymore/starsilver/starsilver.go
@@ -68,7 +68,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			if t.AuraContains(attributes.Cryo, attributes.Frozen) {
 				ai.Mult = mc
 			}
-			c.QueueAttack(ai, combat.NewCircleHit(t, 1), 0, 1)
+			c.QueueAttack(ai, combat.NewCircleHit(t, 3), 0, 1)
 
 		}
 		return false

--- a/internal/weapons/spear/crescent/crescent.go
+++ b/internal/weapons/spear/crescent/crescent.go
@@ -68,7 +68,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 				Mult:       atk,
 			}
 			trg := args[0].(combat.Target)
-			c.QueueAttack(ai, combat.NewCircleHit(trg, 0.1), 0, 1)
+			c.QueueAttack(ai, combat.NewDefSingleTarget(trg.Key()), 0, 1)
 		}
 		return false
 	}, fmt.Sprintf("cpp-%v", char.Base.Key.String()))

--- a/internal/weapons/spear/dragonspine/dragonspine.go
+++ b/internal/weapons/spear/dragonspine/dragonspine.go
@@ -69,7 +69,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			if t.AuraContains(attributes.Cryo, attributes.Frozen) {
 				ai.Mult = atkc
 			}
-			c.QueueAttack(ai, combat.NewCircleHit(t, 2), 0, 1)
+			c.QueueAttack(ai, combat.NewCircleHit(t, 3), 0, 1)
 		}
 		return false
 	}, fmt.Sprintf("dragonspine-%v", char.Base.Key.String()))

--- a/internal/weapons/spear/halberd/halberd.go
+++ b/internal/weapons/spear/halberd/halberd.go
@@ -54,7 +54,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		ai := combat.AttackInfo{
 			ActorIndex: char.Index,
 			Abil:       "Halberd Proc",
-			AttackTag:  combat.AttackTagWeaponSkill,
+			AttackTag:  combat.AttackTagNone,
 			ICDTag:     combat.ICDTagNone,
 			ICDGroup:   combat.ICDGroupDefault,
 			StrikeType: combat.StrikeTypeDefault,

--- a/internal/weapons/spear/skyward/skyward.go
+++ b/internal/weapons/spear/skyward/skyward.go
@@ -79,7 +79,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			Mult:       atk,
 		}
 		trg := args[0].(combat.Target)
-		c.QueueAttack(ai, combat.NewCircleHit(trg, 0.1), 0, 1)
+		c.QueueAttack(ai, combat.NewCircleHit(trg, 0.07), 0, 1)
 
 		//trigger cd
 		char.AddStatus(icdKey, 120, true)

--- a/internal/weapons/sword/aquila/aquila.go
+++ b/internal/weapons/sword/aquila/aquila.go
@@ -37,7 +37,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.ATKP] = .15 + .05*float64(r)
 	char.AddStatMod(character.StatMod{
-		Base:         modifier.NewBase("acquila favonia", -1),
+		Base:         modifier.NewBase("aquila favonia", -1),
 		AffectedStat: attributes.NoStat,
 		Amount: func() ([]float64, bool) {
 			return m, true
@@ -75,7 +75,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			Mult:       dmg,
 		}
 		snap := char.Snapshot(&ai)
-		c.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Combat.Player(), 2), 1)
+		c.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Combat.Player(), 6), 1)
 
 		atk := snap.BaseAtk*(1+snap.Stats[attributes.ATKP]) + snap.Stats[attributes.ATK]
 

--- a/internal/weapons/sword/filletblade/filletblade.go
+++ b/internal/weapons/sword/filletblade/filletblade.go
@@ -65,7 +65,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			Mult:       2.0 + 0.4*float64(r),
 		}
 		trg := args[0].(combat.Target)
-		c.QueueAttack(ai, combat.NewCircleHit(trg, 0.1), 0, 1)
+		c.QueueAttack(ai, combat.NewDefSingleTarget(trg.Key()), 0, 1)
 
 		// trigger cd
 		char.AddStatus(icdKey, cd, true)

--- a/internal/weapons/sword/flute/flute.go
+++ b/internal/weapons/sword/flute/flute.go
@@ -76,7 +76,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 				Mult:       0.75 + 0.25*float64(r),
 			}
 			trg := args[0].(combat.Target)
-			c.QueueAttack(ai, combat.NewCircleHit(trg, 2), 0, 1)
+			c.QueueAttack(ai, combat.NewCircleHit(trg, 4), 0, 1)
 
 		}
 		return false

--- a/internal/weapons/sword/kagotsurubeisshin/kagotsurubeisshin.go
+++ b/internal/weapons/sword/kagotsurubeisshin/kagotsurubeisshin.go
@@ -72,7 +72,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			Mult:       1.8,
 		}
 		trg := args[0].(combat.Target)
-		c.QueueAttack(ai, combat.NewCircleHit(trg, 1), 0, 1)
+		c.QueueAttack(ai, combat.NewCircleHit(trg, 3), 0, 1)
 
 		// trigger cd
 		char.AddStatus(icdKey, cd, true)

--- a/internal/weapons/sword/skyward/skyward.go
+++ b/internal/weapons/sword/skyward/skyward.go
@@ -95,7 +95,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 			Mult:       dmgper,
 		}
 		trg := args[0].(combat.Target)
-		c.QueueAttack(ai, combat.NewCircleHit(trg, 0.1), 0, 1)
+		c.QueueAttack(ai, combat.NewDefSingleTarget(trg.Key()), 0, 1)
 		return false
 
 	}, fmt.Sprintf("skyward-blade-%v", char.Base.Key.String()))

--- a/internal/weapons/sword/swordofdescension/swordofdescension.go
+++ b/internal/weapons/sword/swordofdescension/swordofdescension.go
@@ -94,7 +94,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 				Mult:       2.00,
 			}
 			trg := args[0].(combat.Target)
-			c.QueueAttack(ai, combat.NewCircleHit(trg, 2), 0, 1)
+			c.QueueAttack(ai, combat.NewCircleHit(trg, 1.5), 0, 1)
 
 			return false
 		}, fmt.Sprintf("swordofdescension-%v", char.Base.Key.String()))


### PR DESCRIPTION
changes every attack to better match their intended hitbox if not already (#611). hits that are boxes are approximated using `sqrt(x^2 + z^2)/2`. 

todo before merge:
- [x] itto CA, skipped it for now
- [x] barbara N4, radius unknown
- [x] cyno CA in Q, radius unknown
- [x] lisa CA, radius unknown (?)
- [x] lisa Q, skipped it for now
- [x] lisa hold E (lightning strikes appear to have radius 0.2)
- [x] guoba, radius unknown
- [x] yanfei CA, radius unknown
- [x] yoimiya Q should center on marked target not primary target
- [x] move radii slices out of task function calls
- [x] clean up commits

issues that may be out of scope for this PR:
- yae totem targeting logic, currently won't hit gadgets, supposedly same priority as enemies
- ayato and ganyu Q targeting logic
- amber Q targeting logic
- collei Q targeting logic
- aloy and klee mine placement logic