### PR TITLE
Readjusted rect calcs to use true center

### DIFF
--- a/pkg/core/combat/rectangle.go
+++ b/pkg/core/combat/rectangle.go
@@ -71,7 +71,7 @@ func calcRectangleAABB(corners []Point) []Point {
 }
 
 func (r *Rectangle) Pos() Point {
-	return r.center
+	return r.spawn
 }
 
 func (r *Rectangle) SetPos(p Point) {


### PR DESCRIPTION
Fixes rect-circle collision bugs by making `center` be the true center of the rectangle. Added `spawn` struct to keep track of position for position resets