### PR TITLE
Add possibility for normal cons

### DIFF
--- a/internal/characters/albedo/albedo.go
+++ b/internal/characters/albedo/albedo.go
@@ -32,6 +32,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 40
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	w.Character = &c
 

--- a/internal/characters/aloy/aloy.go
+++ b/internal/characters/aloy/aloy.go
@@ -26,6 +26,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 40
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	c.coilICDExpiry = 0
 	c.lastFieldExit = 0

--- a/internal/characters/ayato/ayato.go
+++ b/internal/characters/ayato/ayato.go
@@ -33,8 +33,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 	c.Character = tmpl.NewWithWrapper(s, w)
 
 	c.EnergyMax = 80
-	c.BurstCon = 3
-	c.SkillCon = 5
+	c.BurstCon = 5
+	c.SkillCon = 3
 	c.NormalHitNum = normalHitNum
 
 	c.shunsuikenCounter = 3

--- a/internal/characters/beidou/beidou.go
+++ b/internal/characters/beidou/beidou.go
@@ -24,6 +24,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 80
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	w.Character = &c
 

--- a/internal/characters/bennett/bennett.go
+++ b/internal/characters/bennett/bennett.go
@@ -23,6 +23,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 60
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	w.Character = &c
 

--- a/internal/characters/diluc/diluc.go
+++ b/internal/characters/diluc/diluc.go
@@ -35,6 +35,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 40
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	c.eCounter = 0
 

--- a/internal/characters/fischl/fischl.go
+++ b/internal/characters/fischl/fischl.go
@@ -33,6 +33,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, p profile.CharacterProfile)
 
 	c.EnergyMax = 60
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	c.ozSource = -1
 	c.ozActive = false

--- a/internal/characters/hutao/hutao.go
+++ b/internal/characters/hutao/hutao.go
@@ -37,6 +37,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 60
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	w.Character = &c
 

--- a/internal/characters/kaeya/kaeya.go
+++ b/internal/characters/kaeya/kaeya.go
@@ -26,6 +26,9 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 60
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
+
 	c.c2ProcCount = 0
 
 	w.Character = &c

--- a/internal/characters/klee/klee.go
+++ b/internal/characters/klee/klee.go
@@ -25,6 +25,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 60
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	c.sparkICD = -1
 

--- a/internal/characters/nahida/nahida.go
+++ b/internal/characters/nahida/nahida.go
@@ -37,6 +37,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 50
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	w.Character = &c
 

--- a/internal/characters/noelle/noelle.go
+++ b/internal/characters/noelle/noelle.go
@@ -28,6 +28,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 60
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	w.Character = &c
 

--- a/internal/characters/sucrose/sucrose.go
+++ b/internal/characters/sucrose/sucrose.go
@@ -31,6 +31,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile)
 
 	c.EnergyMax = 80
 	c.NormalHitNum = normalHitNum
