### PR TITLE
adjust 4.1 4* weapon series implementations

### DIFF
--- a/internal/weapons/claymore/powersaw/powersaw.go
+++ b/internal/weapons/claymore/powersaw/powersaw.go
@@ -14,19 +14,21 @@ import (
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
-const icdKey = "portable-power-saw-icd"
-
-var symbol = []string{"stoic-symbol-0", "stoic-symbol-1", "stoic-symbol-2"}
+const (
+	symbolKey      = "portable-power-saw-symbol"
+	symbolDuration = 30 * 60
+	icdKey         = "portable-power-saw-icd"
+	icdDuration    = 15 * 60
+	buffKey        = "portable-power-saw-em"
+	buffDuration   = 10 * 60
+)
 
 func init() {
 	core.RegisterWeaponFunc(keys.PortablePowerSaw, NewWeapon)
 }
 
 type Weapon struct {
-	core   *core.Core
-	char   *character.CharWrapper
-	refine int
-	buff   []float64
+	stacks int
 	Index  int
 }
 
@@ -39,15 +41,11 @@ func (w *Weapon) Init() error      { return nil }
 // and 2s after the effect occurs, 2/2.5/3/3.5/4 Energy per Symbol consumed will be restored for said character.
 // The Roused effect can be triggered once every 15s,
 // and Symbols can be gained even when the character is not on the field.
-
 func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) (info.Weapon, error) {
-	w := &Weapon{
-		core:   c,
-		char:   char,
-		refine: p.Refine,
-		buff:   make([]float64, attributes.EndStatType),
-	}
+	w := &Weapon{}
+	r := p.Refine
 
+	// gain symbols
 	c.Events.Subscribe(event.OnHeal, func(args ...interface{}) bool {
 		source := args[0].(*player.HealInfo)
 		index := args[1].(int)
@@ -59,66 +57,63 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 			return false
 		}
 
-		// override oldest symbol
-		idx := 0
-		for i, s := range symbol {
-			if char.StatusExpiry(s) < char.StatusExpiry(symbol[idx]) {
-				idx = i
-			}
+		if !char.StatusIsActive(symbolKey) {
+			w.stacks = 0
 		}
-		char.AddStatus(symbol[idx], 30*60, true)
-
-		c.Log.NewEvent("powersaw proc'd", glog.LogWeaponEvent, char.Index).
-			Write("index", idx)
-
+		if w.stacks < 3 {
+			w.stacks++
+		}
+		c.Log.NewEvent("portable-power-saw adding stack", glog.LogWeaponEvent, char.Index).
+			Write("stacks", w.stacks)
+		char.AddStatus(symbolKey, symbolDuration, true)
 		return false
 	}, fmt.Sprintf("portable-power-saw-heal-%v", char.Base.Key.String()))
 
-	key := fmt.Sprintf("portable-power-saw-roused-%v", char.Base.Key.String())
-	c.Events.Subscribe(event.OnBurst, w.consumeEnergy, key)
-	c.Events.Subscribe(event.OnSkill, w.consumeEnergy, key)
-	return w, nil
-}
-
-func (w *Weapon) consumeEnergy(args ...interface{}) bool {
-	em := 30 + 10*float64(w.refine)
-	refund := 1.5 + 0.5*float64(w.refine)
-
-	// check for active before deleting symbol
-	if w.char.StatusIsActive(icdKey) {
-		return false
-	}
-	if w.core.Player.Active() != w.char.Index {
-		return false
-	}
-
-	count := 0
-	for _, s := range symbol {
-		if w.char.StatusIsActive(s) {
-			count++
+	// consume symbols
+	em := 30 + 10*float64(r)
+	refund := 1.5 + 0.5*float64(r)
+	m := make([]float64, attributes.EndStatType)
+	buffFunc := func(args ...interface{}) bool {
+		// skip if no symbols (status not active implies symbols == 0)
+		if !char.StatusIsActive(symbolKey) {
+			return false
 		}
-		w.char.DeleteStatus(s)
-	}
-	if count == 0 {
+		// skip if trigger on icd
+		if char.StatusIsActive(icdKey) {
+			return false
+		}
+		// check for active before deleting symbol
+		if c.Player.Active() != char.Index {
+			return false
+		}
+		// add icd
+		char.AddStatus(icdKey, icdDuration, true)
+
+		// consume symbols
+		count := w.stacks
+		char.DeleteStatus(symbolKey)
+		w.stacks = 0
+
+		// add em buff
+		m[attributes.EM] = em * float64(count)
+		char.AddStatMod(character.StatMod{
+			Base:         modifier.NewBaseWithHitlag(buffKey, buffDuration),
+			AffectedStat: attributes.EM,
+			Amount: func() ([]float64, bool) {
+				return m, true
+			},
+		})
+
+		// regen energy after 2 secs
+		char.QueueCharTask(func() {
+			char.AddEnergy("portable-power-saw-energy", refund*float64(count))
+		}, 2*60)
+
 		return false
 	}
+	key := fmt.Sprintf("portable-power-saw-roused-%v", char.Base.Key.String())
+	c.Events.Subscribe(event.OnBurst, buffFunc, key)
+	c.Events.Subscribe(event.OnSkill, buffFunc, key)
 
-	w.char.AddStatus(icdKey, 15*60, true)
-	w.buff[attributes.EM] = em * float64(count)
-
-	// add em buff
-	w.char.AddStatMod(character.StatMod{
-		Base:         modifier.NewBaseWithHitlag("portable-power-saw-em", 10*60),
-		AffectedStat: attributes.EM,
-		Amount: func() ([]float64, bool) {
-			return w.buff, true
-		},
-	})
-
-	// regen energy after 2 secs
-	w.char.QueueCharTask(func() {
-		w.char.AddEnergy("portable-power-saw-energy", refund*float64(count))
-	}, 2*60)
-
-	return false
+	return w, nil
 }

--- a/internal/weapons/spear/prospectorsdrill/prospectorsdrill.go
+++ b/internal/weapons/spear/prospectorsdrill/prospectorsdrill.go
@@ -14,21 +14,22 @@ import (
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
-const icdKey = "range-gauge-struggle-icd"
-
-var symbol = []string{"unity-symbol-0", "unity-symbol-1", "unity-symbol-2"}
+const (
+	symbolKey      = "prospectors-drill-symbol"
+	symbolDuration = 30 * 60
+	icdKey         = "prospectors-drill-icd"
+	icdDuration    = 15 * 60
+	buffKey        = "prospectors-drill"
+	buffDuration   = 10 * 60
+)
 
 func init() {
 	core.RegisterWeaponFunc(keys.ProspectorsDrill, NewWeapon)
 }
 
 type Weapon struct {
-	core    *core.Core
-	char    *character.CharWrapper
-	refine  int
-	atkp    []float64
-	eleDMGP []float64
-	Index   int
+	stacks int
+	Index  int
 }
 
 func (w *Weapon) SetIndex(idx int) { w.Index = idx }
@@ -39,16 +40,11 @@ func (w *Weapon) Init() error      { return nil }
 // For each Symbol consumed, gain 3/4/5/6/7% ATK and 7/8.5/10/11.5/13% All Elemental DMG Bonus.
 // The Struggle effect can be triggered once every 15s,
 // and Symbols can be gained even when the character is not on the field.
-
 func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) (info.Weapon, error) {
-	w := &Weapon{
-		core:    c,
-		char:    char,
-		refine:  p.Refine,
-		atkp:    make([]float64, attributes.EndStatType),
-		eleDMGP: make([]float64, attributes.EndStatType),
-	}
+	w := &Weapon{}
+	r := p.Refine
 
+	// gain symbols
 	c.Events.Subscribe(event.OnHeal, func(args ...interface{}) bool {
 		source := args[0].(*player.HealInfo)
 		index := args[1].(int)
@@ -60,76 +56,61 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 			return false
 		}
 
-		// override oldest symbol
-		idx := 0
-		for i, s := range symbol {
-			if char.StatusExpiry(s) < char.StatusExpiry(symbol[idx]) {
-				idx = i
-			}
+		if !char.StatusIsActive(symbolKey) {
+			w.stacks = 0
 		}
-		char.AddStatus((symbol[idx]), 30*60, true)
-
-		c.Log.NewEvent("prospectors-drill proc'd", glog.LogWeaponEvent, char.Index).
-			Write("index", idx)
-
-		w.consumeEnergy()
+		if w.stacks < 3 {
+			w.stacks++
+		}
+		c.Log.NewEvent("prospectors-drill adding stack", glog.LogWeaponEvent, char.Index).
+			Write("stacks", w.stacks)
+		char.AddStatus(symbolKey, symbolDuration, true)
 		return false
 	}, fmt.Sprintf("prospectors-drill-heal-%v", char.Base.Key.String()))
 
-	key := fmt.Sprintf("prospectors-drill-struggle-%v", char.Base.Key.String())
-	c.Events.Subscribe(event.OnBurst, w.consumeEnergy, key)
-	c.Events.Subscribe(event.OnSkill, w.consumeEnergy, key)
-	return w, nil
-}
-
-func (w *Weapon) consumeEnergy(args ...interface{}) bool {
-	baseEleDMGP := 0.055 + 0.015*float64(w.refine)
-	atkp := 0.02 + 0.01*float64(w.refine)
-	duration := 10 * 60
-
-	// check for active before deleting symbol
-	if w.char.StatusIsActive(icdKey) {
-		return false
-	}
-	if w.core.Player.Active() != w.char.Index {
-		return false
-	}
-	count := 0
-	for _, s := range symbol {
-		if w.char.StatusIsActive(s) {
-			count++
+	// consume symbols
+	baseEle := 0.055 + 0.015*float64(r)
+	atk := 0.02 + 0.01*float64(r)
+	m := make([]float64, attributes.EndStatType)
+	buffFunc := func(args ...interface{}) bool {
+		// skip if no symbols (status not active implies symbols == 0)
+		if !char.StatusIsActive(symbolKey) {
+			return false
 		}
-		w.char.DeleteStatus(s)
-	}
-	if count == 0 {
+		// skip if trigger on icd
+		if char.StatusIsActive(icdKey) {
+			return false
+		}
+		// check for active before deleting symbol
+		if c.Player.Active() != char.Index {
+			return false
+		}
+		// add icd
+		char.AddStatus(icdKey, icdDuration, true)
+
+		// consume symbols
+		count := w.stacks
+		char.DeleteStatus(symbolKey)
+		w.stacks = 0
+
+		// add buff
+		m[attributes.ATKP] = atk * float64(count)
+		ele := baseEle * float64(count)
+		for i := attributes.PyroP; i <= attributes.DendroP; i++ {
+			m[i] = ele
+		}
+		char.AddStatMod(character.StatMod{
+			Base: modifier.NewBaseWithHitlag(buffKey, buffDuration),
+			Amount: func() ([]float64, bool) {
+				return m, true
+			},
+		})
+
 		return false
 	}
+	key := fmt.Sprintf("prospectors-drill-struggle-%v", char.Base.Key.String())
+	c.Events.Subscribe(event.OnBurst, buffFunc, key)
+	c.Events.Subscribe(event.OnSkill, buffFunc, key)
 
-	w.char.AddStatus(icdKey, 15*60, true)
-	w.atkp[attributes.ATKP] = atkp * float64(count)
-
-	// add atk buff
-	w.char.AddStatMod(character.StatMod{
-		Base:         modifier.NewBaseWithHitlag("prospectors-drill-atk-buff", duration),
-		AffectedStat: attributes.ATKP,
-		Amount: func() ([]float64, bool) {
-			return w.atkp, true
-		},
-	})
-
-	eleDMGP := baseEleDMGP * float64(count)
-	for i := attributes.PyroP; i <= attributes.DendroP; i++ {
-		w.eleDMGP[i] = eleDMGP
-	}
-
-	// add elemental dmg buff
-	w.char.AddStatMod(character.StatMod{
-		Base:         modifier.NewBaseWithHitlag("prospectors-drill-eledmg-buff", duration),
-		AffectedStat: attributes.NoStat,
-		Amount: func() ([]float64, bool) {
-			return w.eleDMGP, true
-		},
-	})
-
-	return false
+	return w, nil
 }


### PR DESCRIPTION
- symbol duration is not tracked per symbol
- one status for all symbols instead of 3
- add weapon log for stack gain
- simplify code
- adjust buff/status naming
- fix bug in rangegauge/prospectorsdrill where all symbols were immediately consumed on stack gain