### PR TITLE
fix keqing c1 and recast e

### DIFF
--- a/internal/characters/keqing/skill.go
+++ b/internal/characters/keqing/skill.go
@@ -82,7 +82,7 @@ func (c *char) skillFirst(p map[string]int) action.ActionInfo {
 
 var skillRecastFrames []int
 
-const skillRecastHitmark = 27
+const skillRecastHitmark = 16
 
 func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 	// C1 DMG happens before Recast DMG

--- a/internal/characters/keqing/skill.go
+++ b/internal/characters/keqing/skill.go
@@ -87,14 +87,6 @@ const skillRecastHitmark = 27
 func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 	// C1 DMG happens before Recast DMG
 	if c.Base.Cons >= 1 {
-		// 2 tick dmg at start to end
-		hits, ok := p["c1"]
-		if !ok {
-			hits = 1 // default 1 hit
-		}
-		if hits > 2 {
-			hits = 2
-		}
 		ai := combat.AttackInfo{
 			Abil:       "Stellar Restoration (C1)",
 			ActorIndex: c.Index,
@@ -106,24 +98,19 @@ func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 			Durability: 25,
 			Mult:       .5,
 		}
-		// TODO: this should be 1st hit on cast and 2nd at end
-		// First hit centers on primary target
-		if hits >= 1 {
-			c.Core.QueueAttack(
-				ai,
-				combat.NewCircleHit(c.Core.Combat.Player(), c.Core.Combat.PrimaryTarget(), nil, 2),
-				skillRecastHitmark,
-				skillRecastHitmark,
-			)
-		}
-		if hits == 2 {
-			c.Core.QueueAttack(
-				ai,
-				combat.NewCircleHitOnTarget(c.Core.Combat.Player(), geometry.Point{Y: 1.5}, 2),
-				skillRecastHitmark,
-				skillRecastHitmark,
-			)
-		}
+		// 2 dmg instances at start and end
+		c.Core.QueueAttack(
+			ai,
+			combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 2),
+			3,
+			3,
+		)
+		c.Core.QueueAttack(
+			ai,
+			combat.NewCircleHit(c.Core.Combat.Player(), c.Core.Combat.PrimaryTarget(), geometry.Point{Y: 1.5}, 2),
+			skillRecastHitmark,
+			skillRecastHitmark,
+		)
 	}
 
 	ai := combat.AttackInfo{

--- a/ui/packages/docs/src/components/AoE/character_data.json
+++ b/ui/packages/docs/src/components/AoE/character_data.json
@@ -3278,13 +3278,13 @@
       {
         "ability": "E-C1-Start",
         "shape": "Circle",
-        "center": "PrimaryTarget",
+        "center": "Player",
         "radius": 2
       },
       {
         "ability": "E-C1-Terminus",
         "shape": "Circle",
-        "center": "Player",
+        "center": "PrimaryTarget",
         "offsetY": 1.5,
         "radius": 2
       }

--- a/ui/packages/docs/src/components/Frames/character_data.json
+++ b/ui/packages/docs/src/components/Frames/character_data.json
@@ -479,6 +479,12 @@
     {
       "vid_credit": "Kolibri#7675",
       "count_credit": "Kolibri#7675",
+      "vid": "https://youtu.be/bcmpBDTSBgI",
+      "count": "https://docs.google.com/spreadsheets/d/1GAeBzMr0XX89azZhpbjEqPfehgruwI3__GlfEgQ1VvA/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "Kolibri#7675",
+      "count_credit": "Kolibri#7675",
       "vid": "https://youtu.be/KlgZlck5kQQ?t=842",
       "count": "https://docs.google.com/spreadsheets/d/1zCwdd6_KYFqMD4OQ_llGLdDshoZTu_1pmAMysxGDQvs/edit?usp=sharing"
     }

--- a/ui/packages/docs/src/components/Params/character_data.json
+++ b/ui/packages/docs/src/components/Params/character_data.json
@@ -321,13 +321,6 @@
       "desc": "0 for no Glide Cancel (default), 1 for Glide Cancel. Using high_plunge after Skill with a Glide Cancel is not allowed."
     }
   ],
-  "keqing": [
-    {
-      "ability": "skill",
-      "param": "c1",
-      "desc": "Number of hits for C1. Default 1 hit, maximum 2 hits."
-    }
-  ],
   "kirara": [
     {
       "ability": "skill",


### PR DESCRIPTION
closes #1400 

There were two major issues:
- wrong c1 hitmark timing (too late for c1 start but correct for c1 end)
- wrong e recast hitmark timing

In detail:
- fix c1 start hitmark timing (recast hitmark (27f) -> 3f), c1 end hitmark is correctly at recast hitmark
- fix start and end hitboxes
- remove c1 param because disabling c1 start hit can be achieved via moving player/target before doing recast e
- fix keqing e recast hitmark frames being too long (27f -> 16f), also affects c1 end hitmark timing
