### PR TITLE
fix yunjin q, c2 and c6 duration

### DIFF
--- a/internal/characters/yunjin/burst.go
+++ b/internal/characters/yunjin/burst.go
@@ -38,6 +38,13 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 		Durability: 50,
 		Mult:       burstDmg[c.TalentLvlBurst()],
 	}
+
+	// delete burst, c2 and c6 at start
+	c.DeleteStatus(burstBuffKey)
+	c.deleteC2()
+	c.deleteC6()
+
+	// queue dmg and burst, c2 and c6 start
 	c.QueueCharTask(func() {
 		c.Core.QueueAttack(ai, combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 6), 0, 0)
 		// Reset number of burst triggers to 30
@@ -45,12 +52,8 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 			char.SetTag(burstBuffKey, 30)
 			char.AddStatus(burstBuffKey, 720, true)
 		}
-		if c.Base.Cons >= 2 {
-			c.c2()
-		}
-		if c.Base.Cons >= 6 {
-			c.c6()
-		}
+		c.c2()
+		c.c6()
 	}, burstHitmark)
 
 	c.ConsumeEnergy(4)

--- a/internal/characters/yunjin/burst.go
+++ b/internal/characters/yunjin/burst.go
@@ -38,21 +38,20 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 		Durability: 50,
 		Mult:       burstDmg[c.TalentLvlBurst()],
 	}
-	c.Core.QueueAttack(ai, combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 6), burstHitmark, burstHitmark)
-
-	// Reset number of burst triggers to 30
-	for _, char := range c.Core.Player.Chars() {
-		char.SetTag(burstBuffKey, 30)
-		char.AddStatus(burstBuffKey, 720, true)
-	}
-
-	// TODO: Need to obtain exact timing of c2/c6. Currently assume that it starts when burst is used
-	if c.Base.Cons >= 2 {
-		c.c2()
-	}
-	if c.Base.Cons >= 6 {
-		c.c6()
-	}
+	c.QueueCharTask(func() {
+		c.Core.QueueAttack(ai, combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 6), 0, 0)
+		// Reset number of burst triggers to 30
+		for _, char := range c.Core.Player.Chars() {
+			char.SetTag(burstBuffKey, 30)
+			char.AddStatus(burstBuffKey, 720, true)
+		}
+		if c.Base.Cons >= 2 {
+			c.c2()
+		}
+		if c.Base.Cons >= 6 {
+			c.c6()
+		}
+	}, burstHitmark)
 
 	c.ConsumeEnergy(4)
 	c.SetCD(action.ActionBurst, 15*60)

--- a/internal/characters/yunjin/cons.go
+++ b/internal/characters/yunjin/cons.go
@@ -10,13 +10,21 @@ import (
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
+const (
+	c2Key = "yunjin-c2"
+	c6Key = "yunjin-c6"
+)
+
 // After Cliffbreaker's Banner is unleashed, all nearby party members' Normal Attack DMG is increased by 15% for 12s.
 func (c *char) c2() {
+	if c.Base.Cons < 2 {
+		return
+	}
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.DmgP] = .15
 	for _, char := range c.Core.Player.Chars() {
 		char.AddAttackMod(character.AttackMod{
-			Base: modifier.NewBaseWithHitlag("yunjin-c2", 12*60),
+			Base: modifier.NewBaseWithHitlag(c2Key, 12*60),
 			Amount: func(ae *combat.AttackEvent, _ combat.Target) ([]float64, bool) {
 				if ae.Info.AttackTag == attacks.AttackTagNormal {
 					return m, true
@@ -27,8 +35,20 @@ func (c *char) c2() {
 	}
 }
 
+func (c *char) deleteC2() {
+	if c.Base.Cons < 2 {
+		return
+	}
+	for _, char := range c.Core.Player.Chars() {
+		char.DeleteStatus(c2Key)
+	}
+}
+
 // When Yun Jin triggers the Crystallize Reaction, her DEF is increased by 20% for 12s.
 func (c *char) c4() {
+	if c.Base.Cons < 4 {
+		return
+	}
 	c.c4bonus = make([]float64, attributes.EndStatType)
 	c.c4bonus[attributes.DEFP] = .2
 	charModFunc := func(args ...interface{}) bool {
@@ -59,10 +79,13 @@ func (c *char) c4() {
 
 // Characters under the effects of the Flying Cloud Flag Formation have their Normal ATK SPD increased by 12%.
 func (c *char) c6() {
+	if c.Base.Cons < 6 {
+		return
+	}
 	for _, char := range c.Core.Player.Chars() {
 		this := char
 		this.AddStatMod(character.StatMod{
-			Base:         modifier.NewBaseWithHitlag("yunjin-c6", 12*60),
+			Base:         modifier.NewBaseWithHitlag(c6Key, 12*60),
 			AffectedStat: attributes.AtkSpd,
 			Amount: func() ([]float64, bool) {
 				//TODO: i assume this buff should go away if stacks are gone?
@@ -72,5 +95,14 @@ func (c *char) c6() {
 				return c.c6bonus, true
 			},
 		})
+	}
+}
+
+func (c *char) deleteC6() {
+	if c.Base.Cons < 6 {
+		return
+	}
+	for _, char := range c.Core.Player.Chars() {
+		char.DeleteStatus(c6Key)
 	}
 }

--- a/internal/characters/yunjin/yunjin.go
+++ b/internal/characters/yunjin/yunjin.go
@@ -40,9 +40,7 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ info.CharacterProfile) er
 func (c *char) Init() error {
 	c.a4Init()
 	c.burstProc()
-	if c.Base.Cons >= 4 {
-		c.c4()
-	}
+	c.c4()
 	if c.Base.Cons >= 6 {
 		c.c6bonus = make([]float64, attributes.EndStatType)
 		c.c6bonus[attributes.AtkSpd] = .12


### PR DESCRIPTION
- should start at hitmark and not on cast (effectively 35f longer now)
- q, c2 and c6 status should be deleted on cast
- adjust cons checks for c2, c4, c6 to be inside of the funcs