### PR TITLE
add buttons to recover config on sim runtime error

### DIFF
--- a/ui/packages/ui/src/Pages/Viewer/Tabs/Config.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Tabs/Config.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 import Editor from "react-simple-code-editor";
 import { Button, Callout, Intent, NonIdealState, Spinner, SpinnerSize } from "@blueprintjs/core";
 import { SimResults } from '@gcsim/types';
@@ -26,11 +26,12 @@ type UseConfigData = {
 
 type ConfigProps = {
   config: UseConfigData;
+  setRecoverConfig: Dispatch<SetStateAction<string>>;
   running: boolean;
   resetTab: () => void;
 };
 
-const ConfigUI = ({ config, running, resetTab }: ConfigProps) => {
+const ConfigUI = ({ config, setRecoverConfig, running, resetTab }: ConfigProps) => {
   const dispatch = useAppDispatch();
   const history = useHistory();
 
@@ -51,6 +52,7 @@ const ConfigUI = ({ config, running, resetTab }: ConfigProps) => {
               loading={!config.isReady || running}
               className="basis-1/2"
               onClick={() => {
+                setRecoverConfig(config.cfg ?? "");
                 dispatch(runSim(config.exec(), config.cfg ?? ""));
                 resetTab();
                 history.push("/web");


### PR DESCRIPTION
- Copy to Config and Send To Simulator
- previously recovery of config from rerun on error impossible
- adjust confirm button text to be more clear about where it leads

example images (not the prettiest but good enough to drastically improve UX for rerun tab on viewer page):
![image](https://github.com/genshinsim/gcsim/assets/98557316/55ac3329-edfb-459b-9876-4b979e28b0c6)
![image](https://github.com/genshinsim/gcsim/assets/98557316/3de64696-ef93-4aa3-8960-f18f2fb096d0)
