### PR TITLE
implement kazuha glide cancel

### DIFF
--- a/internal/characters/kazuha/plunge.go
+++ b/internal/characters/kazuha/plunge.go
@@ -5,6 +5,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 )
 
 var plungePressFrames []int
@@ -32,10 +33,17 @@ func init() {
 }
 
 func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
-	ele := attributes.Physical
-	//TODO: this really shouldn't be anything else since it should only be used after skill?
-	if c.Core.Player.LastAction.Char == c.Index && c.Core.Player.LastAction.Type == action.ActionSkill {
-		ele = attributes.Anemo
+	// last action must be skill without glide cancel
+	if c.Core.Player.LastAction.Type != action.ActionSkill ||
+		c.Core.Player.LastAction.Param["glide"] != 0 {
+		c.Core.Log.NewEvent("only plunge after skill without glide cancel", glog.LogActionEvent, c.Index).
+			Write("action", action.ActionLowPlunge)
+		return action.ActionInfo{
+			Frames:          func(action.Action) int { return 1200 },
+			AnimationLength: 1200,
+			CanQueueAfter:   1200,
+			State:           action.Idle,
+		}
 	}
 
 	act := action.ActionInfo{
@@ -65,7 +73,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 			ICDTag:         combat.ICDTagNone,
 			ICDGroup:       combat.ICDGroupDefault,
 			StrikeType:     combat.StrikeTypeSlash,
-			Element:        ele,
+			Element:        attributes.Anemo,
 			Durability:     0,
 			Mult:           plunge[c.TalentLvlAttack()],
 			IgnoreInfusion: true,
@@ -86,7 +94,7 @@ func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 		ICDTag:         combat.ICDTagNone,
 		ICDGroup:       combat.ICDGroupDefault,
 		StrikeType:     combat.StrikeTypeBlunt,
-		Element:        ele,
+		Element:        attributes.Anemo,
 		Durability:     25,
 		Mult:           highPlunge[c.TalentLvlAttack()],
 		IgnoreInfusion: true,

--- a/internal/characters/kazuha/plunge.go
+++ b/internal/characters/kazuha/plunge.go
@@ -35,7 +35,7 @@ func init() {
 func (c *char) HighPlungeAttack(p map[string]int) action.ActionInfo {
 	// last action must be skill without glide cancel
 	if c.Core.Player.LastAction.Type != action.ActionSkill ||
-		c.Core.Player.LastAction.Param["glide"] != 0 {
+		c.Core.Player.LastAction.Param["glide_cancel"] != 0 {
 		c.Core.Log.NewEvent("only plunge after skill without glide cancel", glog.LogActionEvent, c.Index).
 			Write("action", action.ActionLowPlunge)
 		return action.ActionInfo{

--- a/internal/characters/kazuha/skill.go
+++ b/internal/characters/kazuha/skill.go
@@ -47,7 +47,7 @@ func init() {
 
 func (c *char) Skill(p map[string]int) action.ActionInfo {
 	hold := p["hold"]
-	glide := p["glide"]
+	glide := p["glide_cancel"]
 	if glide < 0 {
 		glide = 0
 	}


### PR DESCRIPTION
- glide cancel is now possible via the `glide_cancel` param on Kazuha's `skill` (>0 means glide cancel)
- small refactoring of skill.go
- restricts his plunge to only be allowed after a Skill without Glide Cancel