### PR TITLE
Make Nahida hold duration more intuitive

### DIFF
--- a/internal/characters/nahida/skill.go
+++ b/internal/characters/nahida/skill.go
@@ -90,12 +90,13 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 	hold := p["hold"]
 	// earliest hold can be let go is roughly 16.5. max is set to 317 so that
 	// it aligns with max cd at 330
-	if hold > 317 {
-		hold = 317
+	if hold > 300 {
+		hold = 300
 	}
-	if hold < 17 {
-		hold = 17
+	if hold < 1 {
+		hold = 1
 	}
+
 
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
@@ -113,7 +114,7 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 		ai,
 		combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 25),
 		0, // TODO: snapshot timing
-		hold+3,
+		hold+3+16,
 		c.skillMarkTargets,
 	)
 

--- a/internal/characters/nahida/skill.go
+++ b/internal/characters/nahida/skill.go
@@ -88,8 +88,8 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 
 func (c *char) skillHold(p map[string]int) action.ActionInfo {
 	hold := p["hold"]
-	// earliest hold can be let go is roughly 16.5. max is set to 317 so that
-	// it aligns with max cd at 330
+	// earliest hold can be let go is roughly 16.5, max is 317
+	// adds the value in hold onto the minimum length of 16, so hold=1 gives 17f and hold=5 gives a 22f delay until hitmark.
 	if hold > 300 {
 		hold = 300
 	}


### PR DESCRIPTION
Make Nahida's Hold Duration be the amount from frames its held longer than the minimum rather than the exact number of frame until hitmark. This is more intuitive to use