### PR TITLE
hold e related fixes

### DIFF
--- a/internal/artifacts/gambler/gambler.go
+++ b/internal/artifacts/gambler/gambler.go
@@ -39,7 +39,7 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 		char.AddAttackMod(character.AttackMod{
 			Base: modifier.NewBase("gambler-2pc", -1),
 			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-				if atk.Info.AttackTag != attacks.AttackTagElementalArt && atk.Info.AttackTag != attacks.AttackTagElementalArtHold {
+				if atk.Info.AttackTag != attacks.AttackTagElementalArt {
 					return nil, false
 				}
 				return m, true

--- a/internal/characters/cyno/cons.go
+++ b/internal/characters/cyno/cons.go
@@ -159,7 +159,7 @@ func (c *char) makeC6CB() combat.AttackCBFunc {
 		ai := combat.AttackInfo{
 			ActorIndex:   c.Index,
 			Abil:         "Raiment: Just Scales (C6)",
-			AttackTag:    attacks.AttackTagElementalArt,
+			AttackTag:    attacks.AttackTagElementalArtHold,
 			ICDTag:       attacks.ICDTagElementalArt,
 			ICDGroup:     attacks.ICDGroupDefault,
 			StrikeType:   attacks.StrikeTypeSlash,

--- a/internal/characters/cyno/skill.go
+++ b/internal/characters/cyno/skill.go
@@ -113,7 +113,8 @@ func (c *char) skillB() action.ActionInfo {
 		ai.Abil = "Duststalker Bolt"
 		ai.Mult = 1.0
 		ai.FlatDmg = c.a4Bolt()
-		ai.ICDTag = attacks.ICDTagCynoBolt
+		ai.AttackTag = attacks.AttackTagElementalArtHold
+		ai.ICDTag = attacks.ICDTagElementalArt
 		ai.ICDGroup = attacks.ICDGroupCynoBolt
 		ai.StrikeType = attacks.StrikeTypeSlash
 		ai.HitlagFactor = 0

--- a/internal/characters/kirara/skill.go
+++ b/internal/characters/kirara/skill.go
@@ -249,7 +249,7 @@ func (c *char) createSkillHoldSnapshot() *combat.AttackEvent {
 		ActorIndex: c.Index,
 		Abil:       "Urgent Neko Parcel",
 		AttackTag:  attacks.AttackTagElementalArtHold,
-		ICDTag:     attacks.ICDTagElementalArt,
+		ICDTag:     attacks.ICDTagElementalArtHold,
 		ICDGroup:   attacks.ICDGroupDefault,
 		StrikeType: attacks.StrikeTypeDefault,
 		Element:    attributes.Dendro,

--- a/internal/characters/mika/skill.go
+++ b/internal/characters/mika/skill.go
@@ -165,10 +165,10 @@ func (c *char) makeRimestarShardsCB() func(combat.AttackCB) {
 		ai := combat.AttackInfo{
 			ActorIndex: c.Index,
 			Abil:       "Rimestar Shard",
-			AttackTag:  attacks.AttackTagElementalArtHold,
+			AttackTag:  attacks.AttackTagElementalArt,
 			ICDTag:     attacks.ICDTagElementalArt,
 			ICDGroup:   attacks.ICDGroupDefault,
-			StrikeType: attacks.StrikeTypeSlash,
+			StrikeType: attacks.StrikeTypePierce,
 			Element:    attributes.Cryo,
 			Durability: 25,
 			Mult:       skillExplode[c.TalentLvlSkill()],

--- a/internal/characters/mika/skill.go
+++ b/internal/characters/mika/skill.go
@@ -107,10 +107,10 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Rimestar Flare",
-		AttackTag:  attacks.AttackTagElementalArtHold,
-		ICDTag:     attacks.ICDTagElementalArtHold,
+		AttackTag:  attacks.AttackTagElementalArt,
+		ICDTag:     attacks.ICDTagElementalArt,
 		ICDGroup:   attacks.ICDGroupDefault,
-		StrikeType: attacks.StrikeTypeSlash,
+		StrikeType: attacks.StrikeTypePierce,
 		Element:    attributes.Cryo,
 		Durability: 25,
 		Mult:       skillHold[c.TalentLvlSkill()],

--- a/internal/characters/mika/skill.go
+++ b/internal/characters/mika/skill.go
@@ -108,7 +108,7 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 		ActorIndex: c.Index,
 		Abil:       "Rimestar Flare",
 		AttackTag:  attacks.AttackTagElementalArtHold,
-		ICDTag:     attacks.ICDTagElementalArt,
+		ICDTag:     attacks.ICDTagElementalArtHold,
 		ICDGroup:   attacks.ICDGroupDefault,
 		StrikeType: attacks.StrikeTypeSlash,
 		Element:    attributes.Cryo,

--- a/internal/characters/razor/skill.go
+++ b/internal/characters/razor/skill.go
@@ -147,7 +147,7 @@ func (c *char) SkillHold(burstActive int) action.ActionInfo {
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Claw and Thunder (Hold)",
-		AttackTag:  attacks.AttackTagElementalArtHold,
+		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,
 		StrikeType: attacks.StrikeTypeBlunt,

--- a/internal/characters/sayu/cons.go
+++ b/internal/characters/sayu/cons.go
@@ -22,7 +22,7 @@ func (c *char) c2() {
 			if atk.Info.ActorIndex != c.Index {
 				return nil, false
 			}
-			if atk.Info.AttackTag != attacks.AttackTagElementalArt && atk.Info.AttackTag != attacks.AttackTagElementalArtHold {
+			if atk.Info.AttackTag != attacks.AttackTagElementalArt {
 				return nil, false
 			}
 			m[attributes.DmgP] = c.c2Bonus

--- a/internal/characters/sayu/cons.go
+++ b/internal/characters/sayu/cons.go
@@ -26,8 +26,6 @@ func (c *char) c2() {
 				return nil, false
 			}
 			m[attributes.DmgP] = c.c2Bonus
-			//reset bonus back to 0
-			c.c2Bonus = 0
 			return m, true
 		},
 	})

--- a/internal/characters/sayu/skill.go
+++ b/internal/characters/sayu/skill.go
@@ -342,7 +342,8 @@ func (c *char) rollAbsorb() {
 		}
 
 		switch atk.Info.AttackTag {
-		case attacks.AttackTagElementalArt:
+		// DoT always has ElementalArtHold tag
+		case attacks.AttackTagElementalArtHold:
 			// DoT Elemental DMG
 			ai := combat.AttackInfo{
 				ActorIndex: c.Index,
@@ -356,7 +357,8 @@ func (c *char) rollAbsorb() {
 				Mult:       skillAbsorb[c.TalentLvlSkill()],
 			}
 			c.Core.QueueAttack(ai, combat.NewSingleTargetHit(e.Key()), 1, 1)
-		case attacks.AttackTagElementalArtHold:
+		// Kick always has ElementalArt tag
+		case attacks.AttackTagElementalArt:
 			// Kick Elemental DMG
 			ai := combat.AttackInfo{
 				ActorIndex: c.Index,

--- a/internal/characters/sayu/skill.go
+++ b/internal/characters/sayu/skill.go
@@ -100,7 +100,7 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Fuufuu Windwheel (DoT Press)",
-		AttackTag:  attacks.AttackTagElementalArt,
+		AttackTag:  attacks.AttackTagElementalArtHold,
 		ICDTag:     attacks.ICDTagElementalArtAnemo,
 		ICDGroup:   attacks.ICDGroupDefault,
 		StrikeType: attacks.StrikeTypeDefault,
@@ -177,7 +177,7 @@ func (c *char) skillShortHold(p map[string]int) action.ActionInfo {
 	ai := combat.AttackInfo{
 		ActorIndex:       c.Index,
 		Abil:             "Fuufuu Whirlwind (Kick Hold)",
-		AttackTag:        attacks.AttackTagElementalArtHold,
+		AttackTag:        attacks.AttackTagElementalArt,
 		ICDTag:           attacks.ICDTagNone,
 		ICDGroup:         attacks.ICDGroupDefault,
 		StrikeType:       attacks.StrikeTypeDefault,
@@ -237,7 +237,7 @@ func (c *char) skillHold(p map[string]int, duration int) action.ActionInfo {
 	ai := combat.AttackInfo{
 		ActorIndex:       c.Index,
 		Abil:             "Fuufuu Whirlwind (Kick Hold)",
-		AttackTag:        attacks.AttackTagElementalArtHold,
+		AttackTag:        attacks.AttackTagElementalArt,
 		ICDTag:           attacks.ICDTagNone,
 		ICDGroup:         attacks.ICDGroupDefault,
 		StrikeType:       attacks.StrikeTypeDefault,
@@ -272,7 +272,7 @@ func (c *char) createSkillHoldSnapshot() *combat.AttackEvent {
 	ai := combat.AttackInfo{
 		ActorIndex:       c.Index,
 		Abil:             "Fuufuu Windwheel (DoT Hold)",
-		AttackTag:        attacks.AttackTagElementalArt,
+		AttackTag:        attacks.AttackTagElementalArtHold,
 		ICDTag:           attacks.ICDTagElementalArtAnemo,
 		ICDGroup:         attacks.ICDGroupDefault,
 		StrikeType:       attacks.StrikeTypeDefault,

--- a/internal/characters/shenhe/skill.go
+++ b/internal/characters/shenhe/skill.go
@@ -117,7 +117,7 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 	ai := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Spring Spirit Summoning (Hold)",
-		AttackTag:  attacks.AttackTagElementalArtHold,
+		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,
 		StrikeType: attacks.StrikeTypeSlash,

--- a/internal/characters/traveleranemo/asc.go
+++ b/internal/characters/traveleranemo/asc.go
@@ -56,7 +56,7 @@ func (c *char) a4() {
 		if atk.Info.ActorIndex != c.Index {
 			return false
 		}
-		if atk.Info.AttackTag != attacks.AttackTagElementalArt {
+		if atk.Info.AttackTag != attacks.AttackTagElementalArt && atk.Info.AttackTag != attacks.AttackTagElementalArtHold {
 			return false
 		}
 		if c.StatusIsActive(a4ICDKey) {

--- a/internal/characters/traveleranemo/skill.go
+++ b/internal/characters/traveleranemo/skill.go
@@ -107,7 +107,7 @@ func (c *char) SkillHold(holdTicks int) action.ActionInfo {
 	aiCut := combat.AttackInfo{
 		ActorIndex: c.Index,
 		Abil:       "Palm Vortex Initial Cutting (Hold)",
-		AttackTag:  attacks.AttackTagElementalArt,
+		AttackTag:  attacks.AttackTagElementalArtHold,
 		ICDTag:     attacks.ICDTagElementalArt,
 		ICDGroup:   attacks.ICDGroupDefault,
 		StrikeType: attacks.StrikeTypeSlash,

--- a/internal/characters/yoimiya/burst.go
+++ b/internal/characters/yoimiya/burst.go
@@ -118,6 +118,7 @@ func (c *char) burstHook() {
 		case attacks.AttackTagExtra:
 		case attacks.AttackTagPlunge:
 		case attacks.AttackTagElementalArt:
+		case attacks.AttackTagElementalArtHold:
 		case attacks.AttackTagElementalBurst:
 		default:
 			return false

--- a/internal/weapons/common/sacrificial.go
+++ b/internal/weapons/common/sacrificial.go
@@ -47,7 +47,7 @@ func NewSacrificial(c *core.Core, char *character.CharWrapper, p weapon.WeaponPr
 		if c.Player.Active() != char.Index {
 			return false
 		}
-		if atk.Info.AttackTag != attacks.AttackTagElementalArt && atk.Info.AttackTag != attacks.AttackTagElementalArtHold {
+		if atk.Info.AttackTag != attacks.AttackTagElementalArt {
 			return false
 		}
 		if char.StatusIsActive(icdKey) {

--- a/pkg/core/attacks/icd.go
+++ b/pkg/core/attacks/icd.go
@@ -7,6 +7,7 @@ const (
 	ICDTagNormalAttack
 	ICDTagExtraAttack
 	ICDTagElementalArt
+	ICDTagElementalArtHold
 	ICDTagElementalArtAnemo
 	ICDTagElementalArtPyro
 	ICDTagElementalArtHydro


### PR DESCRIPTION
closes #216 

some bigger changes:
- fix sayu c2 (before it was gone after 1 DoT hit, now it buffs both normal and absorbed kick only)
- fix sacrificial series checking for hold e attack tag (should only check for normal e attack tag)