### PR TITLE
Changed db to open the config page instead of the results page

### DIFF
--- a/ui/packages/db/src/SharedComponents/DBEntryView.tsx
+++ b/ui/packages/db/src/SharedComponents/DBEntryView.tsx
@@ -18,7 +18,7 @@ export default function DBEntryView({ dbEntry }: { dbEntry: db.IEntry }) {
   }
   let link = `https://gcsim.app/sh/${dbEntry.share_key}`;
   if ("_id" in dbEntry) {
-    link = `https://gcsim.app/db/${dbEntry["_id"]}`;
+    link = `https://gcsim.app/db/${dbEntry["_id"]}#tab=config`;
   }
 
   return (


### PR DESCRIPTION
I think that since the DB is primarily supposed to be used as a rotational database, and that we don't encourage people to blindly compare results of sims from the DB, it makes more sense for links to open to the configs first.