### PR TITLE
refactor char current hp from flat into ratio

### DIFF
--- a/internal/artifacts/berserker/berserker.go
+++ b/internal/artifacts/berserker/berserker.go
@@ -43,8 +43,7 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 		char.AddAttackMod(character.AttackMod{
 			Base: modifier.NewBase("berserker-4pc", -1),
 			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-				maxhp := char.MaxHP()
-				if char.HPCurrent > 0.70*maxhp {
+				if char.CurrentHPRatio() > 0.7 {
 					return nil, false
 				}
 				return m, true

--- a/internal/characters/baizhu/asc.go
+++ b/internal/characters/baizhu/asc.go
@@ -25,7 +25,7 @@ func (c *char) a1() {
 		AffectedStat: attributes.Heal,
 		Amount: func() ([]float64, bool) {
 			active := c.Core.Player.ActiveChar()
-			if active.HPCurrent/active.MaxHP() < 0.5 {
+			if active.CurrentHPRatio() < 0.5 {
 				return mHeal, true
 			}
 			return nil, false
@@ -40,7 +40,7 @@ func (c *char) a1() {
 		AffectedStat: attributes.DendroP,
 		Amount: func() ([]float64, bool) {
 			active := c.Core.Player.ActiveChar()
-			if active.HPCurrent/active.MaxHP() >= 0.5 {
+			if active.CurrentHPRatio() >= 0.5 {
 				return mDendroP, true
 			}
 			return nil, false

--- a/internal/characters/barbara/cons.go
+++ b/internal/characters/barbara/cons.go
@@ -56,8 +56,8 @@ func (c *char) checkc6() {
 	//grab the active char
 	char := c.Core.Player.ActiveChar()
 	//if dead, revive back to 1 hp
-	if char.HPCurrent <= -1 {
-		c.HPCurrent = c.MaxHP()
+	if char.CurrentHPRatio() <= 0 {
+		char.SetHPByAmount(1)
 	}
 
 	c.c6icd = c.Core.F + 60*60*15

--- a/internal/characters/bennett/burst.go
+++ b/internal/characters/bennett/burst.go
@@ -101,7 +101,7 @@ func (c *char) applyBennettField(stats [attributes.EndStatType]float64) func() {
 
 		active := c.Core.Player.ActiveChar()
 		//heal if under 70%
-		if active.HPCurrent/active.MaxHP() < .7 {
+		if active.CurrentHPRatio() < 0.7 {
 			c.Core.Player.Heal(player.HealInfo{
 				Caller:  c.Index,
 				Target:  active.Index,
@@ -117,7 +117,7 @@ func (c *char) applyBennettField(stats [attributes.EndStatType]float64) func() {
 			threshold = 0
 		}
 		// Activate attack buff
-		if active.HPCurrent/active.MaxHP() > threshold {
+		if active.CurrentHPRatio() > threshold {
 			// add weapon infusion
 			if c.Base.Cons >= 6 {
 				switch active.Weapon.Class {

--- a/internal/characters/bennett/cons.go
+++ b/internal/characters/bennett/cons.go
@@ -14,7 +14,7 @@ func (c *char) c2() {
 		Base:         modifier.NewBase("bennett-c2", -1),
 		AffectedStat: attributes.ER,
 		Amount: func() ([]float64, bool) {
-			return m, c.HPCurrent/c.MaxHP() < 0.7
+			return m, c.CurrentHPRatio() < 0.7
 		},
 	})
 }

--- a/internal/characters/chongyun/cons.go
+++ b/internal/characters/chongyun/cons.go
@@ -53,7 +53,7 @@ func (c *char) c6() {
 				if !ok {
 					return nil, false
 				}
-				if x.HP()/x.MaxHP() < c.HPCurrent/c.MaxHP() {
+				if x.HP()/x.MaxHP() < c.CurrentHPRatio() {
 					return m, true
 				}
 				return nil, false

--- a/internal/characters/diona/cons.go
+++ b/internal/characters/diona/cons.go
@@ -30,7 +30,7 @@ func (c *char) c6() {
 			}
 			//add 200EM to active char
 			active := c.Core.Player.ActiveChar()
-			if active.HPCurrent/active.MaxHP() > 0.5 {
+			if active.CurrentHPRatio() > 0.5 {
 				active.AddStatMod(character.StatMod{
 					Base:         modifier.NewBaseWithHitlag("diona-c6", 120),
 					AffectedStat: attributes.EM,

--- a/internal/characters/dori/cons.go
+++ b/internal/characters/dori/cons.go
@@ -47,7 +47,7 @@ func (c *char) c2(travel int) {
 // ·When their Energy is less than 50%, they gain 30% Energy Recharge.
 func (c *char) c4() {
 	active := c.Core.Player.ActiveChar()
-	if active.HPCurrent/active.MaxHP() < 0.5 {
+	if active.CurrentHPRatio() < 0.5 {
 		active.AddHealBonusMod(character.HealBonusMod{
 			Base: modifier.NewBaseWithHitlag("dori-c4-healbonus", 48),
 			Amount: func() (float64, bool) {

--- a/internal/characters/heizou/heizou.go
+++ b/internal/characters/heizou/heizou.go
@@ -45,7 +45,7 @@ func (c *char) Init() error {
 
 	// make sure to use the same key everywhere so that these passives don't stack
 	c.Core.Player.AddStamPercentMod("utility-dash", -1, func(a action.Action) (float64, bool) {
-		if a == action.ActionDash && c.HPCurrent > 0 {
+		if a == action.ActionDash && c.CurrentHPRatio() > 0 {
 			return -0.2, false
 		}
 		return 0, false

--- a/internal/characters/hutao/asc.go
+++ b/internal/characters/hutao/asc.go
@@ -46,7 +46,7 @@ func (c *char) a4() {
 		Base:         modifier.NewBase("hutao-a4", -1),
 		AffectedStat: attributes.PyroP,
 		Amount: func() ([]float64, bool) {
-			if c.HPCurrent/c.MaxHP() <= 0.5 {
+			if c.CurrentHPRatio() <= 0.5 {
 				return c.a4buff, true
 			}
 			return nil, false

--- a/internal/characters/hutao/burst.go
+++ b/internal/characters/hutao/burst.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func (c *char) Burst(p map[string]int) action.ActionInfo {
-	low := (c.HPCurrent / c.MaxHP()) <= 0.5
+	low := c.CurrentHPRatio() <= 0.5
 	mult := burst[c.TalentLvlBurst()]
 	regen := regen[c.TalentLvlBurst()]
 	if low {

--- a/internal/characters/hutao/cons.go
+++ b/internal/characters/hutao/cons.go
@@ -41,16 +41,16 @@ func (c *char) checkc6(check1HP bool) {
 		return
 	}
 	// check if hp less than 25%
-	if c.HPCurrent/c.MaxHP() > .25 {
+	if c.CurrentHPRatio() > 0.25 {
 		return
 	}
 	// check if hp is less than 2 for the 2s check
-	if check1HP && c.HPCurrent >= 2 {
+	if check1HP && c.CurrentHP() >= 2 {
 		return
 	}
 	// if dead, revive back to 1 hp
-	if c.HPCurrent <= -1 {
-		c.HPCurrent = 1
+	if c.CurrentHPRatio() <= 0 {
+		c.SetHPByAmount(1)
 	}
 
 	//increase crit rate to 100%

--- a/internal/characters/hutao/skill.go
+++ b/internal/characters/hutao/skill.go
@@ -55,7 +55,7 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 	c.Core.Player.Drain(player.DrainInfo{
 		ActorIndex: c.Index,
 		Abil:       "Paramita Papilio",
-		Amount:     .30 * c.HPCurrent,
+		Amount:     0.30 * c.CurrentHP(),
 	})
 
 	//trigger 0 damage attack; matters because this breaks freeze

--- a/internal/characters/kaeya/cons.go
+++ b/internal/characters/kaeya/cons.go
@@ -86,7 +86,7 @@ func (c *char) c4() {
 			return false
 		}
 		maxhp := c.MaxHP()
-		if c.HPCurrent/maxhp < .2 {
+		if c.CurrentHPRatio() < 0.2 {
 			c.c4icd = c.Core.F + 3600
 			c.Core.Player.Shields.Add(&shield.Tmpl{
 				ActorIndex: c.Index,

--- a/internal/characters/kaeya/kaeya.go
+++ b/internal/characters/kaeya/kaeya.go
@@ -36,7 +36,7 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 func (c *char) Init() error {
 	// make sure to use the same key everywhere so that these passives don't stack
 	c.Core.Player.AddStamPercentMod("utility-dash", -1, func(a action.Action) (float64, bool) {
-		if a == action.ActionDash && c.HPCurrent > 0 {
+		if a == action.ActionDash && c.CurrentHPRatio() > 0 {
 			return -0.2, false
 		}
 		return 0, false

--- a/internal/characters/kazuha/kazuha.go
+++ b/internal/characters/kazuha/kazuha.go
@@ -45,7 +45,7 @@ func (c *char) Init() error {
 
 	// make sure to use the same key everywhere so that these passives don't stack
 	c.Core.Player.AddStamPercentMod("utility-dash", -1, func(a action.Action) (float64, bool) {
-		if a == action.ActionDash && c.HPCurrent > 0 {
+		if a == action.ActionDash && c.CurrentHPRatio() > 0 {
 			return -0.2, false
 		}
 		return 0, false

--- a/internal/characters/kokomi/burst.go
+++ b/internal/characters/kokomi/burst.go
@@ -132,7 +132,7 @@ func (c *char) makeBurstHealCB() combat.AttackCBFunc {
 			// C2 handling
 			// Sangonomiya Kokomi gains the following Healing Bonuses with regard to characters with 50% or less HP via the following methods:
 			// Nereid's Ascension Normal and Charged Attacks: 0.6% of Kokomi's Max HP.
-			if c.Base.Cons >= 2 && char.HPCurrent/char.MaxHP() <= .5 {
+			if c.Base.Cons >= 2 && char.CurrentHPRatio() <= 0.5 {
 				bonus := 0.006 * c.MaxHP()
 				src += bonus
 				c.Core.Log.NewEvent("kokomi c2 proc'd", glog.LogCharacterEvent, char.Index).

--- a/internal/characters/kokomi/cons.go
+++ b/internal/characters/kokomi/cons.go
@@ -71,7 +71,7 @@ func (c *char) c6() {
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.HydroP] = .4
 	for _, char := range c.Core.Player.Chars() {
-		if char.HPCurrent/char.MaxHP() < .8 {
+		if char.CurrentHPRatio() < 0.8 {
 			continue
 		}
 		c.AddStatMod(character.StatMod{

--- a/internal/characters/kokomi/skill.go
+++ b/internal/characters/kokomi/skill.go
@@ -115,7 +115,7 @@ func (c *char) skillTick(d *combat.AttackEvent) {
 		// Kurage's Oath Bake-Kurage: 4.5% of Kokomi's Max HP.
 		if c.Base.Cons >= 2 {
 			active := c.Core.Player.ActiveChar()
-			if active.HPCurrent/active.MaxHP() <= .5 {
+			if active.CurrentHPRatio() <= 0.5 {
 				bonus := 0.045 * maxhp
 				src += bonus
 				c.Core.Log.NewEvent("kokomi c2 proc'd", glog.LogCharacterEvent, active.Index).

--- a/internal/characters/kuki/asc.go
+++ b/internal/characters/kuki/asc.go
@@ -17,7 +17,7 @@ func (c *char) a1() {
 		Base:         modifier.NewBase("kuki-a1", -1),
 		AffectedStat: attributes.Heal,
 		Amount: func() ([]float64, bool) {
-			if c.HPCurrent/c.MaxHP() <= 0.5 {
+			if c.CurrentHPRatio() <= 0.5 {
 				return m, true
 			}
 			return nil, false

--- a/internal/characters/kuki/burst.go
+++ b/internal/characters/kuki/burst.go
@@ -35,7 +35,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	snap := c.Snapshot(&ai)
 
 	count := 7 //can be 11 at low HP
-	if (c.HPCurrent / c.MaxHP()) <= 0.5 {
+	if c.CurrentHPRatio() <= 0.5 {
 		count = 12
 	}
 	interval := 2 * 60 / 7

--- a/internal/characters/kuki/cons.go
+++ b/internal/characters/kuki/cons.go
@@ -75,12 +75,12 @@ func (c *char) c6() {
 			return false
 		}
 		//check if hp less than 25%
-		if c.HPCurrent/c.MaxHP() > .25 {
+		if c.CurrentHPRatio() > 0.25 {
 			return false
 		}
 		//if dead, revive back to 1 hp
-		if c.HPCurrent <= -1 {
-			c.HPCurrent = 1
+		if c.CurrentHPRatio() <= 0 {
+			c.SetHPByAmount(1)
 		}
 		c.AddStatus(c6IcdKey, 3600, false) // 60s * 60
 

--- a/internal/characters/kuki/skill.go
+++ b/internal/characters/kuki/skill.go
@@ -30,11 +30,13 @@ func init() {
 
 func (c *char) Skill(p map[string]int) action.ActionInfo {
 	// only drain HP when above 20% HP
-	if c.HPCurrent/c.MaxHP() > hpDrainThreshold {
-		hpdrain := 0.3 * c.HPCurrent
+	if c.CurrentHPRatio() > hpDrainThreshold {
+		currentHP := c.CurrentHP()
+		maxHP := c.MaxHP()
+		hpdrain := 0.3 * currentHP
 		// The HP consumption from using this skill can only bring her to 20% HP.
-		if (c.HPCurrent-hpdrain)/c.MaxHP() <= hpDrainThreshold {
-			hpdrain = c.HPCurrent - hpDrainThreshold*c.MaxHP()
+		if (currentHP-hpdrain)/maxHP <= hpDrainThreshold {
+			hpdrain = currentHP - hpDrainThreshold*maxHP
 		}
 		c.Core.Player.Drain(player.DrainInfo{
 			ActorIndex: c.Index,

--- a/internal/characters/noelle/asc.go
+++ b/internal/characters/noelle/asc.go
@@ -31,7 +31,7 @@ func (c *char) a1() {
 			return false
 		}
 		active := c.Core.Player.ActiveChar()
-		if active.HPCurrent/active.MaxHP() >= 0.3 {
+		if active.CurrentHPRatio() >= 0.3 {
 			return false
 		}
 		c.AddStatus(a1IcdKey, 3600, false)

--- a/internal/characters/razor/razor.go
+++ b/internal/characters/razor/razor.go
@@ -43,7 +43,7 @@ func (c *char) Init() error {
 
 	// make sure to use the same key everywhere so that these passives don't stack
 	c.Core.Player.AddStamPercentMod("utility-dash", -1, func(a action.Action) (float64, bool) {
-		if a == action.ActionDash && c.HPCurrent > 0 {
+		if a == action.ActionDash && c.CurrentHPRatio() > 0 {
 			return -0.2, false
 		}
 		return 0, false

--- a/internal/characters/sayu/burst.go
+++ b/internal/characters/sayu/burst.go
@@ -81,7 +81,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				char := c.Core.Player.ActiveChar()
 				hasC1 := c.Base.Cons >= 1
 				// C1 ignores HP limit
-				needHeal := c.Core.Combat.Player().IsWithinArea(burstArea) && (char.HPCurrent/char.MaxHP() <= 0.7 || hasC1)
+				needHeal := c.Core.Combat.Player().IsWithinArea(burstArea) && (char.CurrentHPRatio() <= 0.7 || hasC1)
 
 				// check for enemy
 				enemy := c.Core.Combat.ClosestEnemyWithinArea(burstArea, nil)

--- a/internal/characters/xiao/burst.go
+++ b/internal/characters/xiao/burst.go
@@ -42,7 +42,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				c.Core.Player.Drain(player.DrainInfo{
 					ActorIndex: c.Index,
 					Abil:       "Bane of All Evil",
-					Amount:     burstDrain[c.TalentLvlBurst()] * c.HPCurrent,
+					Amount:     burstDrain[c.TalentLvlBurst()] * c.CurrentHP(),
 				})
 			}
 		}, i)

--- a/internal/characters/xiao/cons.go
+++ b/internal/characters/xiao/cons.go
@@ -38,7 +38,7 @@ func (c *char) c4() {
 		Base:         modifier.NewBase("xiao-c4", -1),
 		AffectedStat: attributes.DEFP,
 		Amount: func() ([]float64, bool) {
-			if c.HPCurrent/c.MaxHP() <= 0.5 {
+			if c.CurrentHPRatio() <= 0.5 {
 				return m, true
 			}
 			return nil, false

--- a/internal/characters/yaoyao/yuegui.go
+++ b/internal/characters/yaoyao/yuegui.go
@@ -131,7 +131,7 @@ func (yg *yuegui) makeParticleCB() combat.AttackCBFunc {
 
 func (yg *yuegui) throw() {
 	yg.Gadget.ThinkInterval = 60
-	currHPPerc := yg.Core.Player.ActiveChar().HPCurrent / yg.Core.Player.ActiveChar().MaxHP()
+	currHPPerc := yg.Core.Player.ActiveChar().CurrentHPRatio()
 	enemy := yg.Core.Combat.RandomEnemyWithinArea(yg.aoe, nil)
 
 	var target geometry.Point

--- a/internal/characters/yoimiya/burst.go
+++ b/internal/characters/yoimiya/burst.go
@@ -151,7 +151,7 @@ func (c *char) burstHook() {
 	if c.Core.Flags.DamageMode {
 		//add check for if yoimiya dies
 		c.Core.Events.Subscribe(event.OnPlayerHPDrain, func(_ ...interface{}) bool {
-			if c.HPCurrent <= 0 {
+			if c.CurrentHPRatio() <= 0 {
 				// remove Aurous Blaze from target
 				for _, x := range c.Core.Combat.Enemies() {
 					trg := x.(*enemy.Enemy)

--- a/internal/weapons/claymore/ferrousshadow/ferrousshadow.go
+++ b/internal/weapons/claymore/ferrousshadow/ferrousshadow.go
@@ -40,8 +40,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 				return nil, false
 			}
 			// don't apply buff if above hp threshold
-			maxhp := char.MaxHP()
-			if char.HPCurrent > hp_check*maxhp {
+			if char.CurrentHPRatio() > hp_check {
 				return nil, false
 			}
 			return m, true

--- a/internal/weapons/spear/homa/homa.go
+++ b/internal/weapons/spear/homa/homa.go
@@ -44,7 +44,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		Amount: func() ([]float64, bool) {
 			maxhp := char.MaxHP()
 			per := atkp
-			if char.HPCurrent <= 0.5*maxhp {
+			if char.CurrentHPRatio() <= 0.5 {
 				per += lowhp
 			}
 			mATK[attributes.ATK] = per * maxhp

--- a/internal/weapons/sword/harbinger/harbinger.go
+++ b/internal/weapons/sword/harbinger/harbinger.go
@@ -32,7 +32,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 		Base:         modifier.NewBase("harbinger", -1),
 		AffectedStat: attributes.CR,
 		Amount: func() ([]float64, bool) {
-			return m, char.HPCurrent/char.MaxHP() >= 0.9
+			return m, char.CurrentHPRatio() >= 0.9
 		},
 	})
 	return w, nil

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -175,10 +175,10 @@ func (c *Core) AddChar(p profile.CharacterProfile) (int, error) {
 	}
 	index := c.Player.AddChar(char)
 
-	// set the hp
-	char.HPCurrent = -1
+	// get starting hp
+	char.StartHP = -1
 	if hp, ok := p.Params["start_hp"]; ok {
-		char.HPCurrent = float64(hp)
+		char.StartHP = hp
 	}
 
 	// set the energy

--- a/pkg/core/player/character/stats.go
+++ b/pkg/core/player/character/stats.go
@@ -119,6 +119,14 @@ func (h *CharWrapper) NonExtraStat(s attributes.Stat) float64 {
 	return val
 }
 
+func (c *CharWrapper) CurrentHPRatio() float64 {
+	return c.currentHPRatio
+}
+
+func (c *CharWrapper) CurrentHP() float64 {
+	return c.currentHPRatio * c.MaxHP()
+}
+
 func (c *CharWrapper) MaxHP() float64 {
 	hpp := c.BaseStats[attributes.HPP]
 	hp := c.BaseStats[attributes.HP]

--- a/pkg/core/player/heal.go
+++ b/pkg/core/player/heal.go
@@ -43,15 +43,18 @@ func (h *Handler) HealIndex(info *HealInfo, index int) {
 	}
 	heal := hp * bonus
 
-	prevhp := c.HPCurrent
-	c.ModifyHP(heal)
+	prevHPRatio := c.CurrentHPRatio()
+	prevHP := c.CurrentHP()
+	c.ModifyHPByAmount(heal)
 
 	h.Log.NewEvent(info.Message, glog.LogHealEvent, index).
-		Write("previous", prevhp).
+		Write("previous_hp_ratio", prevHPRatio).
+		Write("previous_hp", prevHP).
 		Write("base amount", hp).
 		Write("bonus", bonus).
 		Write("final amount", heal).
-		Write("current", c.HPCurrent).
+		Write("current_hp_ratio", c.CurrentHPRatio()).
+		Write("current_hp", c.CurrentHP()).
 		Write("max_hp", c.MaxHP())
 
 	h.Events.Emit(event.OnHeal, info, index, heal)
@@ -67,13 +70,16 @@ type DrainInfo struct {
 func (h *Handler) Drain(di DrainInfo) {
 	c := h.chars[di.ActorIndex]
 
-	prevhp := c.HPCurrent
-	c.ModifyHP(-di.Amount)
+	prevHPRatio := c.CurrentHPRatio()
+	prevHP := c.CurrentHP()
+	c.ModifyHPByAmount(-di.Amount)
 
 	h.Log.NewEvent(di.Abil, glog.LogHurtEvent, di.ActorIndex).
-		Write("previous", prevhp).
+		Write("previous_hp_ratio", prevHPRatio).
+		Write("previous_hp", prevHP).
 		Write("amount", di.Amount).
-		Write("current", c.HPCurrent).
+		Write("current_hp_ratio", c.CurrentHPRatio()).
+		Write("current_hp", c.CurrentHP()).
 		Write("max_hp", c.MaxHP())
 	h.Events.Emit(event.OnPlayerHPDrain, di)
 }

--- a/pkg/core/player/player.go
+++ b/pkg/core/player/player.go
@@ -261,12 +261,15 @@ func (h *Handler) InitializeTeam() error {
 		for k := range h.chars[i].Equip.Sets {
 			h.chars[i].Equip.Sets[k].Init()
 		}
-		//set each char's starting hp
-		if h.chars[i].HPCurrent == -1 {
-			h.chars[i].HPCurrent = h.chars[i].MaxHP()
+		//set each char's starting hp ratio
+		if h.chars[i].StartHP <= 0 {
+			h.chars[i].SetHPByRatio(1)
+		} else {
+			h.chars[i].SetHPByAmount(float64(h.chars[i].StartHP))
 		}
 		h.Log.NewEvent("starting hp set", glog.LogCharacterEvent, i).
-			Write("hp", h.chars[i].HPCurrent)
+			Write("starting_hp_ratio", h.chars[i].CurrentHPRatio()).
+			Write("starting_hp", h.chars[i].CurrentHP())
 	}
 	return nil
 }

--- a/pkg/stats/status/status.go
+++ b/pkg/stats/status/status.go
@@ -99,7 +99,7 @@ func NewStat(core *core.Core) (stats.StatsCollector, error) {
 
 		for i, char := range core.Player.Chars() {
 			out.charEnergy[i] = maxUpdate(out.charEnergy[i], bucket, char.Energy)
-			out.charHealth[i] = avgUpdate(out.charHealth[i], bucket, char.HPCurrent)
+			out.charHealth[i] = avgUpdate(out.charHealth[i], bucket, char.CurrentHP())
 		}
 
 		for i, t := range core.Combat.Enemies() {
@@ -158,7 +158,7 @@ func (b buffer) Flush(core *core.Core, result *stats.Result) {
 
 	for c := 0; c < len(core.Player.Chars()); c++ {
 		for i := 0; i < fill; i++ {
-			b.charHealth[c] = avgUpdate(b.charHealth[c], bucket, core.Player.Chars()[c].HPCurrent)
+			b.charHealth[c] = avgUpdate(b.charHealth[c], bucket, core.Player.Chars()[c].CurrentHP())
 		}
 
 		result.Characters[c].ActiveTime = b.activeTime[c]


### PR DESCRIPTION
closes #1278 

- replace `CurrentHP` with `currentHPRatio` (value between 0 and 1)
- hide access to `currentHPRatio` and current hp behind `CurrentHPRatio()` and `CurrentHP()`
- add `SetHPByAmount` and `SetHPByRatio` 
- replace `ModifyHP` with `ModifyHPByAmount` and `ModifyHPByRatio` 
- add `StartHP` to `CharWrapper` in order to set start hp in `InitializeTeam` instead of `AddChar` (otherwise the start hp would be influenced by hp mods added in `InitializeTeam`)

live: https://gcsim.app/v3/viewer/share/57cb8681-c229-40be-9a51-ecd9f6ef2a3c (xingqiu loses harbinger mid sim because of yelan c2 increasing max hp but not current hp)
pr: https://gcsim.app/v3/viewer/share/8bcf8082-bb4c-4bde-a6d4-380aca4f9b4c (xingqiu has 100% harbinger uptime)