### PR TITLE
fix shenhe c4

### DIFF
--- a/internal/characters/shenhe/shenhe.go
+++ b/internal/characters/shenhe/shenhe.go
@@ -19,7 +19,6 @@ type char struct {
 	skillBuff []float64
 	burstBuff []float64
 	c2buff    []float64
-	c4bonus   []float64
 	c4count   int
 }
 
@@ -56,9 +55,5 @@ func (c *char) Init() error {
 		c.c2buff[attributes.CD] = 0.15
 	}
 
-	if c.Base.Cons >= 4 {
-		c.c4bonus = make([]float64, attributes.EndStatType)
-		c.c4Init()
-	}
 	return nil
 }

--- a/internal/characters/shenhe/skill.go
+++ b/internal/characters/shenhe/skill.go
@@ -72,19 +72,22 @@ func (c *char) skillPress(p map[string]int) action.ActionInfo {
 		IsDeployable:       true,
 	}
 
-	c.Core.QueueAttack(
-		ai,
-		combat.NewCircleHit(
-			c.Core.Combat.Player(),
-			c.Core.Combat.PrimaryTarget(),
-			nil,
-			0.8,
-		),
-		skillPressHitmark,
-		skillPressHitmark,
-		c.makePressParticleCB(),
-		c.makeC4ResetCB(),
-	)
+	c.Core.Tasks.Add(func() {
+		snap := c.Snapshot(&ai)
+		snap.Stats[attributes.DmgP] += c.c4()
+		c.Core.QueueAttackWithSnap(
+			ai,
+			snap,
+			combat.NewCircleHit(
+				c.Core.Combat.Player(),
+				c.Core.Combat.PrimaryTarget(),
+				nil,
+				0.8,
+			),
+			0,
+			c.makePressParticleCB(),
+		)
+	}, skillPressHitmark)
 
 	if c.Base.Ascension >= 4 {
 		c.Core.Tasks.Add(c.skillPressBuff, skillPressCDStart+1)
@@ -126,14 +129,17 @@ func (c *char) skillHold(p map[string]int) action.ActionInfo {
 		Mult:       skillHold[c.TalentLvlSkill()],
 	}
 
-	c.Core.QueueAttack(
-		ai,
-		combat.NewCircleHitOnTarget(c.Core.Combat.Player(), geometry.Point{Y: 1.5}, 4),
-		skillHoldHitmark,
-		skillHoldHitmark,
-		c.holdParticleCB,
-		c.makeC4ResetCB(),
-	)
+	c.Core.Tasks.Add(func() {
+		snap := c.Snapshot(&ai)
+		snap.Stats[attributes.DmgP] += c.c4()
+		c.Core.QueueAttackWithSnap(
+			ai,
+			snap,
+			combat.NewCircleHitOnTarget(c.Core.Combat.Player(), geometry.Point{Y: 1.5}, 4),
+			0,
+			c.holdParticleCB,
+		)
+	}, skillHoldHitmark)
 
 	if c.Base.Ascension >= 4 {
 		c.Core.Tasks.Add(c.skillHoldBuff, skillHoldCDStart+1)


### PR DESCRIPTION
- change from expiry -1 to modifying skill snapshot instead 
- only applied to first enemy in AoE before
- stack gain via E was only +1 in AoE before

live: https://gcsim.app/v3/viewer/share/dc0df522-8415-465e-a89c-7d4c66680c31
pr: https://gcsim.app/v3/viewer/share/86295336-c2d7-4b42-9e59-3b4225127751