### PR TITLE
Fix Key working when the wrong character attacks

### DIFF
--- a/internal/weapons/sword/keyofkhajnisut/keyofkhajnisut.go
+++ b/internal/weapons/sword/keyofkhajnisut/keyofkhajnisut.go
@@ -63,6 +63,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 		if char.StatusIsActive(icdKey) {
 			return false
 		}
+		if atk.Info.ActorIndex != char.Index {
+			return false
+		}
 		if atk.Info.AttackTag != attacks.AttackTagElementalArt && atk.Info.AttackTag != attacks.AttackTagElementalArtHold {
 			return false
 		}


### PR DESCRIPTION
Fixed bug where Key would stack if the equipped character was on field for any skill damage, not just their own.