### PR TITLE
adjust noelle extend param default

### DIFF
--- a/internal/characters/noelle/burst.go
+++ b/internal/characters/noelle/burst.go
@@ -57,7 +57,7 @@ func (c *char) Burst(p map[string]int) action.ActionInfo {
 				ext = 10
 			}
 		} else {
-			ext = 10 // to maintain prev default behaviour of full extension
+			ext = 0 // c6 extension bug requires specific rotations, otherwise it does not happen so default is 0
 		}
 
 		dur += ext * 60

--- a/ui/packages/docs/src/components/Params/character_data.json
+++ b/ui/packages/docs/src/components/Params/character_data.json
@@ -455,7 +455,7 @@
     {
       "ability": "burst",
       "param": "extend",
-      "desc": "Number of seconds to extend Burst by. Value must be between 0 and 10. Default 10."
+      "desc": "Number of seconds to extend Burst by. Value must be between 0 and 10. Default 0."
     }
   ],
   "razor": [


### PR DESCRIPTION
https://discord.com/channels/845087716541595668/1034835649762689105
- no longer assumes max extension/c6 extension bug by default

Breaking change for all noelle sims that currently do not explicitly specify the `extend` param on `burst`.
I think it's worth it, because the max extension via c6 bug is probably not reasonable to assume for noelle sims since it depends on the rotation whether it can be achieved or not.