### PR TITLE
fix config page not displaying exact errors

### DIFF
--- a/pkg/gcs/ast/parse.go
+++ b/pkg/gcs/ast/parse.go
@@ -81,7 +81,7 @@ func (p *Parser) Parse() (*info.ActionList, Node, error) {
 			count += c
 		}
 		if count > 5 {
-			p.res.Errors = append(p.res.Errors, fmt.Errorf("character %v have more than 5 total set items", v.String()))
+			p.res.Errors = append(p.res.Errors, fmt.Errorf("character %v has more than 5 total set items", v.String()))
 		}
 	}
 

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -67,10 +67,13 @@ func Parse(cfg string) (*info.ActionList, ast.Node, error) {
 	//check other errors as well
 	if len(simcfg.Errors) != 0 {
 		fmt.Println("The config has the following errors: ")
+		errMsgs := ""
 		for _, v := range simcfg.Errors {
-			fmt.Printf("\t%v\n", v)
+			errMsg := fmt.Sprintf("\t%v\n", v)
+			fmt.Println(errMsg)
+			errMsgs += errMsg
 		}
-		return &info.ActionList{}, nil, errors.New("sim has errors")
+		return &info.ActionList{}, nil, errors.New(errMsgs)
 	}
 
 	return simcfg, gcsl, nil


### PR DESCRIPTION
instead of always showing "sim has errors" for certain errors, now the actual error messages will be shown

example: 
![grafik](https://github.com/genshinsim/gcsim/assets/98557316/851691fe-c963-4b68-b3a7-c12e213e7980)
