### PR TITLE
add xiangling a4 via param and adjust xianglingguoba status

### DIFF
--- a/internal/characters/xiangling/asc.go
+++ b/internal/characters/xiangling/asc.go
@@ -1,5 +1,14 @@
 package xiangling
 
+import (
+	"fmt"
+
+	"github.com/genshinsim/gcsim/pkg/core/attributes"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
+	"github.com/genshinsim/gcsim/pkg/core/player/character"
+	"github.com/genshinsim/gcsim/pkg/modifier"
+)
+
 // Increases the flame range of Guoba by 20%.
 func (c *char) a1() {
 	if c.Base.Ascension < 1 {
@@ -8,5 +17,28 @@ func (c *char) a1() {
 	c.guobaFlameRange *= 1.2
 }
 
-// A4 is not implemented:
-// TODO: When Guoba Attack's effect ends, Guoba leaves a chili pepper on the spot where it disappeared. Picking up a chili pepper increases ATK by 10% for 10s.
+// When Guoba Attack's effect ends, Guoba leaves a chili pepper on the spot where it disappeared. Picking up a chili pepper increases ATK by 10% for 10s.
+func (c *char) a4(a4Delay int) {
+	if c.Base.Ascension < 4 {
+		return
+	}
+
+	m := make([]float64, attributes.EndStatType)
+	m[attributes.ATKP] = 0.10
+	// pick up chili pepper on active char after a user-specified delay relative to guoba expiry
+	c.Core.Tasks.Add(func() {
+		active := c.Core.Player.ActiveChar()
+		active.AddStatMod(character.StatMod{
+			Base:         modifier.NewBaseWithHitlag("xiangling-a4", 10*60),
+			AffectedStat: attributes.ATKP,
+			Amount: func() ([]float64, bool) {
+				return m, true
+			},
+		})
+		c.Core.Log.NewEvent(
+			fmt.Sprintf("xiangling a4 chili pepper picked up by %v", active.Base.Key.String()),
+			glog.LogCharacterEvent,
+			c.Index,
+		)
+	}, a4Delay)
+}

--- a/internal/characters/xiangling/skill.go
+++ b/internal/characters/xiangling/skill.go
@@ -37,15 +37,27 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		Mult:       guobaTick[c.TalentLvlSkill()],
 	}
 
+	// delay in frames from guoba expiry until the a4 chili pepper is picked up
+	a4Delay, ok := p["a4_delay"]
+	if !ok {
+		a4Delay = 0
+	}
+	if a4Delay < 0 {
+		a4Delay = 0
+	}
+	if a4Delay > 10*60 {
+		a4Delay = 10 * 60
+	}
+
 	// guoba spawns at cd frame
 	c.Core.Status.Add("xianglingguoba", 500+13)
 
 	// lasts 7.3 seconds, shoots every 100 frames
-	// delay := 126 // first tick at 126
-	// snap := c.Snapshot(&ai)
 	guoba := c.newGuoba(ai)
 	c.Core.Tasks.Add(func() {
 		c.Core.Combat.AddGadget(guoba)
+		// queue up a4 relative to guoba expiry
+		c.a4(guoba.Duration + a4Delay)
 	}, 13)
 
 	c.SetCDWithDelay(action.ActionSkill, 12*60, 13)

--- a/internal/characters/xiangling/skill.go
+++ b/internal/characters/xiangling/skill.go
@@ -50,11 +50,10 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	}
 
 	// guoba spawns at cd frame
-	c.Core.Status.Add("xianglingguoba", 500+13)
-
 	// lasts 7.3 seconds, shoots every 100 frames
-	guoba := c.newGuoba(ai)
 	c.Core.Tasks.Add(func() {
+		guoba := c.newGuoba(ai)
+		c.AddStatus("xianglingguoba", guoba.Duration, false)
 		c.Core.Combat.AddGadget(guoba)
 		// queue up a4 relative to guoba expiry
 		c.a4(guoba.Duration + a4Delay)


### PR DESCRIPTION
closes #1132 

- `skill[a4_delay=1]` for picking up on active char 1f (1 <= delay <= 600) after guoba expiry (concept taken from sapwood blade)
- adjust `xianglingguoba` status: 
   - make it start at t=13f instead of t=0s (relative to skill cast) since that's when guoba actually spawns
   - move it to xiangling's column in the debug log by making it a char status
   - make the duration line up with actual guoba duration (500 -> 438)