### PR TITLE
Updated hitlag extension to ceil on ApplyHitlag

### DIFF
--- a/pkg/core/player/character/character.go
+++ b/pkg/core/player/character/character.go
@@ -93,8 +93,8 @@ type CharWrapper struct {
 	mods []modifier.Mod
 
 	//hitlag stuff
-	timePassed   float64 //how many frames have passed since start of sim
-	frozenFrames float64 //how many frames are we still frozen for
+	timePassed   int //how many frames have passed since start of sim
+	frozenFrames int //how many frames are we still frozen for
 	queue        []queue.Task
 }
 

--- a/pkg/core/player/character/hitlag.go
+++ b/pkg/core/player/character/hitlag.go
@@ -9,13 +9,13 @@ import (
 )
 
 func (c *CharWrapper) QueueCharTask(f func(), delay int) {
-	queue.Add(&c.queue, f, c.timePassed+float64(delay))
+	queue.Add(&c.queue, f, c.timePassed+delay)
 }
 
 func (c *CharWrapper) Tick() {
 	//decrement frozen time first
-	c.frozenFrames -= 1.0
-	left := 0.0
+	c.frozenFrames -= 1
+	left := 0
 	if c.frozenFrames < 0 {
 		left = -c.frozenFrames
 		c.frozenFrames = 0
@@ -35,10 +35,10 @@ func (c *CharWrapper) FramePausedOnHitlag() bool {
 	return c.frozenFrames > 0
 }
 
-//ApplyHitlag adds hitlag to the character for specified duration
+// ApplyHitlag adds hitlag to the character for specified duration
 func (c *CharWrapper) ApplyHitlag(factor, dur float64) {
 	//number of frames frozen is total duration * (1 - factor)
-	ext := dur * (1 - factor)
+	ext := int(math.Ceil(dur * (1 - factor)))
 	c.frozenFrames += ext
 	var logs []string
 	var evt glog.Event

--- a/pkg/core/player/character/mods.go
+++ b/pkg/core/player/character/mods.go
@@ -166,7 +166,7 @@ func (c *CharWrapper) StatusDuration(key string) int { return c.getModDuration(k
 
 // Extend.
 
-//extendMod returns true if mod is active and is extended
+// extendMod returns true if mod is active and is extended
 func (c *CharWrapper) extendMod(key string, ext int) bool {
 	m, active := modifier.FindCheckExpiry(&c.mods, key, *c.f)
 	if m == -1 {
@@ -176,7 +176,7 @@ func (c *CharWrapper) extendMod(key string, ext int) bool {
 		return false //nothing to extend is not active
 	}
 	//other wise add to expiry
-	c.mods[m].Extend(float64(ext))
+	c.mods[m].Extend(ext)
 	return true
 }
 
@@ -317,8 +317,8 @@ func (c *CharWrapper) HealBonus() (amt float64) {
 	return amt
 }
 
-//TODO: consider merging this with just attack mods? reaction bonus should
-//maybe just be it's own stat instead of being a separate mod really
+// TODO: consider merging this with just attack mods? reaction bonus should
+// maybe just be it's own stat instead of being a separate mod really
 func (c *CharWrapper) ReactBonus(atk combat.AttackInfo) (amt float64) {
 	n := 0
 	for _, v := range c.mods {

--- a/pkg/enemy/enemy.go
+++ b/pkg/enemy/enemy.go
@@ -48,8 +48,8 @@ type Enemy struct {
 	mods []modifier.Mod
 
 	//hitlag stuff
-	timePassed   float64
-	frozenFrames float64
+	timePassed   int
+	frozenFrames int
 	queue        []queue.Task
 }
 

--- a/pkg/enemy/hitlag.go
+++ b/pkg/enemy/hitlag.go
@@ -10,7 +10,7 @@ import (
 
 func (e *Enemy) ApplyHitlag(factor, dur float64) {
 	//TODO: extend all hitlag affected buff expiry by dur * (1 - factor) i think
-	ext := dur * (1 - factor)
+	ext := int(math.Ceil(dur * (1 - factor)))
 	e.frozenFrames += ext
 
 	var logs []string
@@ -41,7 +41,7 @@ func (e *Enemy) ApplyHitlag(factor, dur float64) {
 }
 
 func (e *Enemy) QueueEnemyTask(f func(), delay int) {
-	queue.Add(&e.queue, f, e.timePassed+float64(delay))
+	queue.Add(&e.queue, f, e.timePassed+delay)
 }
 
 func (e *Enemy) Tick() {
@@ -50,8 +50,8 @@ func (e *Enemy) Tick() {
 		return
 	}
 	//decrement frozen time first
-	e.frozenFrames -= 1.0
-	left := 0.0
+	e.frozenFrames -= 1
+	left := 0
 	if e.frozenFrames < 0 {
 		left = -e.frozenFrames
 		e.frozenFrames = 0

--- a/pkg/modifier/modifier.go
+++ b/pkg/modifier/modifier.go
@@ -1,10 +1,8 @@
-//package modifier provides a universal way of handling a slice
-//of modifiers
+// package modifier provides a universal way of handling a slice
+// of modifiers
 package modifier
 
 import (
-	"math"
-
 	"github.com/genshinsim/gcsim/pkg/core/glog"
 )
 
@@ -14,7 +12,7 @@ type Mod interface {
 	Event() glog.Event
 	SetEvent(glog.Event)
 	AffectedByHitlag() bool
-	Extend(float64)
+	Extend(int)
 }
 
 type Base struct {
@@ -22,16 +20,16 @@ type Base struct {
 	Dur       int
 	Hitlag    bool
 	ModExpiry int
-	extension float64
+	extension int
 	event     glog.Event
 }
 
 func (t *Base) Key() string             { return t.ModKey }
-func (t *Base) Expiry() int             { return t.ModExpiry + int(math.Ceil(t.extension)) }
+func (t *Base) Expiry() int             { return t.ModExpiry + t.extension }
 func (t *Base) Event() glog.Event       { return t.event }
 func (t *Base) SetEvent(evt glog.Event) { t.event = evt }
 func (t *Base) AffectedByHitlag() bool  { return t.Hitlag }
-func (t *Base) Extend(amt float64) {
+func (t *Base) Extend(amt int) {
 	t.extension += amt
 	t.event.SetEnded(t.Expiry())
 }
@@ -58,7 +56,7 @@ func NewBaseWithHitlag(key string, dur int) Base {
 	}
 }
 
-//Delete removes a modifier. Returns true if deleted ok
+// Delete removes a modifier. Returns true if deleted ok
 func Delete[K Mod](slice *[]K, key string) (m Mod) {
 	n := 0
 	for i, v := range *slice {
@@ -73,8 +71,8 @@ func Delete[K Mod](slice *[]K, key string) (m Mod) {
 	return
 }
 
-//Add adds a modifier. Returns true if overwritten and the original evt (if overwritten)
-//TODO: consider adding a map here to track the index to assist with faster lookups
+// Add adds a modifier. Returns true if overwritten and the original evt (if overwritten)
+// TODO: consider adding a map here to track the index to assist with faster lookups
 func Add[K Mod](slice *[]K, mod K, f int) (overwrote bool, evt glog.Event) {
 	ind := Find(slice, mod.Key())
 
@@ -115,7 +113,7 @@ func FindCheckExpiry[K Mod](slice *[]K, key string, f int) (int, bool) {
 	return ind, true
 }
 
-//LogAdd is a helper that logs mod add events
+// LogAdd is a helper that logs mod add events
 func LogAdd[K Mod](prefix string, index int, mod K, logger glog.Logger, overwrote bool, oldEvt glog.Event) {
 	var evt glog.Event
 	if overwrote {

--- a/pkg/queue/tasks.go
+++ b/pkg/queue/tasks.go
@@ -1,12 +1,18 @@
-//package queue provide a universal way of handling queuing and executing tasks
+// package queue provide a universal way of handling queuing and executing tasks
 package queue
 
+// TODO: This entire Task queue should be replaced and core's task queue should be used instead
+// In order to replace, the core task queue must support the ability to update the position of a
+// task in the queue.
+// Also will need to consider order. Currently everything that is queued via QueueCharTask will
+// always happen before all entries in the core task queue. If any implementations depend on this order,
+// this will cause additional problems.
 type Task struct {
 	F     func()
-	Delay float64
+	Delay int
 }
 
-func Add(slice *[]Task, f func(), delay float64) {
+func Add(slice *[]Task, f func(), delay int) {
 	if delay == 0 {
 		f()
 		return
@@ -17,7 +23,7 @@ func Add(slice *[]Task, f func(), delay float64) {
 	})
 }
 
-func Run(slice *[]Task, currentTime float64) {
+func Run(slice *[]Task, currentTime int) {
 	n := 0
 	for i := 0; i < len(*slice); i++ {
 		if (*slice)[i].Delay <= currentTime {


### PR DESCRIPTION
This change will increase the net number of hitlag extension frames that occur. By moving the `ceil` operation to the `ApplyHitlag` function we:
1. treat each `ApplyHitlag` delay as an independent timer that expires on the frame (not such thing as perfect timing). For mods, multiple extensions are now `ceil(extension)*N` instead of `ceil(extension*N)` (as N increases, new approach will net more extension than before)
2. ceil the extenstion added to `frozenFrames` (as described above) such that anything added via `QueueEnemyTask` or `QueueCharTask` will have the same frame extension behavior as observed with modifiers

As an example of this change, currently in gcsim not possible to do `11N2CD` with Hu Tao due to `paramita` mod expiring during the 11th combo attack. There is only 19f left on mod at start of 11th, need at least 34f to perform `N2CD` (39f for combo but N2 adds 4.158f of hitlag extension): https://gcsim.app/v3/viewer/share/e51860ae-17b6-4bfa-b871-55d4a867b831
![image](https://user-images.githubusercontent.com/2059811/217454175-8c60e6ef-0466-44b6-a6d5-59bf6d5ffe60.png)

With this change, now possible to perform 11N2CD (35f left at start of 11th combo attack, last combo adds 5f of hitlag extension):
https://gcsim.app/v3/viewer/share/5b3c472a-19aa-40f6-a7fe-0434fb22e742
![image](https://user-images.githubusercontent.com/2059811/217455353-a72ed36c-d313-453d-a022-6457b67f38a0.png)
![image](https://user-images.githubusercontent.com/2059811/217455422-34a02c62-c693-4e7c-8b28-c3a148d20ec6.png)

Example of 11N2CD being possible in-game: https://www.youtube.com/watch?v=IVlRJ6fuJ3k
