### PR TITLE
fix sara q stormcluster initial offset

### DIFF
--- a/internal/characters/sara/burst.go
+++ b/internal/characters/sara/burst.go
@@ -80,8 +80,8 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		direction := combat.DegreesToDirection(i * stepSize).Rotate(burstInitialDirection)
 		// 6 ticks per stormcluster
 		for j := 0; j < 6; j++ {
-			// start at 6 + 1.35 = 7.35 m offset, move 1.35m per tick
-			stormClusterPos := combat.CalcOffsetPoint(burstInitialPos, combat.Point{Y: 6 + 1.35*float64(j+1)}, direction)
+			// start at 3.6 m offset, move 1.35m per tick
+			stormClusterPos := combat.CalcOffsetPoint(burstInitialPos, combat.Point{Y: 3.6 + 1.35*float64(j)}, direction)
 			stormClusterAp := combat.NewCircleHitOnTarget(stormClusterPos, nil, stormClusterRadius)
 
 			c.Core.QueueAttack(ai, stormClusterAp, burstStart, burstClusterHitmark+18*j, c1cb)


### PR DESCRIPTION
After further investigation, 3.6m seems to be more accurate than 6m.