### PR TITLE
add ShieldTarget to shield interface and other shield fixes

### DIFF
--- a/internal/artifacts/bolide/bolide.go
+++ b/internal/artifacts/bolide/bolide.go
@@ -37,14 +37,10 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 		char.AddAttackMod(character.AttackMod{
 			Base: modifier.NewBase("bolide-4pc", -1),
 			Amount: func(atk *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-				// TODO: works off field?
-				if c.Player.Active() != char.Index {
-					return nil, false
-				}
 				if atk.Info.AttackTag != attacks.AttackTagNormal && atk.Info.AttackTag != attacks.AttackTagExtra {
 					return nil, false
 				}
-				if !c.Player.Shields.PlayerIsShielded() {
+				if !c.Player.Shields.CharacterIsShielded(char.Index, c.Player.Active()) {
 					return nil, false
 				}
 				return m, true

--- a/internal/characters/baizhu/shield.go
+++ b/internal/characters/baizhu/shield.go
@@ -14,6 +14,7 @@ func (c *char) newShield(base float64, dur int) *shd {
 	n := &shd{}
 	n.Tmpl = &shield.Tmpl{}
 	n.Tmpl.ActorIndex = c.Index
+	n.Tmpl.Target = -1
 	n.Tmpl.Src = c.Core.F
 	n.Tmpl.ShieldType = shield.BaizhuBurst
 	n.Tmpl.Ele = attributes.Dendro

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -75,8 +75,9 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 		// create a shield
 		c.Core.Player.Shields.Add(&shield.Tmpl{
 			ActorIndex: c.Index,
+			Target:     -1,
 			Src:        c.Core.F,
-			ShieldType: shield.BeidouThunderShield,
+			ShieldType: shield.BeidouC1,
 			Name:       "Beidou C1",
 			HP:         .16 * c.MaxHP(),
 			Ele:        attributes.Electro,

--- a/internal/characters/beidou/skill.go
+++ b/internal/characters/beidou/skill.go
@@ -64,12 +64,13 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 		// add shield
 		c.Core.Player.Shields.Add(&shield.Tmpl{
 			ActorIndex: c.Index,
+			Target:     c.Index,
 			Src:        c.Core.F,
 			ShieldType: shield.BeidouThunderShield,
 			Name:       "Beidou Skill",
 			HP:         shieldPer[c.TalentLvlSkill()]*c.MaxHP() + shieldBase[c.TalentLvlSkill()],
 			Ele:        attributes.Electro,
-			Expires:    c.Core.F + 900, // 15 sec
+			Expires:    c.Core.F + skillHitmark, // last until hitmark
 		})
 	}
 

--- a/internal/characters/candace/skill.go
+++ b/internal/characters/candace/skill.go
@@ -102,6 +102,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	// Add shield until skill unleashed (treated as frame when attack hits)
 	c.Core.Player.Shields.Add(&shield.Tmpl{
 		ActorIndex: c.Index,
+		Target:     c.Index,
 		Src:        c.Core.F,
 		Name:       "Candace Skill",
 		ShieldType: shield.CandaceSkill,

--- a/internal/characters/diona/skill.go
+++ b/internal/characters/diona/skill.go
@@ -118,6 +118,7 @@ func (c *char) pawsPewPew(f, travel, pawCount int) {
 			} else {
 				shd = &shield.Tmpl{
 					ActorIndex: c.Index,
+					Target:     -1,
 					Src:        c.Core.F,
 					ShieldType: shield.DionaSkill,
 					Name:       "Diona Skill",

--- a/internal/characters/kaeya/cons.go
+++ b/internal/characters/kaeya/cons.go
@@ -90,6 +90,7 @@ func (c *char) c4() {
 			c.c4icd = c.Core.F + 3600
 			c.Core.Player.Shields.Add(&shield.Tmpl{
 				ActorIndex: c.Index,
+				Target:     c.Index,
 				Src:        c.Core.F,
 				ShieldType: shield.KaeyaC4,
 				Name:       "Kaeya C4",

--- a/internal/characters/kirara/shield.go
+++ b/internal/characters/kirara/shield.go
@@ -15,6 +15,8 @@ func (c *char) genShield(src string, shieldamt float64) {
 	// add shield
 	c.Core.Tasks.Add(func() {
 		c.Core.Player.Shields.Add(&shield.Tmpl{
+			ActorIndex: c.Index,
+			Target:     -1,
 			Src:        c.Core.F,
 			ShieldType: shield.KiraraSkill,
 			Name:       src,

--- a/internal/characters/layla/shield.go
+++ b/internal/characters/layla/shield.go
@@ -37,6 +37,7 @@ func (c *char) newShield(base float64, dur int) *shd {
 	n := &shd{}
 	n.Tmpl = &shield.Tmpl{}
 	n.Tmpl.ActorIndex = c.Index
+	n.Tmpl.Target = -1
 	n.Tmpl.Src = c.Core.F
 	n.Tmpl.ShieldType = shield.LaylaSkill
 	n.Tmpl.Ele = attributes.Cryo

--- a/internal/characters/noelle/asc.go
+++ b/internal/characters/noelle/asc.go
@@ -46,6 +46,7 @@ func (c *char) a1() {
 		x := snap.BaseDef*(1+snap.Stats[attributes.DEFP]) + snap.Stats[attributes.DEF]
 		c.Core.Player.Shields.Add(&shield.Tmpl{
 			ActorIndex: c.Index,
+			Target:     active.Index,
 			Src:        c.Core.F,
 			ShieldType: shield.NoelleA1,
 			Name:       "Noelle A1",

--- a/internal/characters/noelle/shield.go
+++ b/internal/characters/noelle/shield.go
@@ -14,6 +14,7 @@ func (c *char) newShield(base float64, t shield.Type, dur int) *noelleShield {
 	n := &noelleShield{}
 	n.Tmpl = &shield.Tmpl{}
 	n.Tmpl.ActorIndex = c.Index
+	n.Tmpl.Target = -1
 	n.Tmpl.Src = c.Core.F
 	n.Tmpl.ShieldType = t
 	n.Tmpl.Name = "Noelle Skill"

--- a/internal/characters/thoma/shield.go
+++ b/internal/characters/thoma/shield.go
@@ -28,6 +28,7 @@ func (c *char) genShield(src string, shieldamt float64, shouldStack bool) {
 	c.Core.Tasks.Add(func() {
 		c.Core.Player.Shields.Add(&shield.Tmpl{
 			ActorIndex: c.Index,
+			Target:     -1,
 			Src:        c.Core.F,
 			ShieldType: shield.ThomaSkill,
 			Name:       src,

--- a/internal/characters/traveler/common/hydro/cons.go
+++ b/internal/characters/traveler/common/hydro/cons.go
@@ -29,6 +29,8 @@ func (c *Traveler) c4() {
 
 	// add shield
 	c.Core.Player.Shields.Add(&shield.Tmpl{
+		ActorIndex: c.Index,
+		Target:     c.Index,
 		Src:        c.Core.F,
 		ShieldType: shield.TravelerHydroC4,
 		Name:       "Traveler (Hydro) C4",

--- a/internal/characters/xinyan/asc.go
+++ b/internal/characters/xinyan/asc.go
@@ -28,18 +28,16 @@ func (c *char) a4() {
 	}
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.PhyP] = 0.15
-	for _, char := range c.Core.Player.Chars() {
+	for i, char := range c.Core.Player.Chars() {
+		idx := i
 		char.AddAttackMod(character.AttackMod{
 			Base: modifier.NewBase("xinyan-a4", -1),
 			Amount: func(_ *combat.AttackEvent, _ combat.Target) ([]float64, bool) {
-				if !c.Core.Player.Shields.PlayerIsShielded() {
-					return nil, false
-				}
 				shd := c.Core.Player.Shields.Get(shield.XinyanSkill)
 				if shd == nil {
 					return nil, false
 				}
-				return m, true
+				return m, c.Core.Player.Active() == idx
 			},
 		})
 	}

--- a/internal/characters/xinyan/shield.go
+++ b/internal/characters/xinyan/shield.go
@@ -14,6 +14,7 @@ func (c *char) newShield(base float64, t shield.Type, dur int) *xinyanShield {
 	n := &xinyanShield{}
 	n.Tmpl = &shield.Tmpl{}
 	n.Tmpl.ActorIndex = c.Index
+	n.Tmpl.Target = -1
 	n.Tmpl.Src = c.Core.F
 	n.Tmpl.ShieldType = t
 	n.Tmpl.Name = "Xinyan Skill"

--- a/internal/characters/yanfei/cons.go
+++ b/internal/characters/yanfei/cons.go
@@ -45,6 +45,7 @@ func (c *char) c4() {
 	}
 	c.Core.Player.Shields.Add(&shield.Tmpl{
 		ActorIndex: c.Index,
+		Target:     -1,
 		Src:        c.Core.F,
 		ShieldType: shield.YanfeiC4,
 		Name:       "Yanfei C4",

--- a/internal/characters/yunjin/skill.go
+++ b/internal/characters/yunjin/skill.go
@@ -109,6 +109,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	// Add shield until skill unleashed (treated as frame when attack hits)
 	c.Core.Player.Shields.Add(&shield.Tmpl{
 		ActorIndex: c.Index,
+		Target:     c.Index,
 		Src:        c.Core.F,
 		Name:       "Yun Jin Skill",
 		ShieldType: shield.YunjinSkill,

--- a/internal/characters/zhongli/shield.go
+++ b/internal/characters/zhongli/shield.go
@@ -50,6 +50,7 @@ func (c *char) newShield(base float64, dur int) *shd {
 	n := &shd{}
 	n.Tmpl = &shield.Tmpl{}
 	n.Tmpl.ActorIndex = c.Index
+	n.Tmpl.Target = -1
 	n.Tmpl.Src = c.Core.F
 	n.Tmpl.ShieldType = shield.ZhongliJadeShield
 	n.Tmpl.Ele = attributes.Geo

--- a/internal/weapons/claymore/beacon/beacon.go
+++ b/internal/weapons/claymore/beacon/beacon.go
@@ -47,7 +47,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 		Base:         modifier.NewBase("beacon-of-the-reed-sea-hp", -1),
 		AffectedStat: attributes.HPP,
 		Amount: func() ([]float64, bool) {
-			if c.Player.Shields.PlayerIsShielded() {
+			if c.Player.Shields.CharacterIsShielded(char.Index, c.Player.Active()) {
 				return nil, false
 			}
 			return mHP, true

--- a/internal/weapons/claymore/bell/bell.go
+++ b/internal/weapons/claymore/bell/bell.go
@@ -52,6 +52,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 
 		c.Player.Shields.Add(&shield.Tmpl{
 			ActorIndex: char.Index,
+			Target:     char.Index,
 			Src:        c.F,
 			ShieldType: shield.Bell,
 			Name:       "Bell",
@@ -67,7 +68,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 		Base:         modifier.NewBase("bell", -1),
 		AffectedStat: attributes.NoStat,
 		Amount: func() ([]float64, bool) {
-			return val, char.Index == c.Player.Active() && c.Player.Shields.PlayerIsShielded()
+			return val, c.Player.Shields.CharacterIsShielded(char.Index, c.Player.Active())
 		},
 	})
 

--- a/internal/weapons/common/goldenmajesty.go
+++ b/internal/weapons/common/goldenmajesty.go
@@ -69,7 +69,7 @@ func (g *GoldenMajesty) NewWeapon(c *core.Core, char *character.CharWrapper, p i
 			AffectedStat: attributes.NoStat,
 			Amount: func() ([]float64, bool) {
 				m[attributes.ATKP] = atkbuff * float64(stacks)
-				if char.Index == c.Player.Active() && c.Player.Shields.PlayerIsShielded() {
+				if c.Player.Shields.CharacterIsShielded(char.Index, c.Player.Active()) {
 					m[attributes.ATKP] *= 2
 				}
 				return m, true

--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -44,7 +44,7 @@ func (p *Player) HandleAttack(atk *combat.AttackEvent) float64 {
 	dmg, crit = p.calc(atk)
 
 	active := p.Core.Player.Active()
-	dmgLeft := p.Core.Player.Shields.OnDamage(active, dmg, atk.Info.Element)
+	dmgLeft := p.Core.Player.Shields.OnDamage(active, active, dmg, atk.Info.Element)
 	if dmgLeft > 0 {
 		p.Core.Player.Drain(player.DrainInfo{
 			ActorIndex: active,

--- a/pkg/core/player/shield/shield.go
+++ b/pkg/core/player/shield/shield.go
@@ -13,6 +13,7 @@ const (
 	ZhongliJadeShield
 	DionaSkill
 	BeidouThunderShield
+	BeidouC1
 	XinyanSkill
 	XinyanC2
 	KaeyaC4
@@ -30,6 +31,7 @@ const (
 
 type Shield interface {
 	ShieldOwner() int
+	ShieldTarget() int // -1 to apply to all characters, character index otherwise
 	Key() int
 	Type() Type
 	ShieldStrength(ele attributes.Element, bonus float64) float64

--- a/pkg/core/player/shield/template.go
+++ b/pkg/core/player/shield/template.go
@@ -4,6 +4,7 @@ import "github.com/genshinsim/gcsim/pkg/core/attributes"
 
 type Tmpl struct {
 	ActorIndex int
+	Target     int
 	Name       string
 	Src        int
 	ShieldType Type
@@ -14,6 +15,10 @@ type Tmpl struct {
 
 func (t *Tmpl) ShieldOwner() int {
 	return t.ActorIndex
+}
+
+func (t *Tmpl) ShieldTarget() int {
+	return t.Target
 }
 
 func (t *Tmpl) Desc() string {

--- a/pkg/reactable/crystallize.go
+++ b/pkg/reactable/crystallize.go
@@ -97,6 +97,7 @@ func NewCrystallizeShield(index int, typ attributes.Element, src, lvl int, em fl
 	}
 
 	s.Tmpl.ActorIndex = index
+	s.Tmpl.Target = -1
 	s.Tmpl.Ele = typ
 	s.Tmpl.ShieldType = shield.Crystallize
 	s.Tmpl.Name = "Crystallize " + typ.String()

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -190,7 +190,7 @@ func SetupResonance(s *core.Core) {
 					return false
 				}
 				atk := args[1].(*combat.AttackEvent)
-				if s.Player.Shields.PlayerIsShielded() && s.Player.Active() == atk.Info.ActorIndex {
+				if s.Player.Shields.CharacterIsShielded(atk.Info.ActorIndex, s.Player.Active()) {
 					t.AddResistMod(combat.ResistMod{
 						Base:  modifier.NewBaseWithHitlag("geo-res", 15*60),
 						Ele:   attributes.Geo,
@@ -203,7 +203,7 @@ func SetupResonance(s *core.Core) {
 			val := make([]float64, attributes.EndStatType)
 			val[attributes.DmgP] = .15
 			atkf := func(ae *combat.AttackEvent, t combat.Target) ([]float64, bool) {
-				if s.Player.Shields.PlayerIsShielded() && s.Player.Active() == ae.Info.ActorIndex {
+				if s.Player.Shields.CharacterIsShielded(ae.Info.ActorIndex, s.Player.Active()) {
 					return val, true
 				}
 				return nil, false


### PR DESCRIPTION
- shielded check should be character specific and shield target specific
- shield add should consider target of the shield for overwrite
- shield OnDamage should only damage shields that apply for the given char
- fix beidou c1 and skill sharing shield type
- fix beidou skill shield lasting for 15s instead of until hitmark
- fix bolide, geo resonance, bell dmg bonus, goldenmajesty not working off-field for 1 character shields
- fix xinyan a4 applying to phys dmg dealt from off-field characters (global shield so need active check) 

dbcompare is looking ok, biggest impact is beidou skill shield dur fix