### PR TITLE
fix shatter not being tracked in reaction stat

### DIFF
--- a/pkg/stats/reaction/reaction.go
+++ b/pkg/stats/reaction/reaction.go
@@ -14,6 +14,7 @@ var eventToReaction = map[event.Event]reactions.ReactionType{
 	event.OnMelt:               reactions.Melt,
 	event.OnVaporize:           reactions.Vaporize,
 	event.OnFrozen:             reactions.Freeze,
+	event.OnShatter:            reactions.Shatter,
 	event.OnElectroCharged:     reactions.ElectroCharged,
 	event.OnSwirlHydro:         reactions.SwirlHydro,
 	event.OnSwirlCryo:          reactions.SwirlCryo,


### PR DESCRIPTION
- will now also show up in "Reactions Per Source" bar chart