### PR TITLE
fix damage timeline graphs cutting off final bucket in some cases

### DIFF
--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/CumulativeData.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/CumulativeData.tsx
@@ -37,10 +37,7 @@ export function useData(input?: CharacterBucketStats, names?: string[]): ChartDa
       };
     }
     
-    const duration = Math.floor(((data.length-1) * bucket_size) / 60);
-    if (duration < data[data.length-1].x) {
-      data.pop();
-    }
+    const duration = ((data.length - 1) * bucket_size) / 60;
 
     return {
       data: data,

--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/DamageOverTimeData.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/DamageOverTimeData.tsx
@@ -36,10 +36,7 @@ export function useData(input?: BucketStats): OverTimeData {
       };
     }
 
-    const duration = Math.floor(((data.length-1) * bucketSize) / 60);
-    if (duration < data[data.length-1].x) {
-      data.pop();
-    }
+    const duration = ((data.length - 1) * bucketSize) / 60;
 
     return {
       data: data,


### PR DESCRIPTION
- now will show all buckets on timeline