### PR TITLE
add map typing

### DIFF
--- a/pkg/gcs/ast/node.go
+++ b/pkg/gcs/ast/node.go
@@ -1028,6 +1028,10 @@ type (
 	StringType struct {
 		Pos //position of :
 	}
+
+	MapType struct {
+		Pos //position of keyword map
+	}
 	FuncType struct {
 		Pos        //position of opening (
 		ArgsType   []ExprType
@@ -1038,6 +1042,7 @@ type (
 // exprTypeNode()
 func (*NumberType) exprTypeNode() {}
 func (*StringType) exprTypeNode() {}
+func (*MapType) exprTypeNode()    {}
 func (*FuncType) exprTypeNode()   {}
 
 // NumberType.
@@ -1086,6 +1091,30 @@ func (s *StringType) String() string {
 
 func (s *StringType) writeTo(sb *strings.Builder) {
 	sb.WriteString("string")
+}
+
+// MapType.
+func (m *MapType) CopyExprType() ExprType {
+	if m == nil {
+		return nil
+	}
+	return &MapType{
+		Pos: m.Pos,
+	}
+}
+
+func (m *MapType) Copy() Node {
+	return m.CopyExprType()
+}
+
+func (m *MapType) String() string {
+	var sb strings.Builder
+	m.writeTo(&sb)
+	return sb.String()
+}
+
+func (m *MapType) writeTo(sb *strings.Builder) {
+	sb.WriteString("map")
 }
 
 // FuncType.

--- a/pkg/gcs/ast/parseFn_test.go
+++ b/pkg/gcs/ast/parseFn_test.go
@@ -60,6 +60,11 @@ func TestFnTyping(t *testing.T) {
 		t,
 	)
 
+	parseAndPrint(
+		`fn z(a number, b number, c map) { print(c); }`,
+		t,
+	)
+
 }
 
 func TestAnonFn(t *testing.T) {

--- a/pkg/gcs/ast/parseTyping.go
+++ b/pkg/gcs/ast/parseTyping.go
@@ -42,6 +42,8 @@ func (p *Parser) parseBasicType() (ExprType, error) {
 		return &StringType{Pos: n.pos}, nil
 	case "number":
 		return &NumberType{Pos: n.pos}, nil
+	case "map":
+		return &MapType{Pos: n.pos}, nil
 	default:
 		return nil, fmt.Errorf("ln%v: unexpected basic type parsing type info; got %v", n.line, n.Val)
 	}


### PR DESCRIPTION
Add `map` typing to function declarations. To allow future typing of `execute_action` properly. This should also ensure any current usage of the following is future compatible:

```
fn rand_delay(mean, stddev) {
  let del = randnorm() * stddev + mean;
  if del > (mean + mean) {
    del = mean + mean;
  }
  delay(del);
}

let prev_char_id = -1;
let prev_action_id = -1;

let _execute_action = execute_action;
fn execute_action(char_id number, action_id number, p map) {
  print(prev_char_id, " ", prev_action_id, " ", char_id, " ", action_id);

  if action_id == .action.swap {
    # add delay before swap
    rand_delay(12, 3);
  } else if prev_action_id == .action.attack && action_id != .action.attack && action_id != .action.charge {
    # add delay after attack, but only if not followed by another attack or charge
    rand_delay(3, 1);
  } else if prev_action_id != .action.attack {
    # add delay to everything else
    rand_delay(3, 1);
  }

  prev_char_id = char_id;
  prev_action_id = action_id;
  return _execute_action(char_id, action_id, p);
}
```