### PR TITLE
fix target field docs

### DIFF
--- a/ui/packages/docs/docs/reference/fields.md
+++ b/ui/packages/docs/docs/reference/fields.md
@@ -21,8 +21,8 @@ For example, if you are looking for the tag for Lisa's A4 (defense shred), then 
 <!-- prettier-ignore -->
 | field1 | field2 | field3 | field4 | description |
 | --- | --- | --- | --- | --- |
-| `debuff` | `res`/`def` | `t1`/`t2`/`t3`/... | res/def modifier name | Evaluates to the remaining duration of the specified res/def modifier on the specified target. See the relevant character/weapon/artifact page for acceptable modifier names. |
-| `element` |  `t1`/`t2`/`t3`/... | `pyro`/`hydro`/`anemo`/`electro`/`dendro`/`cryo`/`geo`/`frozen`/`quicken` | - | `1` if the specified element exists on specified target, `0` otherwise. |
+| `debuff` | `res`/`def` | `t0`/`t1`/`t2`/... | res/def modifier name | Evaluates to the remaining duration of the specified res/def modifier on the specified target. See the relevant character/weapon/artifact page for acceptable modifier names. |
+| `element` |  `t0`/`t1`/`t2`/... | `pyro`/`hydro`/`anemo`/`electro`/`dendro`/`cryo`/`geo`/`frozen`/`quicken` | - | Evaluates to the remaining durability of the specified element on the specified target. |
 | `status` | core status name | - | - | Evaluates to the remaining duration of the specified core status. See the relevant character/weapon/artifact page for acceptable status names. |
 | `stam` | - | - | - | Evaluates to the player's remaining stamina. |
 | `construct` | `duration`/`count` | construct name | - | Evaluates to the duration/count of the specified construct. See individual character page for acceptable construct names. |


### PR DESCRIPTION
found out about this as part of https://discord.com/channels/845087716541595668/1029599016234786867

- element gives durability and not just 0 and 1
- indexing starts at 0 not 1