### PR TITLE
Fix Fischl A4 Timing

### DIFF
--- a/internal/characters/fischl/asc.go
+++ b/internal/characters/fischl/asc.go
@@ -57,7 +57,7 @@ func (c *char) a4() {
 			ai,
 			c.ozSnapshot.Snapshot,
 			combat.NewCircleHitOnTarget(c.Core.Combat.PrimaryTarget(), nil, 0.5),
-			5)
+			4)
 		return false
 	}
 

--- a/internal/characters/fischl/asc.go
+++ b/internal/characters/fischl/asc.go
@@ -57,7 +57,7 @@ func (c *char) a4() {
 			ai,
 			c.ozSnapshot.Snapshot,
 			combat.NewCircleHitOnTarget(c.Core.Combat.PrimaryTarget(), nil, 0.5),
-			3)
+			5)
 		return false
 	}
 

--- a/internal/characters/nahida/skill.go
+++ b/internal/characters/nahida/skill.go
@@ -233,7 +233,7 @@ func (c *char) triggerTriKarmaDamageIfAvail(t *enemy.Enemy) {
 			ai,
 			snap,
 			combat.NewSingleTargetHit(e.Key()),
-			4,
+			3,
 			cb,
 		)
 	}


### PR DESCRIPTION
Fixes Fischl A4 timing. This should cause it to proc after TKP as seen in game. The frame count matches personal testing that I seem to have lost the footage of.