### PR TITLE
fix wanderer a1

### DIFF
--- a/internal/characters/wanderer/asc.go
+++ b/internal/characters/wanderer/asc.go
@@ -89,40 +89,33 @@ func (c *char) a4() bool {
 	return true
 }
 
-// A1 ascension level check happens once inside of skill.go and on every A1 electro callback creation
-
 // If Hanega: Song of the Wind comes into contact with Hydro/Pyro/Cryo/Electro when it is unleashed,
 // this instance of the Windfavored state will obtain buffs.
 func (c *char) absorbCheckA1() {
-	if len(c.a1ValidBuffs) <= c.a1MaxAbsorb {
-		return
-	}
-
 	a1AbsorbCheckLocation := combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 5)
-	absorbCheck := c.Core.Combat.AbsorbCheck(a1AbsorbCheckLocation, c.a1ValidBuffs...)
-
-	if absorbCheck != attributes.NoElement {
+	a1Proc := false // for C4
+	// max 2 A1 elements from absorb check
+	for i := 0; i < 2; i++ {
+		absorbCheck := c.Core.Combat.AbsorbCheck(a1AbsorbCheckLocation, c.a1ValidBuffs...)
+		if absorbCheck == attributes.NoElement {
+			continue
+		}
+		a1Proc = true
+		c.addA1Buff(absorbCheck)
+		c.deleteFromValidBuffs(absorbCheck)
 		c.Core.Log.NewEventBuildMsg(glog.LogCharacterEvent, c.Index,
 			"wanderer a1 absorbed ", absorbCheck.String(),
 		)
-		c.deleteFromValidBuffs(absorbCheck)
-		c.addA1Buff(absorbCheck)
-		if c.Base.Cons >= 4 && len(c.a1ValidBuffs) == 3 {
-			chosenElement := c.a1ValidBuffs[c.Core.Rand.Intn(len(c.a1ValidBuffs))]
-			c.addA1Buff(chosenElement)
-			c.deleteFromValidBuffs(chosenElement)
-			c.Core.Log.NewEventBuildMsg(glog.LogCharacterEvent, c.Index,
-				"wanderer c4 applied a1 ", chosenElement.String(),
-			)
-		}
 	}
-
-	//otherwise queue up
-	delay := 6
-	if c.skydwellerPoints*6 > delay {
-		c.Core.Tasks.Add(c.absorbCheckA1, delay)
+	// add A1 buff from C4 if at least 1 A1 element was absorbed
+	if c.Base.Cons >= 4 && a1Proc {
+		chosenElement := c.a1ValidBuffs[c.Core.Rand.Intn(len(c.a1ValidBuffs))]
+		c.addA1Buff(chosenElement)
+		c.deleteFromValidBuffs(chosenElement)
+		c.Core.Log.NewEventBuildMsg(glog.LogCharacterEvent, c.Index,
+			"wanderer c4 applied a1 ", chosenElement.String(),
+		)
 	}
-
 }
 
 // - Hydro: Kuugoryoku Point cap increases by 20.

--- a/internal/characters/wanderer/skill.go
+++ b/internal/characters/wanderer/skill.go
@@ -53,7 +53,7 @@ func (c *char) skillActivate(p map[string]int) action.ActionInfo {
 
 	c.Core.QueueAttack(ai, combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 6), skillHitmark, skillHitmark)
 
-	// Initial A1 Absorption test
+	// A1
 	if c.Base.Ascension >= 1 {
 		c.a1ValidBuffs = []attributes.Element{attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo}
 		c.absorbCheckA1()

--- a/internal/characters/wanderer/wanderer.go
+++ b/internal/characters/wanderer/wanderer.go
@@ -19,7 +19,6 @@ type char struct {
 	skydwellerPoints    int
 	maxSkydwellerPoints int
 	a1ValidBuffs        []attributes.Element
-	a1MaxAbsorb         int
 	a4Prob              float64
 	c6Count             int
 }
@@ -43,11 +42,6 @@ func (c *char) Init() error {
 	c.maxSkydwellerPoints = 100
 	c.a4Prob = 0.16
 	c.a1ValidBuffs = []attributes.Element{attributes.Pyro, attributes.Hydro, attributes.Electro, attributes.Cryo}
-
-	c.a1MaxAbsorb = 2
-	if c.Base.Cons >= 4 {
-		c.a1MaxAbsorb = 1
-	}
 
 	return nil
 }


### PR DESCRIPTION
- fix a1 checking on interval instead of only once on cast (meaning a1 could be absorbing the 2nd or 3rd (C4) element after skill cast)
- fix a1 not being able to absorb >1 or >2 (C4) elements on cast