### PR TITLE
Initial implementation of self damage

### DIFF
--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -55,8 +55,8 @@ func (p *Player) HandleAttack(atk *combat.AttackEvent) float64 {
 	evt.Write("target", p.Key()).
 		Write("attack-tag", atk.Info.AttackTag).
 		Write("ele", atk.Info.Element.String()).
+		Write("damage_pre_shield", &dmg).
 		Write("damage", &dmgLeft).
-		Write("damage_before_shield", &dmg).
 		Write("crit", &crit).
 		Write("amp", &amp).
 		Write("cata", &cata).
@@ -68,9 +68,13 @@ func (p *Player) HandleAttack(atk *combat.AttackEvent) float64 {
 		if atk.Info.ActorIndex < 0 {
 			log.Println(atk)
 		}
-		preDmgModDebug := p.Core.Combat.Team.CombatByIndex(atk.Info.ActorIndex).ApplyAttackMods(atk, p)
+		preDmgModDebug := p.Core.Combat.Team.CombatByIndex(atk.Info.ActorIndex).
+			ApplyAttackMods(atk, p)
 		evt.Write("pre_damage_mods", preDmgModDebug)
 	}
+
+	// returns 0 so that the damage done to player doesn't count
+	// towards the sim's TotalDamage and DPS statistic
 	return 0
 }
 func (t *Player) calc(atk *combat.AttackEvent, evt glog.Event) (float64, bool) {
@@ -119,8 +123,7 @@ func (t *Player) calc(atk *combat.AttackEvent, evt glog.Event) (float64, bool) {
 	}
 
 	char := t.Core.Player.ActiveChar()
-	// Players don't have resistances right now
-	// res := char.Stat(attributes.DendroRes
+	// TODO: Players don't have resistances right now
 	res := 0.0
 
 	def := char.Base.Def*(1+char.Stat(attributes.DEFP)) + char.Stat(attributes.DEF)
@@ -198,6 +201,7 @@ func (t *Player) calc(atk *combat.AttackEvent, evt glog.Event) (float64, bool) {
 			Write("ele_per", elePer).
 			Write("bonus_dmg", dmgBonus).
 			Write("ignore_def", atk.Info.IgnoreDefPercent).
+			Write("def_adj", 0). // Players don't have DefMods applied
 			Write("target_lvl", char.Base.Level).
 			Write("char_lvl", atk.Snapshot.CharLvl).
 			Write("def_mod", defmod).

--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -1,12 +1,15 @@
 package avatar
 
 import (
+	"log"
+
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/geometry"
 	"github.com/genshinsim/gcsim/pkg/core/glog"
+	"github.com/genshinsim/gcsim/pkg/core/player"
 	"github.com/genshinsim/gcsim/pkg/core/reactions"
 	"github.com/genshinsim/gcsim/pkg/core/targets"
 	"github.com/genshinsim/gcsim/pkg/reactable"
@@ -31,8 +34,198 @@ func (p *Player) Type() targets.TargettableType { return targets.TargettablePlay
 func (p *Player) HandleAttack(atk *combat.AttackEvent) float64 {
 	p.Core.Combat.Events.Emit(event.OnPlayerHit, p, atk)
 
-	//TODO: implement player taking damage here
+	var amp string
+	var cata string
+	var dmg float64
+	var crit bool
+	evt := p.Core.Combat.Log.NewEvent(atk.Info.Abil, glog.LogDamageEvent, atk.Info.ActorIndex).
+		Write("target", p.Key()).
+		Write("attack-tag", atk.Info.AttackTag).
+		Write("ele", atk.Info.Element.String()).
+		Write("damage", &dmg).
+		Write("crit", &crit).
+		Write("amp", &amp).
+		Write("cata", &cata).
+		Write("abil", atk.Info.Abil).
+		Write("source_frame", atk.SourceFrame)
+	evt.WriteBuildMsg(atk.Snapshot.Logs...)
+
+	if !atk.Info.SourceIsSim {
+		if atk.Info.ActorIndex < 0 {
+			log.Println(atk)
+		}
+		preDmgModDebug := p.Core.Combat.Team.CombatByIndex(atk.Info.ActorIndex).ApplyAttackMods(atk, p)
+		evt.Write("pre_damage_mods", preDmgModDebug)
+	}
+
+	// TODO: Implement reactions on player
+
+	dmg, crit = p.calc(atk, evt)
+
+	active := p.Core.Player.Active()
+	shielded := p.Core.Player.Shields.OnDamage(active, dmg, atk.Info.Element)
+	dmg -= shielded
+	if dmg > 0 {
+		p.Core.Player.Drain(player.DrainInfo{
+			ActorIndex: atk.Info.ActorIndex,
+			Abil:       atk.Info.Abil,
+			Amount:     dmg,
+		})
+	}
 	return 0
+}
+func (t *Player) calc(atk *combat.AttackEvent, evt glog.Event) (float64, bool) {
+
+	var isCrit bool
+
+	st := attributes.EleToDmgP(atk.Info.Element)
+	// if st < 0 {
+	// 	log.Println(atk)
+	// }
+	elePer := 0.0
+	if st > -1 {
+		elePer = atk.Snapshot.Stats[st]
+		// Generally not needed except for sim issues
+		// t.Core.Log.NewEvent("ele lookup ok",
+		// 	glog.LogCalc, atk.Info.ActorIndex,
+		// 	"attack_tag", atk.Info.AttackTag,
+		// 	"ele", atk.Info.Element,
+		// 	"st", st,
+		// 	"percent", atk.Snapshot.Stats[st],
+		// 	"abil", atk.Info.Abil,
+		// 	"stats", atk.Snapshot.Stats,
+		// 	"target", t.TargetIndex,
+		// )
+	}
+	dmgBonus := elePer + atk.Snapshot.Stats[attributes.DmgP]
+
+	//calculate using attack or def
+	var a float64
+	totalhp := atk.Snapshot.BaseHP*(1+atk.Snapshot.Stats[attributes.HPP]) + atk.Snapshot.Stats[attributes.HP]
+	if atk.Info.UseDef {
+		a = atk.Snapshot.BaseDef*(1+atk.Snapshot.Stats[attributes.DEFP]) + atk.Snapshot.Stats[attributes.DEF]
+	} else {
+		a = atk.Snapshot.BaseAtk*(1+atk.Snapshot.Stats[attributes.ATKP]) + atk.Snapshot.Stats[attributes.ATK]
+	}
+
+	base := atk.Info.Mult*a + atk.Info.FlatDmg
+	damage := base * (1 + dmgBonus)
+
+	//make sure 0 <= cr <= 1
+	if atk.Snapshot.Stats[attributes.CR] < 0 {
+		atk.Snapshot.Stats[attributes.CR] = 0
+	}
+	if atk.Snapshot.Stats[attributes.CR] > 1 {
+		atk.Snapshot.Stats[attributes.CR] = 1
+	}
+
+	char := t.Core.Player.ActiveChar()
+	// Players don't have resistances right now
+	// res := char.Stat(attributes.DendroRes
+	res := 0.0
+
+	def := char.Base.Def*(1+char.Stat(attributes.DEFP)) + char.Stat(attributes.DEF)
+
+	def *= (1 - atk.Info.IgnoreDefPercent)
+	defmod := 1 - def/(def+float64(5*atk.Snapshot.CharLvl)+500)
+
+	//apply def mod
+	damage = damage * defmod
+	//apply resist mod
+
+	resmod := 1 - res/2
+	if res >= 0 && res < 0.75 {
+		resmod = 1 - res
+	} else if res > 0.75 {
+		resmod = 1 / (4*res + 1)
+	}
+	damage = damage * resmod
+
+	precritdmg := damage
+
+	//check if crit
+	if atk.Info.HitWeakPoint || t.Core.Rand.Float64() <= atk.Snapshot.Stats[attributes.CR] {
+		damage = damage * (1 + atk.Snapshot.Stats[attributes.CD])
+		isCrit = true
+	}
+
+	preampdmg := damage
+
+	//calculate em bonus
+	em := atk.Snapshot.Stats[attributes.EM]
+	emBonus := (2.78 * em) / (1400 + em)
+	var reactBonus float64
+	//check melt/vape
+	if atk.Info.Amped {
+		reactBonus = t.Core.Player.ByIndex(atk.Info.ActorIndex).ReactBonus(atk.Info)
+		// t.Core.Log.Debugw("debug", "frame", t.Core.F, core.LogPreDamageMod, "char", t.Index, "char_react", char.CharIndex(), "reactbonus", char.ReactBonus(atk.Info), "damage_pre", damage)
+		damage = damage * (atk.Info.AmpMult * (1 + emBonus + reactBonus))
+	}
+
+	//reduce damage by damage group
+	x := 1.0
+	if !atk.Info.SourceIsSim {
+		x = t.GroupTagDamageMult(atk.Info.ICDTag, atk.Info.ICDGroup, atk.Info.ActorIndex)
+		damage = damage * x
+	}
+
+	if t.Core.Flags.LogDebug {
+		t.Core.Log.NewEvent(
+			atk.Info.Abil,
+			glog.LogCalc,
+			atk.Info.ActorIndex,
+		).
+			Write("src_frame", atk.SourceFrame).
+			Write("damage_grp_mult", x).
+			Write("damage", damage).
+			Write("abil", atk.Info.Abil).
+			Write("talent", atk.Info.Mult).
+			Write("base_atk", atk.Snapshot.BaseAtk).
+			Write("flat_atk", atk.Snapshot.Stats[attributes.ATK]).
+			Write("atk_per", atk.Snapshot.Stats[attributes.ATKP]).
+			Write("use_def", atk.Info.UseDef).
+			Write("base_def", atk.Snapshot.BaseDef).
+			Write("flat_def", atk.Snapshot.Stats[attributes.DEF]).
+			Write("def_per", atk.Snapshot.Stats[attributes.DEFP]).
+			Write("base_hp", atk.Snapshot.BaseHP).
+			Write("flat_hp", atk.Snapshot.Stats[attributes.HP]).
+			Write("hp_per", atk.Snapshot.Stats[attributes.HPP]).
+			Write("total_hp", totalhp).
+			Write("catalyzed", atk.Info.Catalyzed).
+			Write("flat_dmg", atk.Info.FlatDmg).
+			Write("total_atk_def", a).
+			Write("base_dmg", base).
+			Write("ele", st).
+			Write("ele_per", elePer).
+			Write("bonus_dmg", dmgBonus).
+			Write("ignore_def", atk.Info.IgnoreDefPercent).
+			Write("target_lvl", char.Base.Level).
+			Write("char_lvl", atk.Snapshot.CharLvl).
+			Write("def_mod", defmod).
+			Write("res", res).
+			Write("res_mod", resmod).
+			Write("cr", atk.Snapshot.Stats[attributes.CR]).
+			Write("cd", atk.Snapshot.Stats[attributes.CD]).
+			Write("pre_crit_dmg", precritdmg).
+			Write("dmg_if_crit", precritdmg*(1+atk.Snapshot.Stats[attributes.CD])).
+			Write("avg_crit_dmg", (1-atk.Snapshot.Stats[attributes.CR])*precritdmg+atk.Snapshot.Stats[attributes.CR]*precritdmg*(1+atk.Snapshot.Stats[attributes.CD])).
+			Write("is_crit", isCrit).
+			Write("pre_amp_dmg", preampdmg).
+			Write("reaction_type", atk.Info.AmpType).
+			Write("melt_vape", atk.Info.Amped).
+			Write("react_mult", atk.Info.AmpMult).
+			Write("em", em).
+			Write("em_bonus", emBonus).
+			Write("react_bonus", reactBonus).
+			Write("amp_mult_total", (atk.Info.AmpMult*(1+emBonus+reactBonus))).
+			Write("pre_crit_dmg_react", precritdmg*(atk.Info.AmpMult*(1+emBonus+reactBonus))).
+			Write("dmg_if_crit_react", precritdmg*(1+atk.Snapshot.Stats[attributes.CD])*(atk.Info.AmpMult*(1+emBonus+reactBonus))).
+			Write("avg_crit_dmg_react", ((1-atk.Snapshot.Stats[attributes.CR])*precritdmg+atk.Snapshot.Stats[attributes.CR]*precritdmg*(1+atk.Snapshot.Stats[attributes.CD]))*(atk.Info.AmpMult*(1+emBonus+reactBonus))).
+			Write("target", t.Key())
+
+	}
+
+	return damage, isCrit
 }
 
 func (p *Player) ApplySelfInfusion(ele attributes.Element, dur reactions.Durability, f int) {

--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -1,6 +1,7 @@
 package avatar
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/genshinsim/gcsim/pkg/core"
@@ -63,13 +64,15 @@ func (p *Player) HandleAttack(atk *combat.AttackEvent) float64 {
 	dmg, crit = p.calc(atk, evt)
 
 	active := p.Core.Player.Active()
-	shielded := p.Core.Player.Shields.OnDamage(active, dmg, atk.Info.Element)
-	dmg -= shielded
-	if dmg > 0 {
+	dmgLeft := p.Core.Player.Shields.OnDamage(active, dmg, atk.Info.Element)
+	if dmgLeft < dmg {
+		p.Core.Log.NewEventBuildMsg(glog.LogPlayerEvent, -1, fmt.Sprintf("%.0f damage taken by shields", dmg-dmgLeft))
+	}
+	if dmgLeft > 0 {
 		p.Core.Player.Drain(player.DrainInfo{
-			ActorIndex: atk.Info.ActorIndex,
+			ActorIndex: active,
 			Abil:       atk.Info.Abil,
-			Amount:     dmg,
+			Amount:     dmgLeft,
 		})
 	}
 	return 0

--- a/pkg/core/player/shield/handler.go
+++ b/pkg/core/player/shield/handler.go
@@ -85,12 +85,12 @@ func (s *Handler) List() []Shield {
 func (s *Handler) OnDamage(char int, dmg float64, ele attributes.Element) float64 {
 	//find shield bonuses
 	bonus := s.ShieldBonus()
-	min := dmg //min of damage taken
+	max := dmg //max of damage taken
 	n := 0
 	for _, v := range s.shields {
 		taken, ok := v.OnDamage(dmg, ele, bonus)
-		if taken < min {
-			min = taken
+		if taken > max {
+			max = taken
 		}
 		if ok {
 			s.shields[n] = v
@@ -98,7 +98,7 @@ func (s *Handler) OnDamage(char int, dmg float64, ele attributes.Element) float6
 		}
 	}
 	s.shields = s.shields[:n]
-	return min
+	return max
 }
 
 func (s *Handler) Tick() {

--- a/pkg/core/player/shield/handler.go
+++ b/pkg/core/player/shield/handler.go
@@ -85,12 +85,12 @@ func (s *Handler) List() []Shield {
 func (s *Handler) OnDamage(char int, dmg float64, ele attributes.Element) float64 {
 	//find shield bonuses
 	bonus := s.ShieldBonus()
-	max := dmg //max of damage taken
+	min := dmg //min of damage taken
 	n := 0
 	for _, v := range s.shields {
 		taken, ok := v.OnDamage(dmg, ele, bonus)
-		if taken > max {
-			max = taken
+		if taken < min {
+			min = taken
 		}
 		if ok {
 			s.shields[n] = v
@@ -98,7 +98,7 @@ func (s *Handler) OnDamage(char int, dmg float64, ele attributes.Element) float6
 		}
 	}
 	s.shields = s.shields[:n]
-	return max
+	return min
 }
 
 func (s *Handler) Tick() {

--- a/pkg/core/player/shield/handler.go
+++ b/pkg/core/player/shield/handler.go
@@ -88,13 +88,34 @@ func (s *Handler) OnDamage(char int, dmg float64, ele attributes.Element) float6
 	min := dmg //min of damage taken
 	n := 0
 	for _, v := range s.shields {
+		pre_hp := v.CurrentHP()
 		taken, ok := v.OnDamage(dmg, ele, bonus)
+		s.log.NewEvent(
+			"shield taking damage",
+			glog.LogShieldEvent,
+			-1,
+		).Write("name", v.Desc()).
+			Write("ele", v.Element()).
+			Write("dmg", dmg).
+			Write("previous_hp", pre_hp).
+			Write("dmg_after_shield", taken).
+			Write("current_hp", v.CurrentHP()).
+			Write("expiry", v.Expiry())
 		if taken < min {
 			min = taken
 		}
 		if ok {
 			s.shields[n] = v
 			n++
+		} else {
+			// shield broken
+			s.log.NewEvent(
+				"shield broken",
+				glog.LogShieldEvent,
+				-1,
+			).Write("name", v.Desc()).
+				Write("ele", v.Element()).
+				Write("expiry", v.Expiry())
 		}
 	}
 	s.shields = s.shields[:n]

--- a/pkg/reactable/burning.go
+++ b/pkg/reactable/burning.go
@@ -6,6 +6,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/reactions"
+	"github.com/genshinsim/gcsim/pkg/core/targets"
 )
 
 func (r *Reactable) TryBurning(a *combat.AttackEvent) bool {
@@ -107,10 +108,23 @@ func (r *Reactable) nextBurningTick(src int, counter int, t Enemy) func() {
 		//so burning is active, which means both auras must still have value > 0, so we can do dmg
 		if counter != 9 {
 			// skip the 9th tick because hyv spaghetti
+			ai := r.burningAtk
+			ap := combat.NewCircleHitOnTarget(r.self, nil, 1)
 			r.core.QueueAttackWithSnap(
-				r.burningAtk,
+				ai,
 				r.burningSnapshot,
-				combat.NewCircleHitOnTarget(r.self, nil, 1),
+				ap,
+				0,
+			)
+			//self damage
+			ai.Abil += " (self damage)"
+			ap.SkipTargets[targets.TargettablePlayer] = false
+			ap.SkipTargets[targets.TargettableEnemy] = true
+			ap.SkipTargets[targets.TargettableGadget] = true
+			r.core.QueueAttackWithSnap(
+				ai,
+				r.burningSnapshot,
+				ap,
 				0,
 			)
 		}


### PR DESCRIPTION
Set up the initial implementation of self damage. For hyperbloom, burgeon, bloom, and burning

- [x] Remove HP
- [x] Blocked by shields
- [ ] Modified by resistance
- [ ] Can vape/melt/OL/apply pyro (for burning)

Player characters currently don't have resistance implemented, so it will not be done in this pull request.
Player self auras are also not fully supported, so the reactions for Burning will be omitted