### PR TITLE
adjust damage timeline legend to fill remaining space

### DIFF
--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/index.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/index.tsx
@@ -77,7 +77,7 @@ export default ({ data, running, names }: Props) => {
           <CardTitle title={t<string>("result.dmg_timeline")} tooltip="x" />
           <Options graph={graph} setGraph={setGraph} />
         </div>
-        <div className="flex justify-start sm:justify-center pb-5 sm:pb-0 items-center">
+        <div className="flex flex-grow justify-start sm:justify-center pb-5 sm:pb-0 items-center">
           <Legend graph={graph} names={names} glyphNames={glyphNames} glyphs={glyphs} />
         </div>
       </div>


### PR DESCRIPTION
- previously was towards top left of card instead of center of remaining space at top