### PR TITLE
Make enemy example sensical

### DIFF
--- a/ui/packages/docs/docs/reference/config.md
+++ b/ui/packages/docs/docs/reference/config.md
@@ -98,7 +98,7 @@ If you set this to a negative number or a really large number, behaviour is unde
 
 Example:
 ```
-target lvl=88 resist=0.1 pos=0,0 radius=2 freeze_resist=0.8 hp=9999 particle_threshold=200 particle_drop_count=2;
+target lvl=95 resist=0.1 pos=2.4,0 radius=2 freeze_resist=0.5 hp=795002 particle_threshold=262350 particle_drop_count=3;
 ```
 
 | name | description | default |


### PR DESCRIPTION
Somewhat based on this guy: https://genshin-impact.fandom.com/wiki/Consecrated_Horned_Crocodile
I applied 2.5x abyss multiplier on the HP values.

Instead of dropping 2 Hydro orbs, I've adjusted it to drop 1 clear orb, which gives the same amount of energy to non Hydro units.