### PR TITLE
adjust Sampler UI

### DIFF
--- a/ui/packages/ui/src/Pages/Sample/Components/Options.tsx
+++ b/ui/packages/ui/src/Pages/Sample/Components/Options.tsx
@@ -54,7 +54,7 @@ export function Options(props: OptionsProp) {
           <div>{/* <ButtonGroup></ButtonGroup> */}</div>
         </div>
         <div className={Classes.DIALOG_FOOTER}>
-          <div className={classNames(Classes.DIALOG_FOOTER_ACTIONS, "!flex !flex-col !gap-1.5 !sm:flex-row !sm:gap-0")}>
+          <div className={classNames(Classes.DIALOG_FOOTER_ACTIONS, "!flex !flex-col !gap-1.5 sm:!flex-row sm:!gap-0")}>
             <Button onClick={() => props.handleSetPresets("simple")}>
               {t<string>("viewer.simple")}
             </Button>

--- a/ui/packages/ui/src/Pages/Sample/Components/Options.tsx
+++ b/ui/packages/ui/src/Pages/Sample/Components/Options.tsx
@@ -1,6 +1,7 @@
 import { Button, Classes, Dialog } from "@blueprintjs/core";
 import { eventColor } from "./parse";
 import { Trans, useTranslation } from "react-i18next";
+import classNames from "classnames";
 
 export interface OptionsProp {
   isOpen: boolean;
@@ -49,11 +50,11 @@ export function Options(props: OptionsProp) {
           <div className="text-md font-medium">
             <Trans>viewer.log_options</Trans>
           </div>
-          <div className="grid grid-cols-3">{cols}</div>
+          <div className="grid grid-cols-2 sm:grid-cols-3">{cols}</div>
           <div>{/* <ButtonGroup></ButtonGroup> */}</div>
         </div>
         <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <div className={classNames(Classes.DIALOG_FOOTER_ACTIONS, "!flex !flex-col !gap-1.5 !sm:flex-row !sm:gap-0")}>
             <Button onClick={() => props.handleSetPresets("simple")}>
               {t<string>("viewer.simple")}
             </Button>

--- a/ui/packages/ui/src/Pages/Sample/Components/SampleView.tsx
+++ b/ui/packages/ui/src/Pages/Sample/Components/SampleView.tsx
@@ -196,51 +196,52 @@ function SamplerUI({ sample, data, team, searchable, settings, setSettings }: Sa
   };
 
   return (
+    <>
+    <div className="flex flex-col sm:flex-row justify-between">
+      <FormGroup label={t<string>("viewer.search")} inline>
+        <InputGroup
+          type="text"
+          inputRef={searchRef}
+          rightElement={
+            <FormGroup>
+              <Button
+                icon="arrow-down"
+                intent="warning"
+                onClick={() => {
+                  if (searchRef.current != null) {
+                    searchAndScroll(searchRef.current.value);
+                  }
+                }}
+              />
+              <Button
+                icon="reset"
+                intent="warning"
+                onClick={() => {
+                  if (searchRef.current != null) {
+                    searchRef.current.value = "";
+                  }
+                  lastSearchIndex = 0;
+                  rowVirtualizer.scrollToIndex(0);
+                }}
+              />
+            </FormGroup>
+          }
+        />
+      </FormGroup>
+      <ButtonGroup className="mb-[15px]">
+        <SampleOptions settings={settings} setSettings={setSettings} />
+        <Button
+            icon="bring-data"
+            text={t<string>("viewer.download")}
+            intent={Intent.SUCCESS}
+            onClick={() => {
+              const out = Pako.deflate(JSON.stringify(sample));
+              const blob = new Blob([out], { type: "application/base64" });
+              saveAs(blob, "sample.gz");
+            }} />
+      </ButtonGroup>
+    </div>
     <div className="flex flex-col overflow-x-auto h-[80vh]">
-      <div className="flex justify-between">
-        <FormGroup label={t<string>("viewer.search")} inline>
-          <InputGroup
-            type="text"
-            inputRef={searchRef}
-            rightElement={
-              <FormGroup>
-                <Button
-                  icon="arrow-down"
-                  intent="warning"
-                  onClick={() => {
-                    if (searchRef.current != null) {
-                      searchAndScroll(searchRef.current.value);
-                    }
-                  }}
-                />
-                <Button
-                  icon="reset"
-                  intent="warning"
-                  onClick={() => {
-                    if (searchRef.current != null) {
-                      searchRef.current.value = "";
-                    }
-                    lastSearchIndex = 0;
-                    rowVirtualizer.scrollToIndex(0);
-                  }}
-                />
-              </FormGroup>
-            }
-          />
-        </FormGroup>
-        <ButtonGroup className="mb-[15px]">
-          <SampleOptions settings={settings} setSettings={setSettings} />
-          <Button
-              icon="bring-data"
-              text={t<string>("viewer.download")}
-              intent={Intent.SUCCESS}
-              onClick={() => {
-                const out = Pako.deflate(JSON.stringify(sample));
-                const blob = new Blob([out], { type: "application/base64" });
-                saveAs(blob, "sample.gz");
-              }} />
-        </ButtonGroup>
-      </div>
       <Card className="flex-auto !bg-gray-600 !text-xs min-w-[60rem] ">
         <AutoSizer disableWidth={true}>
           {({ height, width }) => (
@@ -315,6 +316,7 @@ function SamplerUI({ sample, data, team, searchable, settings, setSettings }: Sa
         </AutoSizer>
       </Card>
     </div>
+    </>
   );
 }
 

--- a/ui/packages/ui/src/Pages/Viewer/Tabs/Sample.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Tabs/Sample.tsx
@@ -56,7 +56,7 @@ export default ({ sampler, data, sample, running }: Props) => {
   }
 
   return (
-    <div className="flex flex-grow flex-col gap-[15px] px-2">
+    <div className="w-full 2xl:mx-auto 2xl:container flex flex-grow flex-col gap-[15px] px-2">
       <Generate sampler={sampler} data={data} sample={sample} running={running} />
       <Sampler
           sample={sample.sample}


### PR DESCRIPTION
- now has the same width as the other tabs on viewer page
- fix sample search bar being squished on mobile
- fix log options dialog not fitting on mobile screen
- adjust horizontal scrolling to only include the gray box and not the search/settings/download