### PR TITLE
hide filter names except for traveler element

### DIFF
--- a/ui/packages/db/src/SharedComponents/Filter.tsx
+++ b/ui/packages/db/src/SharedComponents/Filter.tsx
@@ -207,6 +207,8 @@ function CharFilterButtonChild({ charName }: { charName: string }) {
   const t = (s: string) => translation<string>(s);
   const displayCharName = t("game:character_names." + charName);
 
+  const travelerName = (charName.includes("lumine") || charName.includes("aether") ? displayCharName : "").replace(/.*?\((\S+)\).*?/, "$1")
+
   return (
     <div className="flex flex-col truncate gap-1">
       <img
@@ -214,7 +216,7 @@ function CharFilterButtonChild({ charName }: { charName: string }) {
         src={`/api/assets/avatar/${charName}.png`}
         className="truncate h-16 object-contain"
       />
-      <div className="text-center">{displayCharName}</div>
+      { travelerName != "" ?  <div className="text-center">{travelerName}</div> : <></> }
     </div>
   );
 }


### PR DESCRIPTION
Hide character names in DB filter except for traveler element (since it's hard to tell from the picture):

![image](https://github.com/genshinsim/gcsim/assets/906239/b9b2eae4-24f5-4d0a-aab6-3050e371b704)

<img width="367" alt="image" src="https://github.com/genshinsim/gcsim/assets/906239/6d6bcc85-3f41-4d7f-8222-164f0df65109">

<img width="350" alt="image" src="https://github.com/genshinsim/gcsim/assets/906239/19b1931d-8781-4fd9-a0a6-461f31419185">
