### PR TITLE
fix constructs and zhongli stele

### DIFF
--- a/internal/characters/zhongli/stele.go
+++ b/internal/characters/zhongli/stele.go
@@ -132,24 +132,18 @@ func (c *char) resonance(src int) func() {
 }
 
 func (c *char) steleEnergyCB() combat.AttackCBFunc {
-	done := false
 	return func(a combat.AttackCB) {
 		if a.Target.Type() != combat.TargettableEnemy {
 			return
 		}
-		// can only proc once per skill cast / stele tick
-		if done {
-			return
-		}
-		done = true
 		if c.StatusIsActive(particleICDKey) {
 			return
 		}
+		c.AddStatus(particleICDKey, 90, true)
 		// 50% chance
 		if c.Core.Rand.Float64() > 0.5 {
 			return
 		}
-		c.AddStatus(particleICDKey, 90, true)
 		c.Core.QueueParticle("zhongli", 1, attributes.Geo, 20+c.ParticleDelay)
 	}
 }

--- a/internal/characters/zhongli/stele.go
+++ b/internal/characters/zhongli/stele.go
@@ -7,6 +7,8 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/glog"
 )
 
+const particleICDKey = "zhongli-particle-icd"
+
 func (c *char) newStele(dur int) {
 	//deal damage when created
 	ai := combat.AttackInfo{
@@ -23,7 +25,7 @@ func (c *char) newStele(dur int) {
 	}
 	steleDir := c.Core.Combat.Player().Direction()
 	stelePos := combat.CalcOffsetPoint(c.Core.Combat.Player().Pos(), combat.Point{Y: 3}, steleDir)
-	c.Core.QueueAttack(ai, combat.NewCircleHitOnTarget(stelePos, nil, 2), 0, 0)
+	c.Core.QueueAttack(ai, combat.NewCircleHitOnTarget(stelePos, nil, 2), 0, 0, c.steleEnergyCB())
 
 	//create a construct
 	con := &stoneStele{
@@ -97,8 +99,12 @@ func (c *char) resonance(src int) func() {
 
 		steles, others := c.Core.Constructs.ConstructsByType(construct.GeoConstructZhongliSkill)
 
-		orb := false
+		particleCB := c.steleEnergyCB()
 		for _, s := range steles {
+			// skip other stele
+			if s.Key() != src {
+				continue
+			}
 			steleDir := s.Direction()
 			stelePos := s.Pos()
 
@@ -113,23 +119,37 @@ func (c *char) resonance(src int) func() {
 
 			// queue stele attack
 			steleAttackPos := combat.CalcOffsetPoint(stelePos, boxOffset, steleDir)
-			c.Core.QueueAttackWithSnap(ai, snap, combat.NewBoxHitOnTarget(steleAttackPos, nil, boxSize, boxSize), 0)
+			c.Core.QueueAttackWithSnap(ai, snap, combat.NewBoxHitOnTarget(steleAttackPos, nil, boxSize, boxSize), 0, particleCB)
 
 			// queue resonance attacks
 			for _, con := range resonanceConstructs {
 				resonanceAttackPos := combat.CalcOffsetPoint(con.Pos(), boxOffset, con.Direction())
-				c.Core.QueueAttackWithSnap(ai, snap, combat.NewBoxHitOnTarget(resonanceAttackPos, nil, boxSize, boxSize), 0)
+				c.Core.QueueAttackWithSnap(ai, snap, combat.NewBoxHitOnTarget(resonanceAttackPos, nil, boxSize, boxSize), 0, particleCB)
 			}
-
-			// particle check
-			if c.energyICD < c.Core.F && !orb && c.Core.Rand.Float64() < .5 {
-				orb = true
-			}
-		}
-		if orb {
-			c.energyICD = c.Core.F + 90
-			c.Core.QueueParticle("zhongli", 1, attributes.Geo, 20+c.ParticleDelay)
 		}
 		c.Core.Tasks.Add(c.resonance(src), 120)
+	}
+}
+
+func (c *char) steleEnergyCB() combat.AttackCBFunc {
+	done := false
+	return func(a combat.AttackCB) {
+		if a.Target.Type() != combat.TargettableEnemy {
+			return
+		}
+		// can only proc once per skill cast / stele tick
+		if done {
+			return
+		}
+		done = true
+		if c.StatusIsActive(particleICDKey) {
+			return
+		}
+		// 50% chance
+		if c.Core.Rand.Float64() > 0.5 {
+			return
+		}
+		c.AddStatus(particleICDKey, 90, true)
+		c.Core.QueueParticle("zhongli", 1, attributes.Geo, 20+c.ParticleDelay)
 	}
 }

--- a/internal/characters/zhongli/zhongli.go
+++ b/internal/characters/zhongli/zhongli.go
@@ -18,10 +18,9 @@ type char struct {
 	steleSnapshot combat.AttackEvent
 	maxStele      int
 	steleCount    int
-	energyICD     int
 }
 
-//TODO: need to clean up zhongli code still
+// TODO: need to clean up zhongli code still
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
 	c := char{}
 	c.Character = tmpl.NewWithWrapper(s, w)

--- a/pkg/core/construct/handler.go
+++ b/pkg/core/construct/handler.go
@@ -47,6 +47,7 @@ func (h *Handler) NewConstruct(c Construct, refresh bool, constructs *[]Construc
 		(*constructs)[ind].OnDestruct()
 		(*constructs)[ind] = nil
 		h.cleanOutNils(constructs)
+		(*constructs) = append((*constructs), c)
 	} else {
 		//add this one to the end
 		(*constructs) = append((*constructs), c)


### PR DESCRIPTION
- fix construct not getting re-added on refresh
- fix zhongli stele
  - stele tick shouldn't also do resonance routine on the other stele
  - initial dmg should be able to generate energy
  - energy gen refactored into callback
  - energy gen check should not happen per stele/resonance attack
  - energy gen icd should apply to zhongli and be affected by hitlag 
https://gcsim.app/v3/viewer/share/be7ad1a6-df09-4a46-b198-4d8144dfeaae