### PR TITLE
adjust hardcoded field time aggregator capacity

### DIFF
--- a/pkg/agg/fieldtime/fieldtime.go
+++ b/pkg/agg/fieldtime/fieldtime.go
@@ -35,7 +35,7 @@ func (b *buffer) Add(result stats.Result) {
 }
 
 func (b *buffer) Flush(result *model.SimulationStatistics) {
-	result.FieldTime = make([]*model.DescriptiveStats, 4)
+	result.FieldTime = make([]*model.DescriptiveStats, len(b.fieldTimes))
 	for i, c := range b.fieldTimes {
 		result.FieldTime[i] = agg.ToDescriptiveStats(c)
 	}


### PR DESCRIPTION
capacity set to actual number of chars instead of hardcoding to 4