### PR TITLE
fix cyno cd mechanics

### DIFF
--- a/internal/characters/cyno/burst.go
+++ b/internal/characters/cyno/burst.go
@@ -29,10 +29,6 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	c.c4Counter = 0      // reset c4 stacks
 	c.c6Stacks = 0       // same as above
 
-	if !c.StatusIsActive(BurstKey) {
-		c.ReduceActionCooldown(action.ActionSkill, 270)
-	}
-
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.EM] = 100
 	c.AddStatMod(character.StatMod{
@@ -100,11 +96,6 @@ func (c *char) onBurstExpiry(burstSrc int) {
 	}
 	if c.StatusIsActive(BurstKey) {
 		return
-	}
-	cd := skillCD - (c.Core.F - c.lastSkillCast)
-	if cd > 0 {
-		c.ResetActionCooldown(action.ActionSkill)
-		c.SetCD(action.ActionSkill, cd)
 	}
 	c.burstSrc = -1 // make sure we don't call other burst fns
 }

--- a/internal/characters/cyno/skill.go
+++ b/internal/characters/cyno/skill.go
@@ -17,6 +17,9 @@ const (
 
 var (
 	skillCD       = 450
+	skillBCD      = 180
+	skillCDDelay  = 17
+	skillBCDDelay = 26
 	skillHitmark  = 21
 	skillBHitmark = 28
 	skillFrames   []int
@@ -66,8 +69,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		c.makeParticleCB(false),
 	)
 
-	c.lastSkillCast = c.Core.F + 17
-	c.SetCDWithDelay(action.ActionSkill, skillCD, 17)
+	c.Core.Tasks.Add(c.triggerSkillCD, skillCDDelay)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(skillFrames),
@@ -144,8 +146,7 @@ func (c *char) skillB() action.ActionInfo {
 
 	c.tryBurstPPSlide(skillBHitmark)
 
-	c.lastSkillCast = c.Core.F + 26
-	c.SetCDWithDelay(action.ActionSkill, 180, 26)
+	c.Core.Tasks.Add(c.triggerSkillCD, skillBCDDelay)
 
 	return action.ActionInfo{
 		Frames:          frames.NewAbilFunc(skillBFrames),
@@ -153,6 +154,12 @@ func (c *char) skillB() action.ActionInfo {
 		CanQueueAfter:   skillBFrames[action.ActionDash], // earliest cancel
 		State:           action.SkillState,
 	}
+}
+
+func (c *char) triggerSkillCD() {
+	c.ResetActionCooldown(action.ActionSkill)
+	c.SetCD(action.ActionSkill, skillCD)
+	c.SetCD(action.ActionLowPlunge, skillBCD)
 }
 
 func (c *char) makeParticleCB(burst bool) combat.AttackCBFunc {


### PR DESCRIPTION
closes #1117 (4tf proc during q now has an effect on the e cd post q expiry)
open to a less hacky solution that allows for proper cooldown reduction tracking

- abuse low plunge action for e (in q) cooldown tracking
- sims checking for e (in q) cooldown need to change from `.cyno.skill.ready` to `.cyno.low_plunge.ready`