### PR TITLE
add cam cancel related video links to docs

### DIFF
--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -677,6 +677,12 @@
       "count_credit": "Shizuka#7791",
       "vid": "https://youtu.be/Rp8-WwtFxSY",
       "count": "https://docs.google.com/spreadsheets/d/1j3Hzo25qSqo-ZbQBiBqcejR1aa91igSVTxH1xoKYrfc/edit"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1000",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "ningguang": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -523,6 +523,12 @@
       "count_credit": "Shizuka#7791",
       "vid": "https://youtu.be/lcDQi_9YBzA",
       "count": "https://docs.google.com/spreadsheets/d/1CeCbNYTXozBDeeRerGJFLWwsKrKz3K3-PydNSBATx8E/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675 (special thanks to Xreejan#1180)",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1280",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "sucrose": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -311,6 +311,12 @@
       "count_credit": "Kurt#5846",
       "vid": "https://youtu.be/HJrJkYgsg84",
       "count": "https://docs.google.com/spreadsheets/d/1KQB8VOEyaCsRa3QulF-gAq3a1CxsqiauTNYuK2_paMY/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=725",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "kaeya": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -341,6 +341,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/xwdec3mg6rM",
       "count": "https://docs.google.com/spreadsheets/d/1uEbP13O548-w_nGxFPGsf5jqj1qGD3pqFZ_AiV4w3ww/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=781",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "keqing": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -669,6 +669,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/ZO7ViyYFvKQ",
       "count": "https://docs.google.com/spreadsheets/d/1rECAO_yOwB4sDJ70z75pJr6fQsQjx5kgsOWtylcAGLk/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1458",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "xinyan": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -435,6 +435,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/mRSPMhmpKX0",
       "count": "https://docs.google.com/spreadsheets/d/1fCdmkNZ6vXmqiOmk6s0Q8AQFzOQt_UjltspbMyDrx4A/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1072",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "nahida": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -241,6 +241,12 @@
       "count_credit": "Kurt#5846",
       "vid": "https://youtu.be/ROvivlCUR3s",
       "count": "https://docs.google.com/spreadsheets/d/1PDHCZKh-7eWpbE1b0OyQUCzSPHcViYZ22EDEItjiU7Y/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=504",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "gorou": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -465,6 +465,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/56yh-6WqN-I",
       "count": "https://docs.google.com/spreadsheets/d/1uS_n16mlfdfzjBiVG3w6TmR9H7YqSSFOoyox_9bn-Kk/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1159",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "raiden": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -203,6 +203,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/KsBKdqCPFj8",
       "count": "https://docs.google.com/spreadsheets/d/1p0blrnuM7JvwU2QMdZdLayYqP3-7OMDgYC6GDQNn_QU/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=340",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "diona": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -613,6 +613,12 @@
       "count_credit": "Shizuka#7791",
       "vid": "https://youtu.be/Bj7C6zs4Xsc",
       "count": "https://docs.google.com/spreadsheets/d/1NCDFtvqFdXlVRd_0eH2tPw7xMD50AxUCvbWDh1XGhEw/edit"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=411",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "faruzan": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -479,6 +479,12 @@
       "count_credit": "Kurt#5846",
       "vid": "https://youtu.be/70hVIt1_92Y",
       "count": "https://docs.google.com/spreadsheets/d/1ayeS2Yp32dbdVR-xqSyIeSk7CUDuIFSO6A8XrRCRNgY/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1221",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "razor": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -109,6 +109,12 @@
       "count_credit": "phaZZi#6461",
       "vid": "https://youtu.be/ZlKREU4NZPA",
       "count": "https://docs.google.com/spreadsheets/d/1R_OywCjjSW8PeYPPniBLVnoTZ8uQ2L_GLKYmQvFTHV0/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=248",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "beidou": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -27,6 +27,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/mGnzKSsvq9s",
       "count": "https://docs.google.com/spreadsheets/d/11uyES6x6UFGm2bqcsY4dPSqLgsELrdkPv145NmMwTmc/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=57",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "amber": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -297,6 +297,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/6Yq8StVQFOk",
       "count": "https://docs.google.com/spreadsheets/d/13ad3uH2DazxotwjQE6qvWRfcQJpmhkxN4nsbc3vUx78/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=634",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "jean": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -87,6 +87,12 @@
       "count_credit": "Kurt#5846",
       "vid": "https://youtu.be/m0ABsEc-Gaw",
       "count": "https://docs.google.com/spreadsheets/d/1VL6nQvehIj8wTFC6ACC88p3i8lGUZnZV8Lx0G1dZp88/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=183",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "baizhu": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -5,6 +5,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/BYr-3R-XpfE",
       "count": "https://docs.google.com/spreadsheets/d/1WIejtwUZpZ2lqTNlK2_6cJPoDe0PUmCL6QKB05m_AQQ/edit?usp=sharin"
