### PR TITLE
fix circle fan collision edge case

### DIFF
--- a/pkg/core/geometry/circle.go
+++ b/pkg/core/geometry/circle.go
@@ -102,6 +102,7 @@ func (c1 *Circle) IntersectCircle(c2 Circle) bool {
 
 	// c2 has a fanAngle -> there's an intersection if A && (B || C)
 	// https://www.baeldung.com/cs/circle-line-segment-collision-detection
+	// (note: no need for maxDist since we also count segment completely inside of circle as an intersection)
 	// B: check if c1 intersects any of c2's segments, if yes we can exit early
 	// (it's necessary to check for this because c1 can collide with c2's fanAngle area
 	// even if c1's circle center isn't in c2's fanAngle range)
@@ -120,11 +121,10 @@ func (c1 *Circle) IntersectCircle(c2 Circle) bool {
 		oqDist := o.Distance(q)
 
 		minDist := math.Min(opDist, oqDist)
-		maxDist := math.Max(opDist, oqDist)
 		if op.Dot(qp) > 0 && oq.Dot(pq) > 0 {
 			minDist = math.Abs(op.Cross(oq)) / c2.r
 		}
-		if minDist <= c1.r && maxDist >= c1.r {
+		if minDist <= c1.r {
 			return true
 		}
 	}


### PR DESCRIPTION
- if both segments are completely inside of the target circle, it should count as an intersection

live: https://gcsim.app/v3/viewer/share/a863178a-f468-48a5-be7c-9cc588087b3a
pr: https://gcsim.app/v3/viewer/share/cc057fe9-2b87-4ba9-90ae-14f46f233c26
desmos visualization: 
![grafik](https://github.com/genshinsim/gcsim/assets/98557316/69b4207d-b37e-4cb0-956c-954c59a0f66b)
Kirara's attack is the blue circle (fanAngle of 270 degrees, so the small area between the segments at the bottom is the no-hit zone of the circle) and the target is the red circle. As you can see both of the circle line segments of Kirara's attack are completely inside of the target's hitbox. In the current implementation this means there's no intersection, since the line segments do not run through the edge of the red circle. It should actually detect the intersection here and return that an intersection occured. (The final fanAngleAreaCheck also fails since the direction points towards the no-hit zone.)