### PR TITLE
fix wasm runtime err not caught

### DIFF
--- a/ui/packages/executors/src/Workers/worker.ts
+++ b/ui/packages/executors/src/Workers/worker.ts
@@ -14,15 +14,17 @@ if (!WebAssembly.instantiateStreaming) {
 function ready(req: { wasm: string }) {
   const go = new Go();
   WebAssembly.instantiateStreaming(fetch(req.wasm), go.importObject)
-      .then((result) => {
-        go.run(result.instance);
-        postMessage({ type: WorkerResponse.Ready });
-      }).catch((e) => {
-        console.error(e);
-        postMessage({
-          type: WorkerResponse.Failed,
-          reason: e instanceof Error ? e.message : "Unknown Error" });
+    .then((result) => {
+      go.run(result.instance);
+      postMessage({ type: WorkerResponse.Ready });
+    })
+    .catch((e) => {
+      console.error(e);
+      postMessage({
+        type: WorkerResponse.Failed,
+        reason: e instanceof Error ? e.message : "Unknown Error",
       });
+    });
 }
 
 // @ts-ignore
@@ -35,11 +37,19 @@ function initialize(req: { cfg: string }) {
 }
 
 function run(req: { itr: number }) {
-  const resp = simulate();
-  if (typeof(resp) == "string" || resp instanceof String) {
-    return { type: WorkerResponse.Failed, reason: JSON.parse(resp as string).error };
+  try {
+    const resp = simulate();
+    if (typeof resp == "string" || resp instanceof String) {
+      return {
+        type: WorkerResponse.Failed,
+        reason: JSON.parse(resp as string).error,
+      };
+    }
+    return { type: WorkerResponse.Done, result: resp, itr: req.itr };
+  } catch (e) {
+    console.log("simulate() call failed");
+    return { type: WorkerResponse.Failed, reason: `Failed with error: ${e}` };
   }
-  return { type: WorkerResponse.Done, result: resp, itr: req.itr };
 }
 
 // @ts-ignore


### PR DESCRIPTION
wasm crashing was not caught due to promise scoped incorrectly (i.e. promise in in onmessage scope and not handled outside)

this pr should fix it (at least it did in local testing)