### PR TITLE
Prompt on no args

### DIFF
--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -67,6 +69,20 @@ can be viewed in the browser via "go tool pprof -http=localhost:3000 cpu.prof" (
 can be viewed in the browser via "go tool pprof -http=localhost:3000 mem.prof" (insert your desired host/port/filename, requires Graphviz)`)
 
 	flag.Parse()
+
+	_, err := os.Stat(opt.config)
+	usedCLI := false
+	flag.Visit(func(f *flag.Flag) {
+		usedCLI = true
+	})
+	if errors.Is(err, os.ErrNotExist) && !usedCLI {
+		fmt.Printf("The file %s does not exist.\n", opt.config)
+		fmt.Println("What is the filepath of the config you would like to run?")
+		in := bufio.NewReader(os.Stdin)
+		line, _ := in.ReadString('\n')
+		opt.config = line
+		opt.serve = true
+	}
 
 	if opt.cpuprofile != "" {
 		f, err := os.Create(opt.cpuprofile)

--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"runtime"
 	"runtime/pprof"
+	"strings"
 	"sync"
 	"time"
 
@@ -80,7 +81,7 @@ can be viewed in the browser via "go tool pprof -http=localhost:3000 mem.prof" (
 		fmt.Println("What is the filepath of the config you would like to run?")
 		in := bufio.NewReader(os.Stdin)
 		line, _ := in.ReadString('\n')
-		opt.config = line
+		opt.config = strings.TrimSpace(line)
 		opt.serve = true
 	}
 


### PR DESCRIPTION
If config.txt doesn't exist in the current working directory and no arguments were supplied to the executable, the program will now prompt the user for the filename of a config file.