### PR TITLE
Reduced Hu Tao CA in E to 42 frames

### DIFF
--- a/internal/characters/hutao/charge.go
+++ b/internal/characters/hutao/charge.go
@@ -25,11 +25,10 @@ func init() {
 	chargeFrames[action.ActionJump] = chargeHitmark
 
 	// charge (paramita) -> x
-	ppChargeFrames = frames.InitAbilSlice(44)
+	ppChargeFrames = frames.InitAbilSlice(42)
 	ppChargeFrames[action.ActionBurst] = 33
 	ppChargeFrames[action.ActionDash] = ppChargeHitmark
 	ppChargeFrames[action.ActionJump] = ppChargeHitmark
-	ppChargeFrames[action.ActionSwap] = 42
 }
 
 func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {


### PR DESCRIPTION
Updating CA frames to match V2 frame data for Hu Tao: https://docs.google.com/spreadsheets/d/1KR_FMtupIbLEhWRGww2N2UKEJG3hy5mWJIez8S6EZ2w/edit#gid=2118558486

Change makes 9N1C possible on hu tao