### PR TITLE
Made Ganyu C1 a call back and fixed doubled energy gain

### DIFF
--- a/cmd/gcsim/optimise.bat
+++ b/cmd/gcsim/optimise.bat
@@ -1,0 +1,8 @@
+set argument="%2"
+
+set filename=%~1
+set output=%filename:txt=json%
+
+"gcsim.exe" -c="%cd%/config/%filename%" -substatOptim=true -out="%cd%/optimized_config/%filename%" %argument% || exit /b %errorlevel%
+
+"gcsim.exe" -c="%cd%/optimized_config/%filename%" -out="%cd%/viewer_gz/%output%" -gz="true" %argument%

--- a/cmd/gcsim/run.bat
+++ b/cmd/gcsim/run.bat
@@ -1,0 +1,6 @@
+set argument="%2"
+
+set filename=%~1
+set output=%filename:txt=json%
+
+"gcsim.exe" -c="%cd%/config/%filename%" -out="%cd%/viewer_gz/%output%" -gz="true" %argument%

--- a/internal/characters/ganyu/aimed.go
+++ b/internal/characters/ganyu/aimed.go
@@ -70,7 +70,6 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 
 		}
 
-<<<<<<< HEAD
 		c.Core.QueueAttackWithSnap(
 			ai,
 			snap,
@@ -82,25 +81,20 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 				1,
 			),
 			travel,
+			c.c1(),
 		)
-=======
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), travel, c.c1())
->>>>>>> d0a86232 (switched ganyu C1 to a callback and fixed doubled energy gain from it)
 
 		ai.Abil = "Frost Flake Bloom"
 		ai.Mult = ffb[c.TalentLvlAttack()]
 		ai.HitWeakPoint = false
-<<<<<<< HEAD
 		c.Core.QueueAttackWithSnap(
 			ai,
 			snap,
 			combat.NewCircleHitOnTarget(c.Core.Combat.PrimaryTarget(), nil, 5),
 			travel+bloom,
+			c.c1(),
 		)
-
-=======
-		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5), travel+bloom, c.c1())
->>>>>>> d0a86232 (switched ganyu C1 to a callback and fixed doubled energy gain from it)
+		
 		// first shot/bloom do not benefit from a1
 		c.a1Expiry = c.Core.F + 60*5
 	}, aimedHitmark-skip)

--- a/internal/characters/ganyu/aimed.go
+++ b/internal/characters/ganyu/aimed.go
@@ -67,8 +67,10 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 				Write("old", old).
 				Write("new", snap.Stats[attributes.CR]).
 				Write("expiry", c.a1Expiry)
+
 		}
 
+<<<<<<< HEAD
 		c.Core.QueueAttackWithSnap(
 			ai,
 			snap,
@@ -81,10 +83,14 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 			),
 			travel,
 		)
+=======
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 0.5), travel, c.c1())
+>>>>>>> d0a86232 (switched ganyu C1 to a callback and fixed doubled energy gain from it)
 
 		ai.Abil = "Frost Flake Bloom"
 		ai.Mult = ffb[c.TalentLvlAttack()]
 		ai.HitWeakPoint = false
+<<<<<<< HEAD
 		c.Core.QueueAttackWithSnap(
 			ai,
 			snap,
@@ -92,6 +98,9 @@ func (c *char) Aimed(p map[string]int) action.ActionInfo {
 			travel+bloom,
 		)
 
+=======
+		c.Core.QueueAttackWithSnap(ai, snap, combat.NewCircleHit(c.Core.Combat.PrimaryTarget(), 5), travel+bloom, c.c1())
+>>>>>>> d0a86232 (switched ganyu C1 to a callback and fixed doubled energy gain from it)
 		// first shot/bloom do not benefit from a1
 		c.a1Expiry = c.Core.F + 60*5
 	}, aimedHitmark-skip)

--- a/internal/characters/ganyu/cons.go
+++ b/internal/characters/ganyu/cons.go
@@ -3,7 +3,7 @@ package ganyu
 import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/enemy"
 	"github.com/genshinsim/gcsim/pkg/modifier"
