### PR TITLE
fix itto na counter not being reset correctly (again)

### DIFF
--- a/internal/characters/itto/dash.go
+++ b/internal/characters/itto/dash.go
@@ -5,8 +5,11 @@ import (
 )
 
 func (c *char) Dash(p map[string]int) action.ActionInfo {
-	// chaining dashes resets savedNormalCounter
-	if c.Core.Player.CurrentState() == action.DashState {
+	// anything but NA/E -> E should reset savedNormalCounter
+	switch c.Core.Player.LastAction.Type {
+	case action.ActionAttack:
+	case action.ActionSkill:
+	default:
 		c.savedNormalCounter = 0
 	}
 

--- a/internal/characters/itto/skill.go
+++ b/internal/characters/itto/skill.go
@@ -35,9 +35,12 @@ func init() {
 // - Ushi will flee when its HP reaches 0 or its duration ends. It will grant Arataki Itto 1 stack of Superlative Superstrength when it leaves.
 // Ushi is considered a Geo Construct. Arataki Itto can only deploy 1 Ushi on the field at any one time.
 func (c *char) Skill(p map[string]int) action.ActionInfo {
-	// using a skill after a dash resets savedNormalCounter
+	// anything but NA/E -> E should reset savedNormalCounter
 	// can't use CurrentState here since AnimationLength of Dash is the same as Dash -> Skill, so it switches to Idle instead of staying DashState
-	if c.Core.Player.LastAction.Type == action.ActionDash {
+	switch c.Core.Player.LastAction.Type {
+	case action.ActionAttack:
+	case action.ActionSkill:
+	default:
 		c.savedNormalCounter = 0
 	}
 


### PR DESCRIPTION
- was bugged when actions are put between skill and dash
- closes #1403 
- tested here: https://gcsim.app/v3/viewer/share/8bbd72c2-8836-4b3c-8bda-4dde5156e460 (turn on just action, damage and user in the log options for the optimal viewing experience)