### PR TITLE
force functions to return number if null return

### DIFF
--- a/pkg/gcs/eval.go
+++ b/pkg/gcs/eval.go
@@ -203,9 +203,10 @@ type (
 	}
 
 	funcval struct {
-		Args []*ast.Ident
-		Body *ast.BlockStmt
-		Env  *Env
+		Args      []*ast.Ident
+		Body      *ast.BlockStmt
+		Signature *ast.FuncType
+		Env       *Env
 	}
 
 	systemFunc func(*ast.CallExpr, *Env) (Obj, error)

--- a/pkg/gcs/stmt.go
+++ b/pkg/gcs/stmt.go
@@ -86,9 +86,10 @@ func (e *Eval) evalFnStmt(l *ast.FnStmt, env *Env) (Obj, error) {
 		return nil, fmt.Errorf("function %v already exists; cannot redeclare", l.Ident.Val)
 	}
 	var res Obj = &funcval{
-		Args: l.Func.Args,
-		Body: l.Func.Body,
-		Env:  NewEnv(env),
+		Args:      l.Func.Args,
+		Body:      l.Func.Body,
+		Signature: l.Func.Signature,
+		Env:       NewEnv(env),
 	}
 	env.varMap[l.Ident.Val] = &res
 	return &null{}, nil


### PR DESCRIPTION
Fixes following error on existing sims:

```
fn random_wait returned an invalid type; got 0
```