### PR TITLE
fix fischl c4 timing

### DIFF
--- a/internal/characters/fischl/skill.go
+++ b/internal/characters/fischl/skill.go
@@ -167,9 +167,9 @@ func (c *char) queueOz(src string, ozSpawn, firstTick int) {
 	}
 	if ozSpawn > 0 {
 		c.Core.Tasks.Add(spawnFn, ozSpawn)
-	} else {
-		spawnFn()
+		return
 	}
+	spawnFn()
 }
 
 func (c *char) ozTick(src int) func() {


### PR DESCRIPTION
https://discord.com/channels/845087716541595668/1156832994556923984

- heal should happen at end of animation right after oz spawn
- example: songofstillness passive proc shouldn't snap onto burst oz

Fix is showcased here:
[fischl-c4-fix.gz](https://github.com/genshinsim/gcsim/files/13684327/fischl-c4-fix.gz)
