### PR TITLE
Fixed direction set to work when no enemies

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -127,15 +127,17 @@ func (t *Target) SetDirection(trg combat.Point) {
 }
 func (t *Target) SetDirectionToClosestEnemy() {
 	src := t.Pos()
-	// calculate direction towards closest enemy
-	enemyIndex := t.Core.Combat.EnemyByDistance(src, combat.InvalidTargetKey)[0]
-	enemy := t.Core.Combat.Enemy(enemyIndex)
-	if enemy == nil {
-		panic("there should be an enemy to calculate direction")
+	// calculate direction towards closest enemy, or forward direction if none
+	enemies := t.Core.Combat.EnemyByDistance(src, combat.InvalidTargetKey)
+	if len(enemies) == 0 {
+		t.direction = combat.DefaultDirection()
+		return
 	}
+
+	enemy := t.Core.Combat.Enemy(enemies[0])
 	t.SetDirection(enemy.Pos())
 	t.Core.Combat.Log.NewEvent("set target direction to closest enemy", glog.LogDebugEvent, -1).
-		Write("enemy index", enemyIndex).
+		Write("enemy index", enemies[0]).
 		Write("enemy key", enemy.Key()).
 		Write("direction", t.direction)
 }


### PR DESCRIPTION
Will set target direction to the `DefaultDirection` when there are no enemies left in the simulation (no living enemies).