### PR TITLE
adjust source damage instances to not count 0 damage

### DIFF
--- a/pkg/agg/damage/damage.go
+++ b/pkg/agg/damage/damage.go
@@ -115,7 +115,9 @@ func (b *buffer) Add(result stats.Result) {
 				sourceDPSKey += " (" + reactModifier + ")"
 			}
 			sourceDPS[sourceDPSKey] += ev.Damage
-			sourceDamageInstances[sourceDPSKey] += 1
+			if ev.Damage > 0 {
+				sourceDamageInstances[sourceDPSKey] += 1
+			}
 		}
 
 		b.characterDPS[i].Add(charDPS * time)


### PR DESCRIPTION
It's not intuitive that the source instances bar chart also counts dmg instances that did 0 dmg. This is especially relevant for Hyperbloom counts.
I see no value in counting the dmg instances that did 0 dmg in that bar chart for now, but it can always be added back later in some form.