### PR TITLE
fix wanderer a4 being able to proc 2 times in 1 dash

### DIFF
--- a/internal/characters/wanderer/asc.go
+++ b/internal/characters/wanderer/asc.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	a4Key           = "wanderer-a4"
+	a4Prevent       = "wanderer-a4-prevent"
 	a4IcdKey        = "wanderer-a4-icd"
 	a1ElectroKey    = "wanderer-a1-electro"
 	a1ElectroIcdKey = "wanderer-a1-electro-icd"
@@ -40,7 +41,7 @@ func (c *char) makeA4CB() combat.AttackCBFunc {
 			return
 		}
 
-		c.Core.Log.NewEvent("wanderer-a4 proc'd", glog.LogCharacterEvent, c.Index).
+		c.Core.Log.NewEvent("wanderer-a4 available", glog.LogCharacterEvent, c.Index).
 			Write("probability", c.a4Prob)
 
 		c.a4Prob = 0.16
@@ -61,7 +62,13 @@ func (c *char) a4() bool {
 	if !c.StatusIsActive(a4Key) {
 		return false
 	}
+	if c.StatusIsActive(a4Prevent) {
+		return false
+	}
 	c.DeleteStatus(a4Key)
+	c.AddStatus(a4Prevent, 20, true) // prevent a4 proccing again for 20f, should be enough to prevent 2 procs in single dash
+
+	c.Core.Log.NewEvent("wanderer-a4 proc'd", glog.LogCharacterEvent, c.Index)
 
 	a4Mult := 0.35
 

--- a/internal/characters/wanderer/skill.go
+++ b/internal/characters/wanderer/skill.go
@@ -103,6 +103,9 @@ func (c *char) skillEndRoutine() int {
 	if c.StatusIsActive(a4Key) {
 		c.DeleteStatus(a4Key)
 	}
+	if c.StatusIsActive(a4Prevent) {
+		c.DeleteStatus(a4Prevent)
+	}
 
 	c.skydwellerPoints = 0
 	c.a4Prob = 0.16


### PR DESCRIPTION
https://discord.com/channels/845087716541595668/1140029212607139880

Also adjust the char logs for wanderer a4 ("proc'd" moved to when a4 actually fires off arrows and added "available" log for when a4 is available to be used).