### PR TITLE
fix action exec log stam/swap_cd naming to be more accurate

### DIFF
--- a/pkg/core/player/exec.go
+++ b/pkg/core/player/exec.go
@@ -250,7 +250,7 @@ func (h *Handler) useAbility(
 		"executed ", t.String(),
 	).
 		Write("action", t.String()).
-		Write("stam_pre", h.Stam).
-		Write("swap_cd_pre", h.SwapCD)
+		Write("stam_post", h.Stam).
+		Write("swap_cd_post", h.SwapCD)
 	return nil
 }


### PR DESCRIPTION
- logs stam/swap_cd post (after) using the given action