### PR TITLE
fix db entry images not shrinking on very small screens

### DIFF
--- a/ui/packages/db/src/SharedComponents/DBEntryViewComponents/DBEntryPortrait.tsx
+++ b/ui/packages/db/src/SharedComponents/DBEntryViewComponents/DBEntryPortrait.tsx
@@ -62,7 +62,7 @@ function DBEntryMobilePortrait({ name, sets, weapon, cons }: model.ICharacter) {
     );
   }
   return (
-    <div className="bg-slate-700  flex flex-row max-h-fit w-32">
+    <div className="bg-slate-700 flex flex-row max-h-fit max-w-32">
       <div className="grid grid-cols-3 grid-rows-2 bg-slate-500/10 gap-[2px]  ">
         <div className="col-span-2 row-span-2 bg-slate-700">
           <div className=" relative ">


### PR DESCRIPTION
- affects landing page and db on screens with < 392px width