### PR TITLE
Add CLI options for saving min/max-DPS runs as samples

### DIFF
--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -55,7 +55,7 @@ func main() {
 	flag.StringVar(&opt.config, "c", "config.txt", "which profile to use")
 	flag.StringVar(&opt.out, "out", "", "output result to file? supply file path (otherwise empty string for disabled). default disabled")
 	flag.StringVar(&opt.sample, "sample", "", "create sample result. supply file path (otherwise empty string for disabled). default disabled")
-	flag.StringVar(&opt.sampleMinDps, "sampleMinDps", "", "create sample result for the max-DPS run. supply file path (otherwise empty string for disabled). default disabled")
+	flag.StringVar(&opt.sampleMinDps, "sampleMinDps", "", "create sample result for the min-DPS run. supply file path (otherwise empty string for disabled). default disabled")
 	flag.StringVar(&opt.sampleMaxDps, "sampleMaxDps", "", "create sample result for the max-DPS run. supply file path (otherwise empty string for disabled). default disabled")
 	flag.BoolVar(&opt.gz, "gz", false, "gzip json results; require out flag")
 	flag.BoolVar(&opt.serve, "s", false, "serve results to viewer (local). default false")

--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -299,7 +299,7 @@ func writeSample(seed uint64, outputPath string, config string, gz bool, simopt 
 		return err
 	}
 	sample.Save(outputPath, gz)
-	fmt.Printf("Generated sample with seed %v to %s\n", outputPath, seed)
+	fmt.Printf("Generated sample with seed %v to %s\n", seed, outputPath)
 
 	return nil
 }

