### PR TITLE
fix fischl oz conditional breaking during q

### DIFF
--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -131,6 +131,7 @@ func (c *char) queueOz(src string, ozSpawn int, firstTick int) {
 	}
 	spawnFn := func() {
 		// setup variables for tracking oz
+		c.ozActive = true
 		c.ozSource = c.Core.F
 		c.ozTickSrc = c.Core.F
 		c.ozActiveUntil = c.Core.F + dur


### PR DESCRIPTION
- if oz despawns after q start then ozActive stayed 0

[Sample](https://github.com/genshinsim/gcsim/files/12447673/oz.gz)
