### PR TITLE
Add a self infusion event and implement an application of missing elements

### DIFF
--- a/internal/characters/beidou/skill.go
+++ b/internal/characters/beidou/skill.go
@@ -2,6 +2,7 @@ package beidou
 
 import (
 	"github.com/genshinsim/gcsim/internal/frames"
+	"github.com/genshinsim/gcsim/pkg/avatar"
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
@@ -69,6 +70,12 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 			Ele:        attributes.Electro,
 			Expires:    c.Core.F + 900, //15 sec
 		})
+
+		player, ok := c.Core.Combat.Player().(*avatar.Player)
+		if !ok {
+			panic("target 0 should be Player but is not!!")
+		}
+		player.ApplySelfInfusion(attributes.Electro, 25, 0.1*60) // TODO: find actual duration
 	}
 
 	c.SetCDWithDelay(action.ActionSkill, 450, 4)

--- a/internal/characters/razor/razor.go
+++ b/internal/characters/razor/razor.go
@@ -15,10 +15,11 @@ func init() {
 
 type char struct {
 	*tmpl.Character
-	sigils  int
-	a4Bonus []float64
-	c1bonus []float64
-	c2bonus []float64
+	sigils     int
+	a4Bonus    []float64
+	c1bonus    []float64
+	c2bonus    []float64
+	elementSrc int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ profile.CharacterProfile) error {

--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -70,6 +70,8 @@ func (p *Player) ApplySelfInfusion(ele attributes.Element, dur reactions.Durabil
 	//otherwise calculate decay based on specified f (in frames)
 	p.Durability[mod] = dur
 	p.DecayRate[mod] = dur / reactions.Durability(f)
+
+	p.Core.Combat.Events.Emit(event.OnSelfInfusion, ele, dur, f)
 }
 
 func (p *Player) ReactWithSelf(atk *combat.AttackEvent) {

--- a/pkg/core/event/event.go
+++ b/pkg/core/event/event.go
@@ -53,6 +53,7 @@ const (
 	OnCharacterHurt    //amount
 	OnHeal             //src char, target character, amount
 	OnPlayerHPDrain    //DrainInfo
+	OnSelfInfusion     //element, durability, duration
 	//ability use
 	OnActionFailed //ActiveCharIndex, action.Action, param, action.ActionFailure
 	OnActionExec   //ActiveCharIndex, action.Action, param


### PR DESCRIPTION
At the moment there are abilites that apply status to the char:
- [x] Dori burst;
- [x] Razor rurst;
- [x] Beidou hold skill (with shield only);
- [x] Kirara skill;
- [ ] Xingqiu skill;
- [ ] Kokomi skill;
- [x] Barbara skill;
- [x] Thoma skill;
- [x] Bennett burst;
- [ ] Xinyan skill (with shield only);
- [ ] Diona skill;
- [x] Layla skill.