### PR TITLE
remove xingqiu e/q orbital param

### DIFF
--- a/internal/characters/xingqiu/burst.go
+++ b/internal/characters/xingqiu/burst.go
@@ -53,15 +53,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 	}
 	dur = dur * 60
 	c.AddStatus(burstKey, dur+33, true) // add 33f for anim
-
-	orbital, ok := p["orbital"]
-	if !ok {
-		orbital = 1
-	}
-
-	if orbital == 1 {
-		c.applyOrbital(dur, burstHitmark)
-	}
+	c.applyOrbital(dur, burstHitmark)
 
 	c.burstCounter = 0
 	c.numSwords = 2

--- a/internal/characters/xingqiu/skill.go
+++ b/internal/characters/xingqiu/skill.go
@@ -71,15 +71,8 @@ func (c *char) Skill(p map[string]int) action.ActionInfo {
 		}, skillHitmarks[i])
 	}
 
-	orbital, ok := p["orbital"]
-	if !ok {
-		orbital = 1
-	}
-
 	// orbitals apply wet at 44f
-	if orbital == 1 {
-		c.applyOrbital(15*60, 43) //takes 1 frame to apply it
-	}
+	c.applyOrbital(15*60, 43) //takes 1 frame to apply it
 
 	//should last 15s, cd 21s
 	c.SetCDWithDelay(action.ActionSkill, 21*60, 10)

--- a/ui/packages/docs/src/components/Params/character_data.json
+++ b/ui/packages/docs/src/components/Params/character_data.json
@@ -620,18 +620,6 @@
       "desc": "0 for no collision dmg (default), 1 for collision dmg."
     }
   ],
-  "xingqiu": [
-    {
-      "ability": "skill",
-      "param": "orbital",
-      "desc": "0 to disable orbitals from Skill. Default 1 (orbitals enabled)."
-    },
-    {
-      "ability": "burst",
-      "param": "orbital",
-      "desc": "0 to disable orbitals from Burst. Default 1 (orbitals enabled)."
-    }
-  ],
   "yaemiko": [
     {
       "ability": "attack",


### PR DESCRIPTION
since the hitbox refactor the same effect can be achieved by moving the player/target, see <https://docs.gcsim.app/reference/system_functions#set_player_pos> so that the orbital aoe (1.3m radius around player) does not hit.

need opinions on this because this breaks all sims using orbital=0 that do not adjust player/target pos