### PR TITLE
rework crystallize

### DIFF
--- a/pkg/conditional/gadgets.go
+++ b/pkg/conditional/gadgets.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/genshinsim/gcsim/internal/common"
 	"github.com/genshinsim/gcsim/pkg/core"
+	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/reactable"
 )
 
@@ -17,6 +18,8 @@ func evalGadgets(c *core.Core, fields []string) (int, error) {
 		return evalDendroCore(c, fields[2])
 	case "sourcewaterdroplet":
 		return evalSourcewaterDroplet(c, fields[2])
+	case "crystallizeshard":
+		return evalCrystallizeShard(c, fields[2])
 	default:
 		return 0, fmt.Errorf("bad gadgets condition: invalid criteria %v", fields[1])
 	}
@@ -50,4 +53,43 @@ func evalSourcewaterDroplet(c *core.Core, key string) (int, error) {
 	default:
 		return 0, fmt.Errorf("bad gadgets (sourcewaterdroplet) condition: invalid criteria %v", key)
 	}
+}
+
+func evalCrystallizeShard(c *core.Core, key string) (int, error) {
+	switch key {
+	case "all":
+		count := 0
+		for i := 0; i < c.Combat.GadgetCount(); i++ {
+			cs, ok := c.Combat.Gadget(i).(*reactable.CrystallizeShard)
+			if !ok {
+				continue
+			}
+			if c.F < cs.EarliestPickup {
+				continue
+			}
+			count++
+		}
+		return count, nil
+	case attributes.Pyro.String(), attributes.Hydro.String(), attributes.Electro.String(), attributes.Cryo.String():
+		return countElementalCrystallizeShards(c, key), nil
+	default:
+		return 0, fmt.Errorf("bad gadgets (crystallizeshard) condition: invalid criteria %v", key)
+	}
+}
+
+func countElementalCrystallizeShards(c *core.Core, ele string) int {
+	count := 0
+	for i := 0; i < c.Combat.GadgetCount(); i++ {
+		cs, ok := c.Combat.Gadget(i).(*reactable.CrystallizeShard)
+		if !ok {
+			continue
+		}
+		if c.F < cs.EarliestPickup {
+			continue
+		}
+		if cs.Shield.Ele.String() == ele {
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/core/combat/gadget.go
+++ b/pkg/core/combat/gadget.go
@@ -22,6 +22,7 @@ const (
 	GadgetTypGrinMalkinHat
 	GadgetTypSourcewaterDropletHydroTrav
 	GadgetTypSourcewaterDropletNeuv
+	GadgetTypCrystallizeShard
 	GadgetTypTest
 	EndGadgetTyp
 )
@@ -37,6 +38,7 @@ func init() {
 	gadgetLimits[GadgetTypYueguiJumping] = 3
 	gadgetLimits[GadgetTypSourcewaterDropletHydroTrav] = 12
 	gadgetLimits[GadgetTypSourcewaterDropletNeuv] = 12
+	gadgetLimits[GadgetTypCrystallizeShard] = 3
 }
 
 type Gadget interface {

--- a/pkg/reactable/crystallize.go
+++ b/pkg/reactable/crystallize.go
@@ -218,11 +218,6 @@ type CrystallizeShard struct {
 	expiry int
 }
 
-// TODO: check gadget limit
-// TODO: check shard replacement logic
-// TODO: add sys func to pick up shard (add docs)
-// TODO: add conditional for shard count (one for all and then one per element, add docs)
-// TODO: check if em snapshots for shield strength on crystallize trigger -> looks like it snaps EM when the shard is spawned/avail for pickup?
 func (r *Reactable) addCrystallizeShard(char *character.CharWrapper, rt reactions.ReactionType, typ attributes.Element, src int) {
 	// delay shard spawn
 	r.core.Tasks.Add(func() {

--- a/pkg/reactable/crystallize.go
+++ b/pkg/reactable/crystallize.go
@@ -1,11 +1,17 @@
 package reactable
 
 import (
+	"fmt"
+
+	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/geometry"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player/shield"
 	"github.com/genshinsim/gcsim/pkg/core/reactions"
+	"github.com/genshinsim/gcsim/pkg/gadget"
 )
 
 type CrystallizeShield struct {
@@ -66,8 +72,7 @@ func (r *Reactable) tryCrystallizeWithEle(a *combat.AttackEvent, ele attributes.
 		Abil:       string(rt),
 	}
 	snap := char.Snapshot(&ai)
-	shd := NewCrystallizeShield(char.Index, ele, r.core.F, snap.CharLvl, snap.Stats[attributes.EM], r.core.F+900)
-	r.core.Player.Shields.Add(shd)
+	r.addCrystallizeShard(char.Index, ele, r.core.F, snap.CharLvl, snap.Stats[attributes.EM])
 	// reduce
 	r.reduce(ele, a.Info.Durability, 0.5)
 	//TODO: confirm u can only crystallize once
@@ -206,4 +211,103 @@ var shieldBaseHP = []float64{
 	1785.86657714844,
 	1817.13745117188,
 	1851.06030273438,
+}
+
+type CrystallizeShard struct {
+	*gadget.Gadget
+	// earliest that a shard can be picked up after spawn
+	EarliestPickup int
+	// captures the shield because em snapshots
+	Shield *CrystallizeShield
+	// for logging purposes
+	src    int
+	expiry int
+}
+
+// TODO: check gadget limit
+// TODO: check shard replacement logic
+// TODO: add sys func to pick up shard (add docs)
+// TODO: add conditional for shard count (one for all and then one per element, add docs)
+// TODO: check if em snapshots for shield strength on crystallize trigger -> looks like it snaps EM when the shard is spawned/avail for pickup?
+func (r *Reactable) addCrystallizeShard(index int, typ attributes.Element, src, lvl int, em float64) {
+	// delay shard spawn
+	r.core.Tasks.Add(func() {
+		// shield snapshots em on shard spawn
+		// expiry will get set properly later
+		shd := NewCrystallizeShield(index, typ, src, lvl, em, -1)
+		cs := NewCrystallizeShard(r.core, r.self.Shape(), shd)
+		r.core.Combat.AddGadget(cs)
+		r.core.Log.NewEvent(
+			fmt.Sprintf("%v crystallize shard spawned", cs.Shield.Ele),
+			glog.LogElementEvent,
+			cs.Shield.ActorIndex,
+		).
+			Write("src", cs.src).
+			Write("expiry", cs.expiry).
+			Write("earliest_pickup", cs.EarliestPickup)
+	}, 23)
+}
+
+func NewCrystallizeShard(c *core.Core, shp geometry.Shape, shd *CrystallizeShield) *CrystallizeShard {
+	cs := &CrystallizeShard{}
+
+	circ, ok := shp.(*geometry.Circle)
+	if !ok {
+		panic("rectangle target hurtbox is not supported for crystallize shard spawning")
+	}
+
+	// for simplicity, crystallize shards spawn randomly at radius + 0.5
+	r := circ.Radius() + 0.5
+	// radius 2 is ok
+	cs.Gadget = gadget.New(c, geometry.CalcRandomPointFromCenter(circ.Pos(), r, r, c.Rand), 2, combat.GadgetTypDendroCore)
+
+	// shard lasts for 15s from shard spawn
+	cs.Gadget.Duration = 15 * 60
+	// earliest shard pickup is 54f from crystallize text, so 31f from shard spawn
+	cs.EarliestPickup = c.F + 31
+	cs.Shield = shd
+	cs.src = c.F
+	cs.expiry = c.F + cs.Gadget.Duration
+
+	return cs
+}
+
+func (cs *CrystallizeShard) AddShieldKillShard() bool {
+	// don't pick up if shard is not available for pick up yet
+	if cs.Core.F < cs.EarliestPickup {
+		cs.Core.Log.NewEvent(
+			fmt.Sprintf("%v crystallize shard could not be picked up", cs.Shield.Ele),
+			glog.LogElementEvent,
+			cs.Core.Player.Active(),
+		).
+			Write("src", cs.src).
+			Write("expiry", cs.expiry).
+			Write("earliest_pickup", cs.EarliestPickup)
+		return false
+	}
+	cs.Core.Log.NewEvent(
+		fmt.Sprintf("%v crystallize shard picked up", cs.Shield.Ele),
+		glog.LogElementEvent,
+		cs.Core.Player.Active(),
+	).
+		Write("src", cs.src).
+		Write("expiry", cs.expiry).
+		Write("earliest_pickup", cs.EarliestPickup)
+	// add shield
+	cs.Shield.Expires = cs.Core.F + 15.1*60 // shield lasts for 15.1s from shard pickup
+	cs.Core.Player.Shields.Add(cs.Shield)
+	// kill self
+	cs.Kill()
+	return true
+}
+
+func (cs *CrystallizeShard) HandleAttack(atk *combat.AttackEvent) float64 {
+	cs.Core.Events.Emit(event.OnGadgetHit, cs, atk)
+	return 0
+}
+func (cs *CrystallizeShard) Attack(*combat.AttackEvent, glog.Event) (float64, bool) { return 0, false }
+func (cs *CrystallizeShard) SetDirection(trg geometry.Point)                        {}
+func (cs *CrystallizeShard) SetDirectionToClosestEnemy()                            {}
+func (cs *CrystallizeShard) CalcTempDirection(trg geometry.Point) geometry.Point {
+	return geometry.DefaultDirection()
 }

--- a/ui/packages/docs/docs/reference/fields.md
+++ b/ui/packages/docs/docs/reference/fields.md
@@ -28,6 +28,7 @@ For example, if you are looking for the tag for Lisa's A4 (defense shred), then 
 | `construct` | `duration`/`count` | construct name | - | Evaluates to the duration/count of the specified construct. See individual character page for acceptable construct names. |
 | `gadgets` | `dendrocore` | `count` | - | Evaluates to the current number of Dendro Cores. |
 | `gadgets` | `sourcewaterdroplet` | `count` | - | Evaluates to the current number of Sourcewater Droplets. Use character specific fields to get number of Sourcewater Droplets in range. |
+| `gadgets` | `crystallizeshard` | `all`/`pyro`/`hydro`/`electro`/`cryo` | - | Evaluates to the current number of Crystallize Shards that can be picked up. `count` will return the total number of Crystallize Shards while the others will only count the ones of the given element. |
 | `keys` | `char`/`weapon`/`artifact` | char/weapon/artifact name | - | Evaluates to the key for the specified char/weapon/artifact name. See the relevant character/weapon/artifact page for acceptable names. |
 | `action` |  `skill`/`burst`/`attack`/`charge`/`high_plunge`/`low_plunge`/`aim`/`dash`/`jump`/`swap`/`walk`/`wait` | - | Evaluates to the key for the specified action name. |
 | `state` | - | - | - | Evaluates to the current state of the player. | 

--- a/ui/packages/docs/docs/reference/system_functions.md
+++ b/ui/packages/docs/docs/reference/system_functions.md
@@ -317,6 +317,22 @@ kill_target(arg);
 If `arg` is an invalid target (i.e. 3 when there are only 2 targets), then gcsim will exit with an error.
 :::
 
+## pick_up_crystallize
+
+```
+pick_up_crystallize(element);
+```
+
+- `pick_up_crystallize` will pick up the oldest crystallize shard with the specified `element` supplied as a string.
+- `pick_up_crystallize` will not pick up any shard if:
+ - no shard with the specified `element` exists 
+ - there is a shard with the specfied `element`, but it cannot be picked up yet
+- `pick_up_crystallize` will always evaluate to 0.
+
+:::danger
+`element` must be a string or an expression that evaluates to a string.
+:::
+
 ## sin
 
 ```


### PR DESCRIPTION
- before: crystallize shard immediately picked up on trigger
- now: crystallize spawns shards
- shards have to be explicitly picked up via new sys func (pick_up_crystallize)
- new conditionals to track crystallize shard count for waiting until pickup is possible (.gadgets.crystallizeshard.all/pyro/hydro/electro/cryo)
- shield is created on shard pickup

recommended usage (adjust 60 to be number of frames to wait for maximum):
```
for let k=0; k<60; k=k+1 {
    if .gadgets.crystallizeshard.hydro > 0 {
        pick_up_crystallize("hydro");
        break;
    }
    wait(1);
}
```