### PR TITLE
fix goldentroupe 2pc

### DIFF
--- a/internal/artifacts/goldentroupe/goldentroupe.go
+++ b/internal/artifacts/goldentroupe/goldentroupe.go
@@ -30,6 +30,9 @@ type Set struct {
 func (s *Set) SetIndex(idx int) { s.Index = idx }
 
 func (s *Set) Init() error {
+	if s.buff == nil { // no 4pc
+		return nil
+	}
 	if s.core.Player.Active() != s.char.Index {
 		s.gainBuff()
 	}


### PR DESCRIPTION
the program chashed due to no initialization of `buff` when no 4pc gt
![image](https://github.com/genshinsim/gcsim/assets/35897995/6e5905bb-8d8e-463d-9412-6168f3ed9aa2)