--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -27,6 +27,8 @@ type opts struct {
 	config           string
 	out              string //file result name
 	sample           string //file sample name
+	sampleMinDps     string //file sample name for the min-DPS run
+	sampleMaxDps     string //file sample name for the max-DPS run
 	gz               bool
 	serve            bool
 	nobrowser        bool
@@ -53,6 +55,8 @@ func main() {
 	flag.StringVar(&opt.config, "c", "config.txt", "which profile to use")
 	flag.StringVar(&opt.out, "out", "", "output result to file? supply file path (otherwise empty string for disabled). default disabled")
 	flag.StringVar(&opt.sample, "sample", "", "create sample result. supply file path (otherwise empty string for disabled). default disabled")
+	flag.StringVar(&opt.sampleMinDps, "sampleMinDps", "", "create sample result for the max-DPS run. supply file path (otherwise empty string for disabled). default disabled")
+	flag.StringVar(&opt.sampleMaxDps, "sampleMaxDps", "", "create sample result for the max-DPS run. supply file path (otherwise empty string for disabled). default disabled")
 	flag.BoolVar(&opt.gz, "gz", false, "gzip json results; require out flag")
 	flag.BoolVar(&opt.serve, "s", false, "serve results to viewer (local). default false")
 	flag.BoolVar(&opt.norun, "nr", false, "disable running the simulation (useful if you only want to generate a sample")
@@ -161,26 +165,59 @@ can be viewed in the browser via "go tool pprof -http=localhost:3000 mem.prof" (
 	}
 
 	if opt.sample != "" {
-		var seed uint64
+		var err error
 		if opt.norun {
-			seed = uint64(simulator.CryptoRandSeed())
+			err = writeSample(
+				uint64(simulator.CryptoRandSeed()),
+				opt.sample,
+				opt.config,
+				opt.gz,
+				simopt,
+			)
 		} else {
-			seed, _ = strconv.ParseUint(res.SampleSeed, 10, 64)
+			err = parseStrSeedAndWriteSample(
+				res.SampleSeed,
+				opt.sample,
+				opt.config,
+				opt.gz,
+				simopt,
+			)
 		}
 
-		cfg, err := simulator.ReadConfig(opt.config)
 		if err != nil {
 			log.Println(err)
 			return
 		}
+	}
 
-		sample, err := simulator.GenerateSampleWithSeed(cfg, seed, simopt)
+	if opt.sampleMinDps != "" {
+		err := parseStrSeedAndWriteSample(
+			res.Statistics.MinSeed,
+			opt.sampleMinDps,
+			opt.config,
+			opt.gz,
+			simopt,
+		)
+
 		if err != nil {
 			log.Println(err)
 			return
 		}
-		sample.Save(opt.sample, opt.gz)
-		fmt.Printf("Generated sample with seed: %v\n", seed)
+	}
+
+	if opt.sampleMaxDps != "" {
+		err := parseStrSeedAndWriteSample(
+			res.Statistics.MaxSeed,
+			opt.sampleMaxDps,
+			opt.config,
+			opt.gz,
+			simopt,
+		)
+
+		if err != nil {
+			log.Println(err)
+			return
+		}
 	}
 
 	if opt.serve && !opt.norun {
@@ -238,4 +275,31 @@ func openWSL(url string) error {
 	cmd := "powershell.exe"
 	args := []string{"/c", "start", url}
 	return exec.Command(cmd, args...).Start()
+}
+
+func parseStrSeedAndWriteSample(seedStr string, outputPath string, config string, gz bool, simopt simulator.Options) error {
+	seed, err := strconv.ParseUint(seedStr, 10, 64)
+
+	if err != nil {
+		return err
+	}
+
+	return writeSample(seed, outputPath, config, gz, simopt)
+}
+
+
+func writeSample(seed uint64, outputPath string, config string, gz bool, simopt simulator.Options) error {
+	cfg, err := simulator.ReadConfig(config)
+	if err != nil {
+		return err
+	}
+
+	sample, err := simulator.GenerateSampleWithSeed(cfg, seed, simopt)
+	if err != nil {
+		return err
+	}
+	sample.Save(outputPath, gz)
+	fmt.Printf("Generated sample with seed %v to %s\n", outputPath, seed)
+
+	return nil
 }

--- a/ui/packages/docs/docs/reference/cli.md
+++ b/ui/packages/docs/docs/reference/cli.md
@@ -16,6 +16,8 @@ The gcsim CLI accepts the following options:
 | `-c` | Which config file to run gcsim on. This option is required. | Path to the config file. | config.txt | 
 | `-out` | Which file to output the results of the gcsim command to. | Output file path. | disabled |
 | `-sample` | Which file to output a sample result to. | Output file path. | disabled |
+| `-sampleMinDps` | Similar to `-sample`, except that we're writing out the min-DPS run as the sample. | Output file path. | disabled |
+| `-sampleMaxDps` | Similar to `-sample`, except that we're writing out the max-DPS run as the sample. | Output file path. | disabled |
 | `-nr` | Whether to disable running the simulation. Useful in combination with `-sample` if a sample result is all that is needed. | - | disabled |
 | `-gz` | Whether to zip up the results. Can be used together with `-out` and `-sample`. | - | disabled |
 | `-s` | Whether to serve the results to the "local" gcsim viewer page using the default web browser. | - | disabled |


### PR DESCRIPTION
Add two options (`-sampleMinDps` and `-sampleMaxDps`) analogous to `-sample` for saving the min/max-DPS runs as a sample.

Tested with:

```
$ \cp ~/Programming/Git/gcsim/cmd/gcsim/gcsim bin/gcsim && tools/gcsim_tools.py run-sim data/rotations/yanfei-xingqiu-kazuha-bennett.txt --working-dir /tmp/gcsim-out && ll /tmp/gcsim-out/baseline

baseline        | duration  70.0s | avg      32439 (  0.0%) | span      20629 -      35548 std       1263
total 9040
-rw-r--r--  1 jiahaoli  wheel   2.1K Aug 27 15:00 config.txt
-rw-r--r--  1 jiahaoli  wheel    95K Aug 27 15:00 result.json
-rw-r--r--  1 jiahaoli  wheel   1.6M Aug 27 15:00 sample.json
-rw-r--r--  1 jiahaoli  wheel   1.6M Aug 27 15:00 sample.max_dps.json
-rw-r--r--  1 jiahaoli  wheel   1.2M Aug 27 15:00 sample.min_dps.json
-rw-r--r--  1 jiahaoli  wheel   531B Aug 27 15:00 stdout.txt

$ PYTHONPATH=. tools/gcsim_tools.py show-damages /tmp/gcsim-out/baseline/sample.json | pc -1 | get_sum

2358359

$ PYTHONPATH=. tools/gcsim_tools.py show-damages /tmp/gcsim-out/baseline/sample.min_dps.json | pc -1 | get_sum

1444069

$ PYTHONPATH=. tools/gcsim_tools.py show-damages /tmp/gcsim-out/baseline/sample.max_dps.json | pc -1 | get_sum

2488368

$ cat /tmp/gcsim-out/baseline/stdout.txt

Average duration of 70.00 seconds (min: 70.00 max: 70.00 std: 0.00)
Average 2268816.66 damage over 70.00 seconds, resulting in 32412 dps (min: 28312.33 max: 35677.45 std: 1165.35)
Simulation completed 1000 iterations

Generated sample with seed 8296560224945437847 to /tmp/gcsim-out/baseline/sample.json
Generated sample with seed 15940773183633612031 to /tmp/gcsim-out/baseline/sample.min_dps.json
Generated sample with seed 14996492103963110579 to /tmp/gcsim-out/baseline/sample.max_dps.json
```

