### PR TITLE
add mod extension logs and adjust status extension log

### DIFF
--- a/pkg/core/player/character/hitlag.go
+++ b/pkg/core/player/character/hitlag.go
@@ -56,7 +56,8 @@ func (c *CharWrapper) ApplyHitlag(factor, dur float64) {
 
 	for i, v := range c.mods {
 		if v.AffectedByHitlag() && v.Expiry() != -1 && v.Expiry() > *c.f {
-			c.mods[i].Extend(ext)
+			mod := c.mods[i]
+			mod.Extend(mod.Key(), c.log, c.Index, ext)
 			if c.debug {
 				logs = append(logs, fmt.Sprintf("%v: %v", v.Key(), v.Expiry()))
 			}

--- a/pkg/core/player/character/mods.go
+++ b/pkg/core/player/character/mods.go
@@ -178,7 +178,8 @@ func (c *CharWrapper) extendMod(key string, ext int) bool {
 		return false //nothing to extend is not active
 	}
 	//other wise add to expiry
-	c.mods[m].Extend(ext)
+	mod := c.mods[m]
+	mod.Extend(mod.Key(), c.log, c.Index, ext)
 	return true
 }
 

--- a/pkg/core/status/status.go
+++ b/pkg/core/status/status.go
@@ -58,7 +58,7 @@ func (t *Handler) Add(key string, dur int) {
 	t.status[key] = a
 }
 
-func (t *Handler) Extend(key string, dur int) {
+func (t *Handler) Extend(key string, amt int) {
 	a, ok := t.status[key]
 
 	//do nothing if status doesn't exist
@@ -66,11 +66,12 @@ func (t *Handler) Extend(key string, dur int) {
 		return
 	}
 
-	a.expiry += dur
+	a.expiry += amt
 	a.evt.SetEnded(a.expiry)
 	t.status[key] = a
-	t.log.NewEvent("status refreshed", glog.LogStatusEvent, -1).
+	t.log.NewEvent("status extended", glog.LogStatusEvent, -1).
 		Write("key", key).
+		Write("amt", amt).
 		Write("expiry", a.expiry)
 
 }

--- a/pkg/enemy/hitlag.go
+++ b/pkg/enemy/hitlag.go
@@ -28,7 +28,8 @@ func (e *Enemy) ApplyHitlag(factor, dur float64) {
 	//check resist mods
 	for i, v := range e.mods {
 		if v.AffectedByHitlag() && v.Expiry() != -1 && v.Expiry() > e.Core.F {
-			e.mods[i].Extend(ext)
+			mod := e.mods[i]
+			mod.Extend(mod.Key(), e.Core.Log, -1, ext)
 			if e.Core.Flags.LogDebug {
 				logs = append(logs, fmt.Sprintf("%v: %v", v.Key(), v.Expiry()))
 			}

--- a/pkg/modifier/modifier.go
+++ b/pkg/modifier/modifier.go
@@ -12,7 +12,7 @@ type Mod interface {
 	Event() glog.Event
 	SetEvent(glog.Event)
 	AffectedByHitlag() bool
-	Extend(int)
+	Extend(string, glog.Logger, int, int)
 }
 
 type Base struct {
@@ -29,12 +29,16 @@ func (t *Base) Expiry() int             { return t.ModExpiry + t.extension }
 func (t *Base) Event() glog.Event       { return t.event }
 func (t *Base) SetEvent(evt glog.Event) { t.event = evt }
 func (t *Base) AffectedByHitlag() bool  { return t.Hitlag }
-func (t *Base) Extend(amt int) {
+func (t *Base) Extend(key string, logger glog.Logger, index int, amt int) {
 	t.extension += amt
 	if t.extension < 0 {
 		t.extension = 0
 	}
 	t.event.SetEnded(t.Expiry())
+	logger.NewEvent("mod extended", glog.LogStatusEvent, -1).
+		Write("key", key).
+		Write("amt", amt).
+		Write("expiry", t.Expiry())
 }
 func (t *Base) SetExpiry(f int) {
 	if t.Dur == -1 {


### PR DESCRIPTION
closes #1291 

This means the status log category will be even more crowded, example: https://gcsim.app/v3/viewer/share/d932879c-8d28-4470-bf99-fa8806b8d39d