+	c.SkillCon = 3
+	c.BurstCon = 5
 
 	if c.Base.Cons >= 1 {
 		c.SetNumCharges(action.ActionSkill, 2)

--- a/pkg/core/player/character/character.go
+++ b/pkg/core/player/character/character.go
@@ -231,6 +231,9 @@ func (c *CharWrapper) TalentLvlAttack() int {
 	if c.NormalCon > 0 && c.Base.Cons >= c.NormalCon {
 		add += 3
 	}
+	if add >= 4 {
+		add = 4
+	}
 	return c.Talents.Attack + add
 }
 func (c *CharWrapper) TalentLvlSkill() int {
@@ -239,6 +242,9 @@ func (c *CharWrapper) TalentLvlSkill() int {
 	if c.SkillCon > 0 && c.Base.Cons >= c.SkillCon {
 		add += 3
 	}
+	if add >= 4 {
+		add = 4
+	}
 	return c.Talents.Skill + add
 }
 func (c *CharWrapper) TalentLvlBurst() int {
@@ -246,6 +252,9 @@ func (c *CharWrapper) TalentLvlBurst() int {
 	add := -1
 	if c.BurstCon > 0 && c.Base.Cons >= c.BurstCon {
 		add += 3
+	}
+	if add >= 4 {
+		add = 4
 	}
 	return c.Talents.Burst + add
 }

--- a/pkg/core/player/character/character.go
+++ b/pkg/core/player/character/character.go
@@ -62,13 +62,14 @@ type CharWrapper struct {
 	tasks  task.Tasker
 
 	//base characteristics
-	Base     profile.CharacterBase
-	Weapon   weapon.WeaponProfile
-	Talents  profile.TalentProfile
-	CharZone profile.ZoneType
-	CharBody profile.BodyType
-	SkillCon int
-	BurstCon int
+	Base      profile.CharacterBase
+	Weapon    weapon.WeaponProfile
+	Talents   profile.TalentProfile
+	CharZone  profile.ZoneType
+	CharBody  profile.BodyType
+	NormalCon int
+	SkillCon  int
+	BurstCon  int
 
 	Equip struct {
 		Weapon weapon.Weapon
@@ -133,9 +134,12 @@ func New(
 	s := (*[attributes.EndStatType]float64)(p.Stats)
 	c.BaseStats = *s
 	c.Equip.Sets = make(map[keys.Set]artifact.Set)
-	//default cons
-	c.SkillCon = 3
-	c.BurstCon = 5
+
+	//set to -1 by default and let each char specify normal/skill/burst cons
+	c.NormalCon = -1
+	c.SkillCon = -1
+	c.BurstCon = -1
+
 	//check talents
 	if c.Talents.Attack < 1 || c.Talents.Attack > 10 {
 		return nil, fmt.Errorf("invalid talent lvl: attack - %v", c.Talents.Attack)
@@ -203,22 +207,28 @@ func (c *CharWrapper) ModifyHPByRatio(r float64) {
 }
 
 func (c *CharWrapper) TalentLvlAttack() int {
+	add := -1
 	if c.Tags[keys.ChildePassive] > 0 {
-		return c.Talents.Attack
+		add++
 	}
-	return c.Talents.Attack - 1
+	if c.NormalCon > 0 && c.Base.Cons >= c.NormalCon {
+		add += 3
+	}
+	return c.Talents.Attack + add
 }
 func (c *CharWrapper) TalentLvlSkill() int {
-	if c.Base.Cons >= c.SkillCon {
-		return c.Talents.Skill + 2
+	add := -1
+	if c.SkillCon > 0 && c.Base.Cons >= c.SkillCon {
+		add += 3
 	}
-	return c.Talents.Skill - 1
+	return c.Talents.Skill + add
 }
 func (c *CharWrapper) TalentLvlBurst() int {
-	if c.Base.Cons >= c.BurstCon {
-		return c.Talents.Burst + 2
+	add := -1
+	if c.BurstCon > 0 && c.Base.Cons >= c.BurstCon {
+		add += 3
 	}
-	return c.Talents.Burst - 1
+	return c.Talents.Burst + add
 }
 
 type Particle struct {

--- a/pkg/core/player/character/character.go
+++ b/pkg/core/player/character/character.go
@@ -206,7 +206,24 @@ func (c *CharWrapper) ModifyHPByRatio(r float64) {
 	c.SetHPByRatio(newHPRatio)
 }
 
+func (c *CharWrapper) consCheck() {
+	consUnset := 0
+	if c.NormalCon < 0 {
+		consUnset++
+	}
+	if c.SkillCon < 0 {
+		consUnset++
+	}
+	if c.BurstCon < 0 {
+		consUnset++
+	}
+	if consUnset != 1 {
+		panic(fmt.Sprintf("cons not set properly for %v, please set two out of three values:\nNormalCon: %v\nSkillCon: %v\nBurstCon: %v", c.Base.Key.String(), c.NormalCon, c.SkillCon, c.BurstCon))
+	}
+}
+
 func (c *CharWrapper) TalentLvlAttack() int {
+	c.consCheck()
 	add := -1
 	if c.Tags[keys.ChildePassive] > 0 {
 		add++
@@ -217,6 +234,7 @@ func (c *CharWrapper) TalentLvlAttack() int {
 	return c.Talents.Attack + add
 }
 func (c *CharWrapper) TalentLvlSkill() int {
+	c.consCheck()
 	add := -1
 	if c.SkillCon > 0 && c.Base.Cons >= c.SkillCon {
 		add += 3
@@ -224,6 +242,7 @@ func (c *CharWrapper) TalentLvlSkill() int {
 	return c.Talents.Skill + add
 }
 func (c *CharWrapper) TalentLvlBurst() int {
+	c.consCheck()
 	add := -1
 	if c.BurstCon > 0 && c.Base.Cons >= c.BurstCon {
 		add += 3

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -17,9 +17,9 @@ import (
 func (s *Simulation) Run() (res stats.Result, err error) {
 	defer func() {
 		// recover from panic if one occured. Set err to nil otherwise.
-		if recover() != nil {
+		if r := recover(); r != nil {
 			res = stats.Result{Seed: uint64(s.C.Seed), Duration: s.C.F + 1}
-			err = errors.New("simulation panic occured")
+			err = errors.New(fmt.Sprintf("simulation panic occured: %v", r))
 		}
 	}()
 	//run sim for 90s if no duration set


### PR DESCRIPTION
- fix ayato c3 and c5 being swapped
- from this point onwards, skill cons being 3 and burst cons being 5 is no longer default and char implementations have to specify NormalCon/SkillCon/BurstCon if they should be enabled at a certain constellation, default value is -1 which means that it doesn't apply at any constellation