### PR TITLE
move start_hp to params in char line

### DIFF
--- a/internal/tests/characters/characters_test.go
+++ b/internal/tests/characters/characters_test.go
@@ -58,7 +58,6 @@ func defProfile(key keys.Char) profile.CharacterProfile {
 	p.Sets = make(map[keys.Set]int)
 	p.SetParams = make(map[keys.Set]map[string]int)
 	p.Weapon.Params = make(map[string]int)
-	p.Base.StartHP = -1
 	p.Base.Element = keys.CharKeyToEle[key]
 	p.Weapon.Key = keys.DullBlade
 

--- a/internal/tests/collision/collision_test.go
+++ b/internal/tests/collision/collision_test.go
@@ -57,7 +57,6 @@ func makeCore(trgCount int) (*core.Core, []*enemy.Enemy) {
 		p.Sets = make(map[keys.Set]int)
 		p.SetParams = make(map[keys.Set]map[string]int)
 		p.Weapon.Params = make(map[string]int)
-		p.Base.StartHP = -1
 		p.Base.Element = attributes.Geo
 		p.Weapon.Key = keys.DullBlade
 

--- a/internal/tests/reactable/reactable_test.go
+++ b/internal/tests/reactable/reactable_test.go
@@ -50,7 +50,6 @@ func makeCore(trgCount int) (*core.Core, []*enemy.Enemy) {
 		p.Sets = make(map[keys.Set]int)
 		p.SetParams = make(map[keys.Set]map[string]int)
 		p.Weapon.Params = make(map[string]int)
-		p.Base.StartHP = -1
 		p.Base.Element = attributes.Geo
 		p.Weapon.Key = keys.DullBlade
 

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -175,11 +175,17 @@ func (c *Core) AddChar(p profile.CharacterProfile) (int, error) {
 	}
 	index := c.Player.AddChar(char)
 
+	// set the hp
+	char.HPCurrent = -1
+	if hp, ok := p.Params["start_hp"]; ok {
+		char.HPCurrent = float64(hp)
+	}
+
 	// set the energy
 	char.Energy = char.EnergyMax
 	if e, ok := p.Params["start_energy"]; ok {
 		char.Energy = float64(e)
-		//some sanity check in case user decide to set energy = 10000000
+		// some sanity check in case user decide to set energy = 10000000
 		if char.Energy > char.EnergyMax {
 			char.Energy = char.EnergyMax
 		}

--- a/pkg/core/player/character/character.go
+++ b/pkg/core/player/character/character.go
@@ -144,12 +144,6 @@ func New(
 	if c.Talents.Burst < 1 || c.Talents.Burst > 10 {
 		return nil, fmt.Errorf("invalid talent lvl: burst - %v", c.Talents.Burst)
 	}
-	//setup base hp
-	if p.Base.StartHP > -1 {
-		c.HPCurrent = p.Base.StartHP
-	} else {
-		c.HPCurrent = -1 //to be cleared up in init
-	}
 
 	return c, nil
 }

--- a/pkg/core/player/character/profile/profile.go
+++ b/pkg/core/player/character/profile/profile.go
@@ -66,7 +66,6 @@ type CharacterBase struct {
 	Atk       float64            `json:"base_atk"`
 	Def       float64            `json:"base_def"`
 	Cons      int                `json:"cons"`
-	StartHP   float64            `json:"start_hp"`
 }
 
 type TalentProfile struct {

--- a/pkg/gcs/ast/item.go
+++ b/pkg/gcs/ast/item.go
@@ -97,7 +97,6 @@ const (
 	keywordRefine            // refine
 	keywordCons              // cons
 	keywordTalent            // talent
-	keywordStartHP           // start_hp
 	keywordCount             // count
 	keywordParams            // params
 	keywordLabel             // label

--- a/pkg/gcs/ast/keys.go
+++ b/pkg/gcs/ast/keys.go
@@ -31,7 +31,6 @@ var key = map[string]TokenType{
 	"refine":              keywordRefine,
 	"cons":                keywordCons,
 	"talent":              keywordTalent,
-	"start_hp":            keywordStartHP,
 	"count":               keywordCount,
 	"params":              keywordParams,
 	"label":               keywordLabel,

--- a/pkg/gcs/ast/parseCharacter.go
+++ b/pkg/gcs/ast/parseCharacter.go
@@ -34,7 +34,6 @@ func (p *Parser) newChar(key keys.Char) {
 	r.Sets = make(map[keys.Set]int)
 	r.SetParams = make(map[keys.Set]map[string]int)
 	r.Weapon.Params = make(map[string]int)
-	r.Base.StartHP = -1
 	r.Base.Element = keys.CharKeyToEle[key]
 	p.chars[key] = &r
 	p.charOrder = append(p.charOrder, key)
@@ -81,11 +80,6 @@ func parseCharDetails(p *Parser) (parseFn, error) {
 			c.Talents.Burst, err = itemNumberToInt(x)
 			if err != nil {
 				return nil, err
-			}
-		case keywordStartHP:
-			x, err = p.acceptSeqReturnLast(itemAssign, itemNumber)
-			if err == nil {
-				c.Base.StartHP, err = itemNumberToFloat64(x)
 			}
 		case ItemPlus: //optional flags
 			n = p.next()

--- a/pkg/reactable/reactable_test.go
+++ b/pkg/reactable/reactable_test.go
@@ -47,7 +47,6 @@ func testCore() *core.Core {
 	p.Sets = make(map[keys.Set]int)
 	p.SetParams = make(map[keys.Set]map[string]int)
 	p.Weapon.Params = make(map[string]int)
-	p.Base.StartHP = -1
 	p.Base.Element = attributes.Geo
 	p.Weapon.Key = keys.DullBlade
 


### PR DESCRIPTION
closes #857 

- before: hutao char lvl=90/90 cons=0 talent=9,9,9 start_hp=1;
- now: hutao char lvl=90/90 cons=0 talent=9,9,9 +params=[start_hp=1];

This is a breaking change for configs that utilize start_hp (mostly hu tao sims), but with this change start_hp and start_energy syntax will be consistent.