### PR TITLE
fix reactBonus

### DIFF
--- a/pkg/enemy/damage.go
+++ b/pkg/enemy/damage.go
@@ -86,10 +86,9 @@ func (t *Enemy) calc(atk *combat.AttackEvent, evt glog.Event) (float64, bool) {
 	//calculate em bonus
 	em := atk.Snapshot.Stats[attributes.EM]
 	emBonus := (2.78 * em) / (1400 + em)
-	var reactBonus float64
+	reactBonus := t.Core.Player.ByIndex(atk.Info.ActorIndex).ReactBonus(atk.Info)
 	//check melt/vape
 	if atk.Info.Amped {
-		reactBonus = t.Core.Player.ByIndex(atk.Info.ActorIndex).ReactBonus(atk.Info)
 		// t.Core.Log.Debugw("debug", "frame", t.Core.F, core.LogPreDamageMod, "char", t.Index, "char_react", char.CharIndex(), "reactbonus", char.ReactBonus(atk.Info), "damage_pre", damage)
 		damage = damage * (atk.Info.AmpMult * (1 + emBonus + reactBonus))
 	}


### PR DESCRIPTION
for many reactions the reaction bonus is not displayed.
for example: https://gcsim.app/v3/viewer/share/8818ff23-055f-4669-9943-cf3a9c7afdfb (491 frame)
![image](https://user-images.githubusercontent.com/35897995/206446409-85b055e3-faf4-4633-8def-15d1df33c240.png)
with fix:
![image](https://user-images.githubusercontent.com/35897995/206446452-d1a81f7b-196a-46cc-ba37-9dbeaa3952ea.png)