+    },
+    {
+      "vid_credit": "Kolibri#7675 (special thanks to Xreejan#1180)",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "alhaitham": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -671,6 +671,12 @@
       "count_credit": "Kolibri#767",
       "vid": "https://youtu.be/diz7tQf8-yY",
       "count": "https://docs.google.com/spreadsheets/d/19dQSj8Y8LJ_2kLgWKPlkNp9y7sqvFiquO5h03R2YNXI/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1832",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "thoma": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -601,6 +601,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/oadNODbooZQ",
       "count": "https://docs.google.com/spreadsheets/d/1WHJy9UjCQY0AO32yluJMhX_ecGO1KGb6SjbOZt9VJDg/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1598",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "xingqiu": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -763,6 +763,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/UUcbZDh4oIA",
       "count": "https://docs.google.com/spreadsheets/d/1G8_pp_NFtM1wteo_xRZaG-lTcS3NZ1vADVmjFFp_SOk/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1644",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "yanfei": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -61,6 +61,12 @@
       "count_credit": "Kurt#5846",
       "vid": "https://youtu.be/ulTSQRrR4n8",
       "count": "https://docs.google.com/spreadsheets/d/1WPxQ7vf0_dp5g96aqGF0_JZSqjtYHOJC0b89zRS_WrA/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=117",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "ayato": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -629,6 +629,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/4WpZhbvEktU",
       "count": "https://docs.google.com/spreadsheets/d/1k4f8EkgneV_588EpJlDavx_0zyFi5ZiWd0HdUV6wx38/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1719",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "yoimiya": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -643,6 +643,12 @@
       "count_credit": "Kurt#5846",
       "vid": "https://youtu.be/UNo3Q-DPmbM",
       "count": "https://docs.google.com/spreadsheets/d/1DYYiGSNeFekVt3eQQC_MujkLCd_8rgPIIlpPNvwHKTA/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1773",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "yunjin": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -277,6 +277,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/a8vo9uxMWM0",
       "count": "https://docs.google.com/spreadsheets/d/1KR_FMtupIbLEhWRGww2N2UKEJG3hy5mWJIez8S6EZ2w/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=566",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "itto": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -361,6 +361,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/9xe2nygCtKE",
       "count": "https://docs.google.com/spreadsheets/d/1GAeBzMr0XX89azZhpbjEqPfehgruwI3__GlfEgQ1VvA/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=842",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "kirara": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -383,6 +383,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/jDQDx1hhzkc",
       "count": "https://docs.google.com/spreadsheets/d/1cRHRn2iR8knyzcioUGGoMFNZgaNJQdlpkUqjeIPowCM/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=915",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "kuki": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -571,6 +571,12 @@
       "count_credit": "Kurt#5846",
       "vid": "https://youtu.be/6SNc67MnDz8",
       "count": "https://docs.google.com/spreadsheets/d/1wjNpI530VwWX8PtmAA7ZZex5FurVpItfu6jmRQsMcaw/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1520",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "wanderer": [

--- a/ui/packages/docs/src/components/Frames/data.json
+++ b/ui/packages/docs/src/components/Frames/data.json
@@ -557,6 +557,12 @@
       "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/rpVDDq-F5ZM",
       "count": "https://docs.google.com/spreadsheets/d/1TDAItxWT_p76Z84EMpk2oIAN2etTWR0DiubllnWBnbc/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/KlgZlck5kQQ?t=1357",
+      "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }
   ],
   "venti": [


### PR DESCRIPTION
add video links for the [cam cancel sheet](https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing), where changes occured in https://github.com/genshinsim/gcsim/pull/906 (tighnari's were part of his initial implementation pr)