### PR TITLE
fix itto na counter not being reset correctly and itto e -> e frames

### DIFF
--- a/internal/characters/itto/dash.go
+++ b/internal/characters/itto/dash.go
@@ -1,0 +1,14 @@
+package itto
+
+import (
+	"github.com/genshinsim/gcsim/pkg/core/action"
+)
+
+func (c *char) Dash(p map[string]int) action.ActionInfo {
+	// chaining dashes resets savedNormalCounter
+	if c.Core.Player.CurrentState() == action.DashState {
+		c.savedNormalCounter = 0
+	}
+
+	return c.Character.Dash(p)
+}

--- a/internal/characters/itto/skill.go
+++ b/internal/characters/itto/skill.go
@@ -35,6 +35,12 @@ func init() {
 // - Ushi will flee when its HP reaches 0 or its duration ends. It will grant Arataki Itto 1 stack of Superlative Superstrength when it leaves.
 // Ushi is considered a Geo Construct. Arataki Itto can only deploy 1 Ushi on the field at any one time.
 func (c *char) Skill(p map[string]int) action.ActionInfo {
+	// using a skill after a dash resets savedNormalCounter
+	// can't use CurrentState here since AnimationLength of Dash is the same as Dash -> Skill, so it switches to Idle instead of staying DashState
+	if c.Core.Player.LastAction.Type == action.ActionDash {
+		c.savedNormalCounter = 0
+	}
+
 	// Added "travel" parameter for future, since Ushi is thrown and takes 12 frames to hit the ground from a press E
 	travel, ok := p["travel"]
 	if !ok {

--- a/internal/characters/itto/skill.go
+++ b/internal/characters/itto/skill.go
@@ -18,7 +18,8 @@ const (
 
 func init() {
 	skillFrames = frames.InitAbilSlice(42) // E -> N1/Q
-	skillFrames[action.ActionCharge] = 28  // since we assumme that Ushi always hits for a stack, we can just use E -> CA1/CAF
+	skillFrames[action.ActionCharge] = 28  // since we assume that Ushi always hits for a stack, we can just use E -> CA1/CAF
+	skillFrames[action.ActionSkill] = 28   // E -> E
 	skillFrames[action.ActionDash] = 28    // E -> D
 	skillFrames[action.ActionJump] = 28    // E -> J
 	skillFrames[action.ActionSwap] = 41    // E -> Swap


### PR DESCRIPTION
closes #1267 

Itto's NA counter now correctly resets if chaining dashes or doing D -> E. Reset via timer (N1 -> E -> wait a long time -> N1) is not implemented.

E -> E frames should be the same as E -> CA/D/J as can be seen here: https://youtu.be/oa0njfapZeE?t=22