### PR TITLE
change some mods from expiry -1

### DIFF
--- a/internal/artifacts/crimson/crimson.go
+++ b/internal/artifacts/crimson/crimson.go
@@ -21,7 +21,6 @@ func init() {
 
 type Set struct {
 	stacks int
-	key    string
 	Index  int
 }
 
@@ -33,7 +32,6 @@ const cw4pc = "cw-4pc"
 func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[string]int) (artifact.Set, error) {
 	s := Set{}
 	s.stacks = 0
-	s.key = fmt.Sprintf("%v-cw-4pc", char.Base.Key.String())
 
 	if count >= 2 {
 		m := make([]float64, attributes.EndStatType)
@@ -74,7 +72,7 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 				Write("current stacks", s.stacks)
 			char.AddStatus(cw4pc, 10*60, true)
 			return false
-		}, s.key)
+		}, fmt.Sprintf("%v-cw-4pc", char.Base.Key.String()))
 
 		char.AddReactBonusMod(character.ReactBonusMod{
 			Base: modifier.NewBase("crimson-4pc", -1),

--- a/internal/artifacts/crimson/crimson.go
+++ b/internal/artifacts/crimson/crimson.go
@@ -27,7 +27,7 @@ type Set struct {
 func (s *Set) SetIndex(idx int) { s.Index = idx }
 func (s *Set) Init() error      { return nil }
 
-const cw4pc = "cw-4pc"
+const cw4pc = "crimson-4pc-stacks"
 
 func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[string]int) (artifact.Set, error) {
 	s := Set{}
@@ -35,25 +35,18 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 
 	if count >= 2 {
 		m := make([]float64, attributes.EndStatType)
+		m[attributes.PyroP] = 0.15
 		char.AddStatMod(character.StatMod{
 			Base:         modifier.NewBase("crimson-2pc", -1),
 			AffectedStat: attributes.PyroP,
 			Amount: func() ([]float64, bool) {
-				if !char.StatusIsActive(cw4pc) {
-					s.stacks = 0
-				}
-				mult := 0.5*float64(s.stacks) + 1
-				m[attributes.PyroP] = 0.15 * mult
-				if mult > 1 {
-					c.Log.NewEvent("crimson witch 4pc", glog.LogArtifactEvent, char.Index).Write("mult", mult)
-				}
-
 				return m, true
 			},
 		})
 	}
 
 	if count >= 4 {
+		mStacks := make([]float64, attributes.EndStatType)
 		// post snap shot to increase stacks
 		c.Events.Subscribe(event.OnSkill, func(args ...interface{}) bool {
 			if c.Player.Active() != char.Index {
@@ -70,7 +63,16 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 
 			c.Log.NewEvent("crimson witch 4pc adding stack", glog.LogArtifactEvent, char.Index).
 				Write("current stacks", s.stacks)
-			char.AddStatus(cw4pc, 10*60, true)
+
+			mStacks[attributes.PyroP] = 0.15 * 0.5 * float64(s.stacks)
+			char.AddStatMod(character.StatMod{
+				Base:         modifier.NewBaseWithHitlag(cw4pc, 10*60),
+				AffectedStat: attributes.PyroP,
+				Amount: func() ([]float64, bool) {
+					return mStacks, true
+				},
+			})
+
 			return false
 		}, fmt.Sprintf("%v-cw-4pc", char.Base.Key.String()))
 

--- a/internal/artifacts/flowerofparadiselost/flowerofparadiselost.go
+++ b/internal/artifacts/flowerofparadiselost/flowerofparadiselost.go
@@ -66,11 +66,7 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 				default:
 					return 0, false
 				}
-
-				if !char.StatusIsActive(buffKey) {
-					s.stacks = 0
-				}
-				return 0.4 * (1 + float64(s.stacks)*0.25), false
+				return 0.4, false
 			},
 		})
 
@@ -87,14 +83,27 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 			if !char.StatusIsActive(buffKey) {
 				s.stacks = 0
 			}
-			s.stacks++
-			if s.stacks > 4 {
-				s.stacks = 4
+			if s.stacks < 4 {
+				s.stacks++
 			}
 
 			c.Log.NewEvent("flower of paradise lost 4pc adding stack", glog.LogArtifactEvent, char.Index).
 				Write("stacks", s.stacks)
-			char.AddStatus(buffKey, 10*60, true)
+
+			char.AddReactBonusMod(character.ReactBonusMod{
+				Base: modifier.NewBaseWithHitlag(buffKey, 10*60),
+				Amount: func(ai combat.AttackInfo) (float64, bool) {
+					switch ai.AttackTag {
+					case attacks.AttackTagBloom:
+					case attacks.AttackTagHyperbloom:
+					case attacks.AttackTagBurgeon:
+					default:
+						return 0, false
+					}
+					return 0.4 * float64(s.stacks) * 0.25, false
+				},
+			})
+
 			return false
 		}
 

--- a/internal/characters/mika/asc.go
+++ b/internal/characters/mika/asc.go
@@ -33,23 +33,16 @@ func (c *char) addDetectorStack() {
 //
 // The Soulwind state can have a maximum of 3 Detector stacks, and if Starfrost Swirl is cast again during this duration, the pre-existing
 // Soulwind state and all its Detector stacks will be cleared.
-func (c *char) a1() {
+func (c *char) a1(char *character.CharWrapper) {
 	m := make([]float64, attributes.EndStatType)
-	for i, char := range c.Core.Player.Chars() {
-		idx := i
-		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBaseWithHitlag(a1Buff, -1),
-			AffectedStat: attributes.PhyP,
-			Amount: func() ([]float64, bool) {
-				if !char.StatusIsActive(skillBuffKey) {
-					c.SetTag(a1Stacks, 0)
-					return nil, false
-				}
-				m[attributes.PhyP] = 0.1 * float64(c.Tag(a1Stacks))
-				return m, c.Core.Player.Active() == idx
-			},
-		})
-	}
+	char.AddStatMod(character.StatMod{
+		Base:         modifier.NewBaseWithHitlag(a1Buff, skillBuffDuration),
+		AffectedStat: attributes.PhyP,
+		Amount: func() ([]float64, bool) {
+			m[attributes.PhyP] = 0.1 * float64(c.Tag(a1Stacks))
+			return m, c.Core.Player.Active() == char.Index
+		},
+	})
 }
 
 // When an active character affected by both Skyfeather Song's Eagleplume and Starfrost Swirl's Soulwind at once scores a CRIT Hit with their

--- a/internal/characters/mika/cons.go
+++ b/internal/characters/mika/cons.go
@@ -31,7 +31,7 @@ func (c *char) c2() func(combat.AttackCB) {
 // Additionally, active characters affected by Soulwind will deal 60% more Physical CRIT DMG.
 func (c *char) c6(char *character.CharWrapper) {
 	char.AddAttackMod(character.AttackMod{
-		Base: modifier.NewBaseWithHitlag("mika-c6", 12*60),
+		Base: modifier.NewBaseWithHitlag("mika-c6", skillBuffDuration),
 		Amount: func(atk *combat.AttackEvent, _ combat.Target) ([]float64, bool) {
 			if c.Core.Player.Active() != char.Index {
 				return nil, false

--- a/internal/characters/mika/mika.go
+++ b/internal/characters/mika/mika.go
@@ -43,9 +43,6 @@ func (c *char) Init() error {
 	c.healIcd = 2.5 * 60
 
 	c.onBurstHeal()
-	if c.Base.Ascension >= 1 {
-		c.a1()
-	}
 	if c.Base.Ascension >= 4 {
 		c.a4()
 		c.maxDetectorStacks++

--- a/internal/characters/mika/skill.go
+++ b/internal/characters/mika/skill.go
@@ -25,7 +25,8 @@ const (
 	skillHoldTravel     = 3
 	rimestarShardTravel = 46
 
-	skillBuffKey = "soulwind"
+	skillBuffKey      = "soulwind"
+	skillBuffDuration = 12 * 60
 )
 
 func init() {
@@ -218,12 +219,16 @@ func (c *char) applyBuffs() {
 func (c *char) skillBuff() {
 	for _, char := range c.Core.Player.Chars() {
 		char.AddStatMod(character.StatMod{
-			Base:         modifier.NewBaseWithHitlag(skillBuffKey, 12*60),
+			Base:         modifier.NewBaseWithHitlag(skillBuffKey, skillBuffDuration),
 			AffectedStat: attributes.AtkSpd,
 			Amount: func() ([]float64, bool) {
 				return c.skillbuff, true
 			},
 		})
+
+		if c.Base.Ascension >= 1 {
+			c.a1(char)
+		}
 
 		if c.Base.Cons >= 6 {
 			c.c6(char)

--- a/internal/characters/razor/burst.go
+++ b/internal/characters/razor/burst.go
@@ -36,7 +36,16 @@ func init() {
 func (c *char) Burst(p map[string]int) action.ActionInfo {
 	c.Core.Tasks.Add(func() {
 		c.a1CDReset()
-		c.AddStatus(burstBuffKey, 15*60, true)
+		// atk spd
+		val := make([]float64, attributes.EndStatType)
+		val[attributes.AtkSpd] = burstATKSpeed[c.TalentLvlBurst()]
+		c.AddStatMod(character.StatMod{
+			Base:         modifier.NewBaseWithHitlag(burstBuffKey, 15*60),
+			AffectedStat: attributes.AtkSpd,
+			Amount: func() ([]float64, bool) {
+				return val, true
+			},
+		})
 	}, burstHitmark)
 
 	ai := combat.AttackInfo{
@@ -68,21 +77,6 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 		CanQueueAfter:   burstHitmark,
 		State:           action.BurstState,
 	}
-}
-
-func (c *char) speedBurst() {
-	val := make([]float64, attributes.EndStatType)
-	val[attributes.AtkSpd] = burstATKSpeed[c.TalentLvlBurst()]
-	c.AddStatMod(character.StatMod{
-		Base:         modifier.NewBase("speed-burst", -1),
-		AffectedStat: attributes.AtkSpd,
-		Amount: func() ([]float64, bool) {
-			if !c.StatusIsActive(burstBuffKey) {
-				return nil, false
-			}
-			return val, true
-		},
-	})
 }
 
 func (c *char) wolfBurst(normalCounter int) func(combat.AttackCB) {

--- a/internal/characters/razor/razor.go
+++ b/internal/characters/razor/razor.go
@@ -4,7 +4,6 @@ import (
 	tmpl "github.com/genshinsim/gcsim/internal/template/character"
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/action"
-	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/core/player/character/profile"
@@ -16,11 +15,10 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	sigils          int
-	skillSigilBonus []float64
-	a4Bonus         []float64
-	c1bonus         []float64
-	c2bonus         []float64
+	sigils  int
+	a4Bonus []float64
+	c1bonus []float64
+	c2bonus []float64
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {
@@ -38,10 +36,6 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 }
 
 func (c *char) Init() error {
-	// skill
-	c.skillSigilBonus = make([]float64, attributes.EndStatType)
-	c.energySigil()
-
 	// burst
 	c.onSwapClearBurst()
 

--- a/internal/characters/razor/razor.go
+++ b/internal/characters/razor/razor.go
@@ -43,7 +43,6 @@ func (c *char) Init() error {
 	c.energySigil()
 
 	// burst
-	c.speedBurst()
 	c.onSwapClearBurst()
 
 	c.a4()

--- a/internal/weapons/claymore/beacon/beacon.go
+++ b/internal/weapons/claymore/beacon/beacon.go
@@ -41,29 +41,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	const skillKey = "beacon-of-the-reed-sea-skill"
 	const damagedKey = "beacon-of-the-reed-sea-damaged"
 
-	mATK := make([]float64, attributes.EndStatType)
 	mHP := make([]float64, attributes.EndStatType)
 	mHP[attributes.HPP] = 0.24 + float64(r)*.08
-	char.AddStatMod(character.StatMod{
-		Base:         modifier.NewBase("beacon-of-the-reed-sea-atk", -1),
-		AffectedStat: attributes.ATKP,
-		Amount: func() ([]float64, bool) {
-			count := 0
-
-			if char.StatusIsActive(skillKey) {
-				count++
-			}
-			if char.StatusIsActive(damagedKey) {
-				count++
-			}
-
-			atkbonus := stackAtk * float64(count)
-
-			mATK[attributes.ATKP] = atkbonus
-
-			return mATK, true
-		},
-	})
 	char.AddStatMod(character.StatMod{
 		Base:         modifier.NewBase("beacon-of-the-reed-sea-hp", -1),
 		AffectedStat: attributes.HPP,
@@ -75,19 +54,34 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		},
 	})
 
+	mATK := make([]float64, attributes.EndStatType)
 	c.Events.Subscribe(event.OnEnemyDamage, func(args ...interface{}) bool {
 		atk := args[1].(*combat.AttackEvent)
 		if atk.Info.ActorIndex != char.Index {
 			return false
 		}
-
-		if atk.Info.AttackTag == attacks.AttackTagElementalArt || atk.Info.AttackTag == attacks.AttackTagElementalArtHold {
-			char.AddStatus(skillKey, stackDuration, true)
-			if damaged > 0 {
-				char.AddStatus(damagedKey, stackDuration, true)
-			}
-
+		if atk.Info.AttackTag != attacks.AttackTagElementalArt && atk.Info.AttackTag != attacks.AttackTagElementalArtHold {
+			return false
 		}
+
+		mATK[attributes.ATKP] = stackAtk
+		char.AddStatMod(character.StatMod{
+			Base:         modifier.NewBaseWithHitlag(skillKey, stackDuration),
+			AffectedStat: attributes.ATKP,
+			Amount: func() ([]float64, bool) {
+				return mATK, true
+			},
+		})
+		if damaged > 0 {
+			char.AddStatMod(character.StatMod{
+				Base:         modifier.NewBaseWithHitlag(damagedKey, stackDuration),
+				AffectedStat: attributes.ATKP,
+				Amount: func() ([]float64, bool) {
+					return mATK, true
+				},
+			})
+		}
+
 		return false
 	}, fmt.Sprintf("beacon-of-the-reed-sea-%v", char.Base.Key.String()))
 


### PR DESCRIPTION
working on #203 

- done
	- crimson witch 4pc -> 2pc increase (also adjust mod name: cw-4pc -> crimson-4pc-stacks)
	- flower of paradise lost 4pc increase
	- mika a1
	- razor q speed burst (also adjust mod name: speed-burst -> razor-q)
	- razor e energy sigil (also adjust mod name: er-sigil/razor-sigil-duration -> razor-sigil)
	- mappa mare (also adjust mod name: mappa/mappa-mare-stacks -> mappa-mare)
	- beacon
- TODO (part of separate PR after mods and stats array rewrite since these require new enemy mods, namely ones to influence dmg bonus/crit rate buffs tied to an enemy):
	- ganyu c4 damage bonus
	- mona burst damage bonus
	- mona c4 crit rate
	- toukabou shigure damage bonus
- considered changing these but I don't think it's feasible (**person reviewing the PR should double-check**):
	- husk 4pc
	- nymph's dream 4pc
	- aloy coil mod
	- ayaka c6
	- ayato c2
	- candace a4
	- candace burst init
	- heizou c6
	- sayu c2
	- shenhe c4
	- polar star
	- thundering pulse
	- fruit of fulfillment 
	- serpent spine 
	- alley flash 
	- mistsplitter 
	- lost prayer