@@ -13,15 +13,16 @@ const (
 	c1Key = "ganyu-c1"
 	c4Key = "ganyu-c4"
 	c6Key = "ganyu-c6"
+	c1ICD = "ganyu-c1-energy-icd"
 )
 
-func (c *char) c1() {
-	c.Core.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
-		atk := args[1].(*combat.AttackEvent)
-		e, ok := args[0].(*enemy.Enemy)
-		if !ok {
-			return false
+func (c *char) c1() combat.AttackCBFunc {
+	return func(a combat.AttackCB) {
+		e:= a.Target.(*enemy.Enemy)
+		if e.Type() != combat.TargettableEnemy {
+			return
 		}
+<<<<<<< HEAD
 		if atk.Info.ActorIndex != c.Index {
 			return false
 		}
@@ -30,14 +31,20 @@ func (c *char) c1() {
 		}
 
 		c.AddEnergy(c1Key, 2)
+=======
+>>>>>>> d0a86232 (switched ganyu C1 to a callback and fixed doubled energy gain from it)
 		e.AddResistMod(enemy.ResistMod{
-			Base:  modifier.NewBase(c1Key, 5*60),
+			Base:  modifier.NewBaseWithHitlag("ganyu-c1", 300),
 			Ele:   attributes.Cryo,
 			Value: -0.15,
 		})
-
-		return false
-	}, c1Key)
+		if !c.StatusIsActive(c1ICD) {
+			c.AddEnergy(c1Key, 2)
+			c.AddStatus(c1ICD, 24, false)
+		}
+		c.Core.Log.NewEvent("Rosaria A1 activation", glog.LogCharacterEvent, c.Index).
+			Write("ends_on", c.Core.F+300)
+	}
 }
 
 func (c *char) c4() {

--- a/internal/characters/ganyu/cons.go
+++ b/internal/characters/ganyu/cons.go
@@ -24,17 +24,6 @@ func (c *char) c1() combat.AttackCBFunc {
 		if e.Type() != combat.TargettableEnemy {
 			return
 		}
-<<<<<<< HEAD
-		if atk.Info.ActorIndex != c.Index {
-			return false
-		}
-		if !(atk.Info.Abil == "Frost Flake Arrow" || atk.Info.Abil == "Frost Flake Bloom") {
-			return false
-		}
-
-		c.AddEnergy(c1Key, 2)
-=======
->>>>>>> d0a86232 (switched ganyu C1 to a callback and fixed doubled energy gain from it)
 		e.AddResistMod(enemy.ResistMod{
 			Base:  modifier.NewBaseWithHitlag("ganyu-c1", 300),
 			Ele:   attributes.Cryo,

--- a/internal/characters/ganyu/cons.go
+++ b/internal/characters/ganyu/cons.go
@@ -16,6 +16,8 @@ const (
 	c1ICD = "ganyu-c1-energy-icd"
 )
 
+//Ganyu C1: Taking DMG from a Charge Level 2 Frostflake Arrow or Frostflake Arrow Bloom decreases opponents' Cryo RES by 15% for 6s.
+//A hit regenerates 2 Energy for Ganyu. This effect can only occur once per Charge Level 2 Frostflake Arrow, regardless if Frostflake Arrow itself or its Bloom hit the target.
 func (c *char) c1() combat.AttackCBFunc {
 	return func(a combat.AttackCB) {
 		e:= a.Target.(*enemy.Enemy)
@@ -38,6 +40,7 @@ func (c *char) c1() combat.AttackCBFunc {
 			Ele:   attributes.Cryo,
 			Value: -0.15,
 		})
+		//Uses ICD to simulate per arrow. 25f has it be restored on the same frame that the bloom hits. There should be no practical way to circumvent this
 		if !c.StatusIsActive(c1ICD) {
 			c.AddEnergy(c1Key, 2)
 			c.AddStatus(c1ICD, 24, false)


### PR DESCRIPTION
Made Ganyu C1 a callback.

In addition, the bug where her C1 restored energy on every CA hit is fixed. This currently uses a status with a 25f delay to prevent energy gain. This should work for all practical scenarios outside of travel time shenanigans. 