### PR TITLE
add back reaction/non-reaction source dps split

### DIFF
--- a/pkg/agg/damage/damage.go
+++ b/pkg/agg/damage/damage.go
@@ -105,7 +105,12 @@ func (b *buffer) Add(result stats.Result) {
 			charTargetDPS[ev.Target] += ev.Damage
 			charElementDPS[ev.Element] += ev.Damage
 			charDPS += ev.Damage
-			sourceDPS[ev.Source] += ev.Damage
+			sourceDPSKey := ev.Source
+			reactModifier := string(ev.ReactionModifier)
+			if reactModifier != "" {
+				sourceDPSKey += " (" + reactModifier + ")"
+			}
+			sourceDPS[sourceDPSKey] += ev.Damage
 		}
 
 		b.characterDPS[i].Add(charDPS * time)

--- a/pkg/stats/damage/damage.go
+++ b/pkg/stats/damage/damage.go
@@ -69,11 +69,11 @@ func NewStat(core *core.Core) (stats.StatsCollector, error) {
 		}
 
 		if attack.Info.Amped {
-			switch attack.Info.AmpMult {
-			case 1.5:
-				event.ReactionModifier = stats.Amp15
-			case 2:
-				event.ReactionModifier = stats.Amp20
+			switch attack.Info.AmpType {
+			case reactions.Vaporize:
+				event.ReactionModifier = stats.Vaporize
+			case reactions.Melt:
+				event.ReactionModifier = stats.Melt
 			}
 		}
 

--- a/pkg/stats/result.go
+++ b/pkg/stats/result.go
@@ -13,8 +13,8 @@ const (
 	OnField  FieldStatus = "on_field"
 	OffField FieldStatus = "off_field"
 
-	Amp15     ReactionModifier = "amp_1_5"
-	Amp20     ReactionModifier = "amp_2_0"
+	Melt      ReactionModifier = "melt"
+	Vaporize  ReactionModifier = "vaporize"
 	Spread    ReactionModifier = "spread"
 	Aggravate ReactionModifier = "aggravate"
 )


### PR DESCRIPTION
closes #1563 

Splits the abilities of the source dps graph into reaction/non-reaction with no option to group them together again for now.

Example image:
![grafik](https://github.com/genshinsim/gcsim/assets/98557316/867c030c-f5bd-424e-8255-40aecf69f52c)
