### PR TITLE
force db default sort by create_date

### DIFF
--- a/ui/packages/db/src/SharedHooks/databaseQuery.ts
+++ b/ui/packages/db/src/SharedHooks/databaseQuery.ts
@@ -98,10 +98,14 @@ export function craftQuery(
       $in: filter.tags,
     };
   }
+  //force default sort by date for now
   return {
     query,
     limit,
     skip,
+    sort: {
+      create_date: -1,
+    }
   };
 }
 
@@ -113,6 +117,8 @@ export interface DbQuery {
     };
   };
   limit: number;
-  sort?: unknown;
+  sort?: {
+    create_date: number;
+  };
   skip?: number;
 }


### PR DESCRIPTION
Force DB results to always sort by newest to oldest. To be changed in future when we add actual UI elements for other sorting options