### PR TITLE
fix freeze resist reducing gauge instead of decay

### DIFF
--- a/pkg/reactable/freeze.go
+++ b/pkg/reactable/freeze.go
@@ -98,7 +98,7 @@ func (r *Reactable) ShatterCheck(a *combat.AttackEvent) bool {
 func (r *Reactable) triggerFreeze(a, b reactions.Durability) reactions.Durability {
 	d := min(a, b)
 	//trigger freeze should only addDurability and should not touch decay rate
-	r.attachOverlap(ModifierFrozen, 2*d*reactions.Durability(1-r.FreezeResist), ZeroDur)
+	r.attachOverlap(ModifierFrozen, 2*d, ZeroDur)
 	return d
 }
 

--- a/pkg/reactable/freeze.go
+++ b/pkg/reactable/freeze.go
@@ -97,6 +97,9 @@ func (r *Reactable) ShatterCheck(a *combat.AttackEvent) bool {
 // add to freeze durability and return amount of durability consumed
 func (r *Reactable) triggerFreeze(a, b reactions.Durability) reactions.Durability {
 	d := min(a, b)
+	if r.FreezeResist >= 1 {
+		return d
+	}
 	//trigger freeze should only addDurability and should not touch decay rate
 	r.attachOverlap(ModifierFrozen, 2*d, ZeroDur)
 	return d

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -381,7 +381,7 @@ func (r *Reactable) Tick() {
 	if r.Durability[ModifierFrozen] > ZeroDur {
 		//ramp up decay rate first
 		r.DecayRate[ModifierFrozen] += frzDelta
-		r.Durability[ModifierFrozen] -= r.DecayRate[ModifierFrozen]
+		r.Durability[ModifierFrozen] -= r.DecayRate[ModifierFrozen] / reactions.Durability(1.0 - r.FreezeResist)
 
 		r.checkFreeze()
 	} else if r.DecayRate[ModifierFrozen] > frzDecayCap { //otherwise ramp down decay rate


### PR DESCRIPTION
Freeze resistance affects the duration of freeze rather than gauge. We incorporate this by reducing ModifierFrozen durability via function of decay rate.