### PR TITLE
fix kuki e stacking infinitely due to missing src check

### DIFF
--- a/internal/characters/kuki/cons.go
+++ b/internal/characters/kuki/cons.go
@@ -33,7 +33,7 @@ func (c *char) c4() {
 		if ae.Info.ActorIndex != c.Core.Player.Active() {
 			return false
 		}
-		if c.Core.Status.Duration("kuki-e") == 0 {
+		if c.Core.Status.Duration(ringKey) == 0 {
 			return false
 		}
 		c.AddStatus(c4IcdKey, 300, true) // 5s * 60

--- a/internal/characters/kuki/kuki.go
+++ b/internal/characters/kuki/kuki.go
@@ -14,7 +14,7 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	bellActiveUntil int
+	ringSrc int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {

--- a/internal/characters/kuki/skill.go
+++ b/internal/characters/kuki/skill.go
@@ -14,6 +14,7 @@ var skillFrames []int
 const (
 	skillHitmark     = 11 // Initial Hit
 	hpDrainThreshold = 0.2
+	ringKey          = "kuki-e"
 )
 
 func init() {
@@ -59,16 +60,16 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		skilldur = 900 //12+3s
 	}
 
-	// this gets executed before kuki can expierence hitlag so no need for char queue
+	// this gets executed before kuki can experience hitlag so no need for char queue
 	// ring duration starts after hitmark
 	c.Core.Tasks.Add(func() {
 		// E duration and ticks are not affected by hitlag
-		c.Core.Status.Add("kuki-e", skilldur)
-		c.Core.Tasks.Add(c.bellTick(), 90) // Assuming this executes every 90 frames = 1.5s
-		c.bellActiveUntil = c.Core.F + skilldur
+		c.Core.Status.Add(ringKey, skilldur)
+		c.ringSrc = c.Core.F
+		c.Core.Tasks.Add(c.bellTick(c.Core.F), 90) // Assuming this executes every 90 frames = 1.5s
 		c.Core.Log.NewEvent("Bell activated", glog.LogCharacterEvent, c.Index).
-			Write("expected end", c.bellActiveUntil).
-			Write("next expected tick", c.Core.F+90)
+			Write("next expected tick", c.Core.F+90).
+			Write("expected end", c.Core.F+skilldur)
 	}, 23)
 
 	c.SetCDWithDelay(action.ActionSkill, 15*60, 7)
@@ -81,8 +82,14 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 }
 
-func (c *char) bellTick() func() {
+func (c *char) bellTick(src int) func() {
 	return func() {
+		if src != c.ringSrc {
+			return
+		}
+		if c.Core.Status.Duration(ringKey) == 0 {
+			return
+		}
 		c.Core.Log.NewEvent("Bell ticking", glog.LogCharacterEvent, c.Index)
 
 		ai := combat.AttackInfo{
@@ -97,6 +104,8 @@ func (c *char) bellTick() func() {
 			Mult:       skilldot[c.TalentLvlSkill()],
 			FlatDmg:    c.Stat(attributes.EM) * 0.25,
 		}
+		//trigger damage
+		//TODO: Check for snapshots
 		c.Core.QueueAttack(ai, combat.NewCircleHit(c.Core.Combat.Player(), 4), 2, 2)
 
 		//A4 is considered here
@@ -108,22 +117,12 @@ func (c *char) bellTick() func() {
 			Bonus:   c.Stat(attributes.Heal),
 		})
 
-		c.Core.Log.NewEvent("Bell ticked", glog.LogCharacterEvent, c.Index).
-			Write("next expected tick", c.Core.F+90).
-			Write("active", c.bellActiveUntil)
-		//trigger damage
-		//TODO: Check for snapshots
-
-		//c.Core.QueueAttackEvent(&ae, 0)
 		//check for orb
 		//Particle check is 45% for particle
 		if c.Core.Rand.Float64() < .45 {
 			c.Core.QueueParticle("kuki", 1, attributes.Electro, c.ParticleDelay) // TODO: idk the particle timing yet fml (or probability)
 		}
 
-		//queue up next hit only if next hit bell is still active
-		if c.Core.F+90 <= c.bellActiveUntil {
-			c.Core.Tasks.Add(c.bellTick(), 90)
-		}
+		c.Core.Tasks.Add(c.bellTick(src), 90)
 	}
 }


### PR DESCRIPTION
closes #1138 
only affects teams where Kuki gets CD reduction (4 tf, sac sword, c2 chongyun, anemo resonance, ...) and you cast her E again before it's supposed to be over originally 
fix tested here: https://gcsim.app/v3/viewer/share/998b8750-1e60-44b9-be73-fa697a637c89