### PR TITLE
remove confusing "Guest" text top right on sim page

### DIFF
--- a/ui/packages/ui/src/Sectioning/Nav.tsx
+++ b/ui/packages/ui/src/Sectioning/Nav.tsx
@@ -72,7 +72,7 @@ export default ({}) => {
           {PageNavs}
         </Navbar.Group>
         <Navbar.Group align={Alignment.RIGHT} className="!flex !items-stretch">
-          <NavButton href="/account" icon="user" text={user.uid === "" ? "Guest" : user.name} />
+          {/* <NavButton href="/account" icon="user" text={user.uid === "" ? "Guest" : user.name} /> */}
           <HTMLSelect
               className="ml-2 self-center"
               value={i18n.resolvedLanguage}


### PR DESCRIPTION
https://discord.com/channels/845087716541595668/1136311047045775370

Talking about:
![image](https://github.com/genshinsim/gcsim/assets/98557316/e2b1c45b-47b7-467a-b71a-8b710f495616)

- discord login is not implemented

