### PR TITLE
fix hp bond weapons atk calc and active unit check

### DIFF
--- a/internal/weapons/catalyst/flowingpurity/flowingpurity.go
+++ b/internal/weapons/catalyst/flowingpurity/flowingpurity.go
@@ -48,6 +48,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	bondDMGPCap := 0.09 + float64(r)*0.03
 
 	c.Events.Subscribe(event.OnSkill, func(args ...interface{}) bool {
+		if c.Player.Active() != char.Index {
+			return false
+		}
 		if char.StatusIsActive(icdKey) {
 			return false
 		}
@@ -65,7 +68,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 
 		char.SetHPDebtByRatio(hp)
 		debt := char.CurrentHPDebt()
-		bondDMGP := (debt / 1000) * bondPercentage // use hp debt since you only get the buff after clearing bond anyway
+		bondDMGP := debt * bondPercentage // use hp debt since you only get the buff after clearing bond anyway
 		if bondDMGP > bondDMGPCap {
 			bondDMGP = bondDMGPCap
 		}

--- a/internal/weapons/catalyst/flowingpurity/flowingpurity.go
+++ b/internal/weapons/catalyst/flowingpurity/flowingpurity.go
@@ -68,7 +68,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 
 		char.SetHPDebtByRatio(hp)
 		debt := char.CurrentHPDebt()
-		bondDMGP := debt * bondPercentage // use hp debt since you only get the buff after clearing bond anyway
+		bondDMGP := (debt / 1000) * bondPercentage // use hp debt since you only get the buff after clearing bond anyway
 		if bondDMGP > bondDMGPCap {
 			bondDMGP = bondDMGPCap
 		}

--- a/internal/weapons/sword/finaleofthedeep/finaleofthedeep.go
+++ b/internal/weapons/sword/finaleofthedeep/finaleofthedeep.go
@@ -46,6 +46,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 	bondAtkCap := 112.5 + float64(r)*37.5
 
 	c.Events.Subscribe(event.OnSkill, func(args ...interface{}) bool {
+		if c.Player.Active() != char.Index {
+			return false
+		}
 		if char.StatusIsActive(icdKey) {
 			return false
 		}
@@ -63,7 +66,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p weapon.WeaponProfile
 
 		char.SetHPDebtByRatio(hp)
 		debt := char.CurrentHPDebt()
-		bondAtk := (debt / 1000) * bondPercentage // use hp debt since you only get the buff after clearing bond anyway
+		bondAtk := debt * bondPercentage // use hp debt since you only get the buff after clearing bond anyway
 		if bondAtk > bondAtkCap {
 			bondAtk = bondAtkCap
 		}


### PR DESCRIPTION
From [Discord](https://discord.com/channels/845087716541595668/1143010182562062377/1143010182562062377):

Sample before commits: https://gcsim.app/sh/FWJWTC7CgTfk#sample=10236862637200687826&tab=sample

HP bonds were previously: 
1) activating on any ally skill (47f)
2) giving a flat atk buff lower than intended by a factor of 1000 (531f, atk gain should be 233 not 0.23)