### PR TITLE
Implements Dash CD

### DIFF
--- a/internal/characters/ayaka/dash.go
+++ b/internal/characters/ayaka/dash.go
@@ -57,8 +57,8 @@ func (c *char) Dash(p map[string]int) action.ActionInfo {
 		)
 	}, dashHitmark+f)
 
-	// call default implementation to handle stamina
-	c.Character.Dash(p)
+	// handle stamina usage, avoid default dash implementation since dont want CD
+	c.QueueDashStaminaConsumption(p)
 
 	return action.ActionInfo{
 		Frames:          func(next action.Action) int { return dashFrames[next] + f },

--- a/internal/characters/mona/dash.go
+++ b/internal/characters/mona/dash.go
@@ -58,8 +58,8 @@ func (c *char) Dash(p map[string]int) action.ActionInfo {
 		c.Core.Tasks.Add(c.c6(c.Core.F), 60)
 	}
 
-	// call default implementation to handle stamina
-	c.Character.Dash(p)
+	// handle stamina usage, avoid default dash implementation since dont want CD
+	c.QueueDashStaminaConsumption(p)
 
 	return action.ActionInfo{
 		Frames:          func(next action.Action) int { return dashFrames[next] + f },

--- a/internal/characters/wanderer/dash.go
+++ b/internal/characters/wanderer/dash.go
@@ -23,18 +23,10 @@ func init() {
 }
 
 func (c *char) Dash(p map[string]int) action.ActionInfo {
-	delay := c.checkForSkillEnd()
-
 	if c.StatusIsActive(skillKey) {
 		return c.WindfavoredDash(p)
 	}
-
-	ai := c.Character.Dash(p)
-	ai.Frames = func(action action.Action) int { return delay + ai.Frames(action) }
-	ai.AnimationLength = delay + ai.AnimationLength
-	ai.CanQueueAfter = delay + ai.CanQueueAfter
-
-	return ai
+	return c.Character.Dash(p)
 }
 
 func (c *char) WindfavoredDash(p map[string]int) action.ActionInfo {

--- a/internal/template/character/stam.go
+++ b/internal/template/character/stam.go
@@ -57,18 +57,21 @@ func (c *Character) Dash(p map[string]int) action.ActionInfo {
 	}
 }
 
+// set the dash CD. If the dash was on CD when this dash executes, lockout dash
 func (c *Character) ApplyDashCD() {
-	// set the dash CD. If the dash was on CD when this dash executes, lockout dash
+	var evt glog.Event
+
 	if c.Core.Player.DashCDExpirationFrame > c.Core.F {
 		c.Core.Player.DashLockout = true
 		c.Core.Player.DashCDExpirationFrame = c.Core.F + 1.5*60
+		evt = c.Core.Log.NewEvent("dash cooldown triggered", glog.LogCooldownEvent, c.Index)
 	} else {
 		c.Core.Player.DashLockout = false
 		c.Core.Player.DashCDExpirationFrame = c.Core.F + 0.8*60
+		evt = c.Core.Log.NewEvent("dash lockout evaluation started", glog.LogCooldownEvent, c.Index)
 	}
 
-	c.Core.Log.NewEventBuildMsg(glog.LogCooldownEvent, c.Index, "dash cooldown triggered").
-		Write("lockout", c.Core.Player.DashLockout).
+	evt.Write("lockout", c.Core.Player.DashLockout).
 		Write("expiry", c.Core.Player.DashCDExpirationFrame-c.Core.F).
 		Write("expiry_frame", c.Core.Player.DashCDExpirationFrame)
 }

--- a/internal/template/character/stam.go
+++ b/internal/template/character/stam.go
@@ -8,8 +8,8 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/player/weapon"
 )
 
-//ActionStam provides default implementation for stam cost for charge and dash
-//character should override this though
+// ActionStam provides default implementation for stam cost for charge and dash
+// character should override this though
 func (c *Character) ActionStam(a action.Action, p map[string]int) float64 {
 	switch a {
 	case action.ActionCharge:
@@ -42,18 +42,35 @@ func (c *Character) ActionStam(a action.Action, p map[string]int) float64 {
 }
 
 func (c *Character) Dash(p map[string]int) action.ActionInfo {
-	var f int = 20
-	switch c.CharBody {
-	case profile.BodyBoy, profile.BodyLoli:
-		f = 21
-	case profile.BodyGirl:
-		f = 20
-	case profile.BodyMale:
-		f = 19
-	case profile.BodyLady:
-		f = 22
+	length := c.DashLength()
+
+	// set the dash CD. If the dash was on CD when this dash executes, lockout dash
+	if c.Core.Player.DashCDExpirationFrame > c.Core.F {
+		c.Core.Player.DashLockout = true
+		c.Core.Player.DashCDExpirationFrame = c.Core.F + 1.5*60
+	} else {
+		c.Core.Player.DashLockout = false
+		c.Core.Player.DashCDExpirationFrame = c.Core.F + 0.8*60
 	}
 
+	c.Core.Log.NewEventBuildMsg(glog.LogCooldownEvent, c.Index, "dash cooldown triggered").
+		Write("lockout", c.Core.Player.DashLockout).
+		Write("expiry", c.Core.Player.DashCDExpirationFrame-c.Core.F).
+		Write("expiry_frame", c.Core.Player.DashCDExpirationFrame).
+		Write("dash_length", length)
+
+	// consume stamina at end of the dash
+	c.QueueDashStaminaConsumption(p)
+
+	return action.ActionInfo{
+		Frames:          func(action.Action) int { return length },
+		AnimationLength: length,
+		CanQueueAfter:   length,
+		State:           action.DashState,
+	}
+}
+
+func (c *Character) QueueDashStaminaConsumption(p map[string]int) {
 	//consume stam at the end
 	c.Core.Tasks.Add(func() {
 		req := c.Core.Player.AbilStamCost(c.Index, action.ActionDash, p)
@@ -64,13 +81,19 @@ func (c *Character) Dash(p map[string]int) action.ActionInfo {
 		}
 		c.Core.Player.LastStamUse = c.Core.F
 		c.Core.Events.Emit(event.OnStamUse, action.DashState)
-	}, f-1)
+	}, c.DashLength()-1)
+}
 
-	return action.ActionInfo{
-		Frames:          func(action.Action) int { return f },
-		AnimationLength: f,
-		CanQueueAfter:   f,
-		State:           action.DashState,
+func (c *Character) DashLength() int {
+	switch c.CharBody {
+	case profile.BodyBoy, profile.BodyLoli:
+		return 21
+	case profile.BodyMale:
+		return 19
+	case profile.BodyLady:
+		return 22
+	default:
+		return 20
 	}
 }
 

--- a/pkg/core/action/failure.go
+++ b/pkg/core/action/failure.go
@@ -16,6 +16,7 @@ const (
 	InsufficientEnergy
 	InsufficientStamina
 	CharacterDesceased // TODO: need chars to die first
+	DashCD
 )
 
 var failureString = [...]string{
@@ -26,6 +27,7 @@ var failureString = [...]string{
 	"insufficient_energy",
 	"insufficient_stamina",
 	"character_desceased",
+	"dash_cd",
 }
 
 func (e ActionFailure) String() string {

--- a/pkg/core/player/character/character.go
+++ b/pkg/core/player/character/character.go
@@ -92,6 +92,10 @@ type CharWrapper struct {
 	//mods
 	mods []modifier.Mod
 
+	//dash cd: keeps track of remaining cd frames for off-field chars
+	RemainingDashCD int
+	DashLockout     bool
+
 	//hitlag stuff
 	timePassed   int //how many frames have passed since start of sim
 	frozenFrames int //how many frames are we still frozen for

--- a/pkg/core/player/exec.go
+++ b/pkg/core/player/exec.go
@@ -79,6 +79,15 @@ func (p *Handler) Exec(t action.Action, k keys.Char, param map[string]int) error
 			p.Events.Emit(event.OnActionFailed, p.active, t, param, action.InsufficientStamina)
 			return ErrActionNotReady
 		}
+
+		// dash is still on cooldown and is locked out, cannot dash again until CD expires
+		if p.DashLockout && p.DashCDExpirationFrame > *p.F {
+			p.Log.NewEvent("dash on cooldown", glog.LogWarnings, -1).
+				Write("dash_cd_expiration", p.DashCDExpirationFrame-*p.F)
+			p.Events.Emit(event.OnActionFailed, p.active, t, param, action.DashCD)
+			return ErrActionNotReady
+		}
+
 		p.useAbility(t, param, char.Dash) //TODO: make sure characters are consuming stam in dashes
 	case action.ActionJump:
 		p.useAbility(t, param, char.Jump)


### PR DESCRIPTION
Closes #892

Example sim with dash CD and lockout being retained between swaps
https://gcsim.app/v3/viewer/share/7ea7f12d-4a2f-4ce9-bd1e-e79e75ba7616

**Note:** in current state:
* in-game 3N2CD (using macros) hits dash lockout on 3rd dash (so 2nd happens while first is in 0.8s CD w/ hitlag extension). Video: https://www.youtube.com/watch?v=IdBaKWc3-5Q
* In sim, dash lockout does not happen (with hitlag extension, first dash cd ends on frame 127 [see extension on frame 117], second dash starts on frame 128): https://gcsim.app/v3/viewer/share/5ac1e788-f3cb-4d22-807f-c8c6f334b08a
* in-game 3N2CD (using macros) will **only** hit lockout with hitlag extension