### PR TITLE
keqing recast e -> dash and CanQueueAfter, keqing a1 duration

### DIFF
--- a/internal/characters/keqing/asc.go
+++ b/internal/characters/keqing/asc.go
@@ -12,8 +12,8 @@ func (c *char) a1() {
 	if c.Base.Ascension < 1 {
 		return
 	}
-	// account for it starting somewhere around hitmark
-	dur := 300 + skillRecastHitmark
+	// account for it starting a bit after hitmark to cover 5 N1C
+	dur := 300 + 20
 	c.Core.Status.Add("keqinginfuse", dur)
 	c.Core.Player.AddWeaponInfuse(
 		c.Index,

--- a/internal/characters/keqing/skill.go
+++ b/internal/characters/keqing/skill.go
@@ -11,11 +11,13 @@ import (
 )
 
 var skillFrames []int
+var skillRecastFrames []int
 
 const (
-	skillHitmark   = 25
-	stilettoKey    = "keqingstiletto"
-	particleICDKey = "keqing-particle-icd"
+	skillHitmark       = 25
+	skillRecastHitmark = 16
+	stilettoKey        = "keqingstiletto"
+	particleICDKey     = "keqing-particle-icd"
 )
 
 func init() {
@@ -30,8 +32,8 @@ func init() {
 	// skill (recast) -> x
 	skillRecastFrames = frames.InitAbilSlice(43)
 	skillRecastFrames[action.ActionAttack] = 42
-	skillRecastFrames[action.ActionDash] = 15
-	skillRecastFrames[action.ActionJump] = 16
+	skillRecastFrames[action.ActionDash] = skillRecastHitmark
+	skillRecastFrames[action.ActionJump] = skillRecastHitmark
 	skillRecastFrames[action.ActionSwap] = 42
 }
 
@@ -79,10 +81,6 @@ func (c *char) skillFirst(p map[string]int) action.ActionInfo {
 		State:           action.SkillState,
 	}
 }
-
-var skillRecastFrames []int
-
-const skillRecastHitmark = 16
 
 func (c *char) skillRecast(p map[string]int) action.ActionInfo {
 	// C1 DMG happens before Recast DMG


### PR DESCRIPTION
- fix keqing recast e -> dash frames and CanQueueAfter
- fix keqing A1 duration so that it entirely covers 5 N1C since that is possible ingame, see #567. In the live version, the CA-2 hit of the final CA was not covered by the A1 infusion.

closes #1400 