### PR TITLE
fix ayaka ca and adjust gadget selection

### DIFF
--- a/internal/characters/ayaka/charge.go
+++ b/internal/characters/ayaka/charge.go
@@ -27,7 +27,7 @@ func (c *char) ChargeAttack(p map[string]int) action.ActionInfo {
 		ActorIndex: c.Index,
 		AttackTag:  attacks.AttackTagExtra,
 		ICDTag:     attacks.ICDTagExtraAttack,
-		ICDGroup:   attacks.ICDGroupDefault,
+		ICDGroup:   attacks.ICDGroupAyakaExtraAttack,
 		StrikeType: attacks.StrikeTypeSlash,
 		Element:    attributes.Physical,
 		Durability: 25,

--- a/pkg/core/attacks/icd.go
+++ b/pkg/core/attacks/icd.go
@@ -84,6 +84,7 @@ const (
 	ICDGroupYaoyaoRadishSkill
 	ICDGroupYaoyaoRadishBurst
 	ICDGroupBaizhuC2
+	ICDGroupAyakaExtraAttack
 	ICDGroupLength
 )
 
@@ -120,6 +121,7 @@ func init() {
 	ICDGroupResetTimer[ICDGroupYaoyaoRadishSkill] = 150
 	ICDGroupResetTimer[ICDGroupYaoyaoRadishBurst] = 90
 	ICDGroupResetTimer[ICDGroupBaizhuC2] = 240
+	ICDGroupResetTimer[ICDGroupAyakaExtraAttack] = 30
 
 	ICDGroupEleApplicationSequence = make([][]float64, ICDGroupLength)
 	ICDGroupEleApplicationSequence[ICDGroupDefault] = []float64{1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0}
@@ -149,6 +151,7 @@ func init() {
 	ICDGroupEleApplicationSequence[ICDGroupYaoyaoRadishSkill] = []float64{1, 0, 0, 0, 0, 0}
 	ICDGroupEleApplicationSequence[ICDGroupYaoyaoRadishBurst] = []float64{1, 0, 0, 0, 0, 0}
 	ICDGroupEleApplicationSequence[ICDGroupBaizhuC2] = []float64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	ICDGroupEleApplicationSequence[ICDGroupAyakaExtraAttack] = []float64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
 	ICDGroupDamageSequence = make([][]float64, ICDGroupLength)
 	ICDGroupDamageSequence[ICDGroupDefault] = []float64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
@@ -180,4 +183,5 @@ func init() {
 	ICDGroupDamageSequence[ICDGroupYaoyaoRadishSkill] = []float64{1, 1, 1, 1, 1, 1}
 	ICDGroupDamageSequence[ICDGroupYaoyaoRadishBurst] = []float64{1, 1, 1, 1, 1, 1}
 	ICDGroupDamageSequence[ICDGroupBaizhuC2] = []float64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	ICDGroupDamageSequence[ICDGroupAyakaExtraAttack] = []float64{1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 }

--- a/pkg/core/combat/gadget.go
+++ b/pkg/core/combat/gadget.go
@@ -10,9 +10,11 @@ type GadgetTyp int
 
 const (
 	GadgetTypUnknown GadgetTyp = iota
+	StartGadgetTypEnemy
 	GadgetTypDendroCore
-	GadgetTypGuoba
 	GadgetTypLeaLotus
+	EndGadgetTypEnemy
+	GadgetTypGuoba
 	GadgetTypYueguiThrowing
 	GadgetTypYueguiJumping
 	GadgetTypTest

--- a/pkg/core/combat/select.go
+++ b/pkg/core/combat/select.go
@@ -37,6 +37,10 @@ func gadgetsWithinAreaFiltered(a AttackPattern, filter func(t Gadget) bool, orig
 		if v == nil {
 			continue
 		}
+		// check if gadget is enemy camp, abilities don't target allied gadgets
+		if !(v.GadgetTyp() > StartGadgetTypEnemy && v.GadgetTyp() < EndGadgetTypEnemy) {
+			continue
+		}
 		if hasFilter && !filter(v) {
 			continue
 		}
@@ -189,6 +193,10 @@ func gadgetsWithinAreaSorted(a AttackPattern, filter func(t Gadget) bool, skipAt
 	hasFilter := filter != nil
 	for _, v := range originalGadgets {
 		if v == nil {
+			continue
+		}
+		// check if gadget is enemy camp, abilities don't target allied gadgets
+		if !(v.GadgetTyp() > StartGadgetTypEnemy && v.GadgetTyp() < EndGadgetTypEnemy) {
 			continue
 		}
 		if hasFilter && !filter(v) {


### PR DESCRIPTION
- fix ayaka ca icd
- add distinction between enemy (only dendro core and dmc q for now) and allied gadget (needed for ayaka ca)
- fix ayaka ca logic
   - delay first enemy check until before first ca hit
   - pick an anchor enemy to use for chargeArea
   - queue up ca hits to follow moving enemy