### PR TITLE
fix source reaction bar chart text cutting off

### DIFF
--- a/ui/packages/ui/src/Pages/Viewer/Components/Miscellaneous/SourceReactionsBarChart/BarChart.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Miscellaneous/SourceReactionsBarChart/BarChart.tsx
@@ -27,6 +27,8 @@ export const BarChartLegend = ({ names }: { names?: string[] }) => {
   );
 };
 
+const margin = { top: 0, left: 140, right: 20, bottom: 40 };
+
 const Graph = ({ width, height, reactions, names }: Props) => {
   const { data, sources, xMax } = useData(reactions, names);
 
@@ -54,6 +56,7 @@ const Graph = ({ width, height, reactions, names }: Props) => {
       stat={(d, k) => d.data[names[k]].data}
       barColor={k => DataColors.character(k)}
       hoverColor={k => DataColors.characterLabel(k)}
+      margin={margin}
       tooltipContent={(d, k) => (
         <FloatStatTooltipContent
             title={names[k] + ": " + d.source}


### PR DESCRIPTION
before:
![grafik](https://github.com/genshinsim/gcsim/assets/98557316/7f4fb2ab-7b49-4b09-b009-e5936313df43)
after:
![grafik](https://github.com/genshinsim/gcsim/assets/98557316/1231d3f6-fe76-4f8d-97e3-5be1fa829a60)

crystallize-electro is the longest reaction name we have.