### PR TITLE
Bugfixes for sample logs

### DIFF
--- a/pkg/modifier/modifier.go
+++ b/pkg/modifier/modifier.go
@@ -35,11 +35,13 @@ func (t *Base) Extend(key string, logger glog.Logger, index, amt int) {
 		t.extension = 0
 	}
 	t.event.SetEnded(t.Expiry())
-	logger.NewEvent("mod extended", glog.LogStatusEvent, -1).
+	logger.NewEvent("mod extended", glog.LogStatusEvent, index).
 		Write("key", key).
 		Write("amt", amt).
-		Write("expiry", t.Expiry())
+		Write("expiry", t.Expiry()).
+		Write("ext", t.extension)
 }
+
 func (t *Base) SetExpiry(f int) {
 	if t.Dur == -1 {
 		t.ModExpiry = -1

--- a/ui/packages/ui/src/Pages/Sample/Components/parsev2.ts
+++ b/ui/packages/ui/src/Pages/Sample/Components/parsev2.ts
@@ -337,15 +337,7 @@ export function parseLogV2(
         break;
       case "status":
         e.icon = "iso";
-
-        // Add expiry frame to the end if exists
-        switch (d.expiry) {
-          case undefined:
-            break;
-          default:
-            e.msg += strFrameWithSec(d.expiry);
-            e.msg = d.key + " " + e.msg;
-        }
+        e.msg = d.key + " " + e.msg;
 
         // this hacky but i don't care
         if (e.ended === e.frame && line.msg.includes("refreshed")) {
@@ -365,8 +357,9 @@ export function parseLogV2(
           }
         }
 
-        if (d.target != undefined) {
-          e.target = d.target;
+        if (e.ended != undefined) {
+          // maybe use e.target?
+          e.msg += strFrameWithSec(e.ended);
         }
         break;
       default:

--- a/ui/packages/ui/src/Pages/Sample/Components/parsev2.ts
+++ b/ui/packages/ui/src/Pages/Sample/Components/parsev2.ts
@@ -340,12 +340,11 @@ export function parseLogV2(
         e.msg = d.key + " " + e.msg;
 
         // this hacky but i don't care
-        if (e.ended === e.frame && line.msg.includes("refreshed")) {
+        if (e.ended === e.frame && (line.msg.includes("refreshed") || line.msg.includes("extended"))) {
           const idx = lines.findIndex((a) => {
             return (
               a.event === "status" &&
               line.char_index === a.char_index &&
-              !a.logs.overwrite &&
               a.logs.key === line.logs.key &&
               line.frame >= a.frame &&
               line.frame < a.ended

--- a/ui/packages/ui/src/Pages/Sample/Components/parsev2.ts
+++ b/ui/packages/ui/src/Pages/Sample/Components/parsev2.ts
@@ -211,20 +211,15 @@ export function parseLogV2(
 
         e.icon = "queue";
         break;
+      case "cooldown":
+        // if (d.expiry != undefined) {
+        //   e.ended = e.frame + d.expiry;
+        //   e.msg += strFrameWithSec(e.ended);
+        // }
+        break;
       case "action":
         if (line.msg.includes("executed") && d.action === "swap") {
           e.msg += " to " + d.target;
-        }
-
-        if (line.msg.includes("cooldown")) {
-          // Add expiry frame to the end if exists
-          switch (d.expiry) {
-            case undefined:
-              break;
-            default:
-              e.msg += strFrameWithSec(d.expiry);
-              e.msg = d.type + " " + e.msg;
-          }
         }
         //trim "executed "
         e.msg = e.msg.replace("executed ", "");


### PR DESCRIPTION
* Add highlight to animation and `mod extended` logs
* Fix mod logs to use hitlagged expiry
* Move `mod extended` logs to char column
* Remove event name from cooldown logs `cooldown: skill cooldown triggered` -> `skill cooldown triggered`