### PR TITLE
fix keqing a1, na/ca frames and n1 -> ca

### DIFF
--- a/internal/characters/keqing/asc.go
+++ b/internal/characters/keqing/asc.go
@@ -12,9 +12,12 @@ func (c *char) a1() {
 	if c.Base.Ascension < 1 {
 		return
 	}
-	// account for it starting a bit after hitmark to cover 5 N1C
-	dur := 300 + 20
-	c.Core.Status.Add("keqinginfuse", dur)
+	// starts on E Recast start
+	// should actually be 5.6s
+	// should barely cover EE N1 Q N1 E 2N1C / 5N1C N1
+	// very susceptible to break
+	dur := 5*60 + 20
+	c.AddStatus("keqinginfuse", dur, true)
 	c.Core.Player.AddWeaponInfuse(
 		c.Index,
 		"keqing-a1",

--- a/internal/characters/keqing/attack.go
+++ b/internal/characters/keqing/attack.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	attackFrames          [][]int
-	attackHitmarks        = [][]int{{11}, {11}, {15}, {12, 22}, {26}}
+	attackHitmarks        = [][]int{{10}, {10}, {14}, {11, 21}, {22}}
 	attackHitlagHaltFrame = [][]float64{{.03}, {.03}, {.06}, {0, .03}, {0}}
 	attackDefHalt         = [][]bool{{true}, {true}, {true}, {false, true}, {false}}
 	attackHitboxes        = [][]float64{{1.5, 2.2}, {1.5}, {1.8}, {1.5}, {0.8}}
@@ -89,10 +89,18 @@ func (c *char) Attack(p map[string]int) action.ActionInfo {
 
 	defer c.AdvanceNormalIndex()
 
-	return action.ActionInfo{
+	act := action.ActionInfo{
 		Frames:          frames.NewAttackFunc(c.Character, attackFrames),
 		AnimationLength: attackFrames[c.NormalCounter][action.InvalidAction],
 		CanQueueAfter:   attackHitmarks[c.NormalCounter][len(attackHitmarks[c.NormalCounter])-1],
 		State:           action.NormalAttackState,
 	}
+
+	if c.NormalCounter == 0 {
+		act.UseNormalizedTime = func(next action.Action) bool {
+			return next == action.ActionCharge
+		}
+	}
+
+	return act
 }

--- a/internal/characters/keqing/charge.go
+++ b/internal/characters/keqing/charge.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	chargeFrames   []int
-	chargeHitmarks = []int{22, 24}
+	chargeHitmarks = []int{21, 24}
 	chargeRadius   = []float64{2.2, 2.3}
 	chargeOffsets  = []float64{1.5, 1.8}
 )


### PR DESCRIPTION
https://discord.com/channels/845087716541595668/1138052124803076167

[Sample](https://github.com/genshinsim/gcsim/files/12294141/keqingceiling.gz) to upload [here](https://gcsim.app/sample/upload).

Config:
```
options swap_delay=12 iteration=1;
energy every interval=480,720 amount=200;

keqing char lvl=90/90 cons=0 talent=10,10,10;
keqing add weapon="dullblade" refine=1 lvl=1/20;
keqing add set="tf" count=4;
keqing add stats atk=42 cr=0.311 ; #main
keqing add stats atk=14 atk%=0.095  em=39.627 cd=0.287;


nahida char lvl=90/90 cons=4 talent=8,10,10;
nahida add weapon="apprenticesnotes" refine=1 lvl=1/20;

collei char lvl=90/90 cons=6 talent=9,9,9;
collei add weapon="huntersbow" refine=1 lvl=1/20;

active nahida;

target lvl=85 resist=0.1 radius=2 pos=0,2.4 hp=999999999; 

nahida skill;
wait(60);
# E E N1 Q N1 E 2xN1C
keqing skill, skill,
       attack,
       burst,
       attack,
       skill,
       attack, charge,
       attack, charge;
keqing attack;
wait(5*60);
# E E 5xN1C N1
keqing skill, skill,
       attack, charge,
       attack, charge,
       attack, charge,
       attack, charge,
       attack, charge,
       attack;
wait(20*60);
nahida skill;
# E Q E N1C N1 E 3xN1C N1
keqing skill, 
       burst, 
       skill, 
       attack, charge, 
       attack, skill, 
       attack, charge, 
       attack, charge, 
       attack, charge, 
       attack;
wait(5*60);
keqing attack;
```
