### PR TITLE
fix xiangling c6 not applying to 3rd initial

### DIFF
--- a/internal/characters/xiangling/burst.go
+++ b/internal/characters/xiangling/burst.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	burstFrames   []int
-	burstHitmarks = []int{18, 33, 56} // initial 3 hits
+	burstHitmarks = []int{18, 33, 57} // initial 3 hits
 	burstRadius   = []float64{2.5, 2.5, 3}
 )
 
@@ -68,7 +68,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		}
 		c.Core.Status.Add("xianglingburst", max)
 		snap := c.Snapshot(&burstHit)
-		for delay := 0; delay <= max; delay += 73 { //first hit on same frame as 3rd initial hit
+		for delay := 0; delay <= max; delay += 73 { //first hit 1f before the 3rd initial hit
 			// TODO: proper hitbox
 			c.Core.Tasks.Add(func() {
 				c.Core.QueueAttackWithSnap(
@@ -79,10 +79,9 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				)
 			}, delay)
 		}
-		//add an effect starting at frame 55 to end of duration to increase pyro dmg by 15% if c6
+		//add an effect starting at frame 56 to end of duration to increase pyro dmg by 15% if c6
 		if c.Base.Cons >= 6 {
-			//wait 1 frame after Q starts
-			c.Core.Tasks.Add(func() { c.c6(max) }, 1)
+			c.c6(max)
 		}
 	}, a)
 


### PR DESCRIPTION
closes #1279 
- before: 2nd initial, 3rd initial, 1st pyronado, c6
- now: 2nd initial, 1st pyronado, c6, 3rd initial

tested here: https://gcsim.app/v3/viewer/share/527670f3-a676-4004-89c0-4cac668ce6bd