### PR TITLE
fix furina fanfare gain mechanics

### DIFF
--- a/internal/characters/furina/furina.go
+++ b/internal/characters/furina/furina.go
@@ -32,16 +32,17 @@ func (a Arkhe) String() string {
 
 type char struct {
 	*tmpl.Character
-	curFanfare          float64
-	maxQFanfare         float64
-	maxC2Fanfare        float64
-	burstBuff           []float64
-	a4Buff              []float64
-	a4IntervalReduction float64
-	lastSummonSrc       int
-	arkhe               Arkhe
-	c6Count             int
-	c6HealSrc           int
+	curFanfare                float64
+	maxQFanfare               float64
+	maxC2Fanfare              float64
+	fanfareDebounceTaskQueued bool
+	burstBuff                 []float64
+	a4Buff                    []float64
+	a4IntervalReduction       float64
+	lastSummonSrc             int
+	arkhe                     Arkhe
+	c6Count                   int
+	c6HealSrc                 int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ info.CharacterProfile) error {


### PR DESCRIPTION
closes #1994 

- assumption: salon member hp drain will drain all chars in same frame (inconsistent ingame, assumption was not changed here)
- fanfare gain seems to have a ~0.5s debounce status and ~6f delay from hp drain confirmation from server to actual fanfare gain if debounce status is not up yet
- if debounce status is up, all fanfare changes seem to be delayed until this status is gone
- example:
  - t=0f: hp drain happens, debounce status not up so queued fanfare gain to happen at t=0+6=6f and queued debounce status application at t=1f
  - t=1f: debounce status applied, lasts until t=36f, any hp drains that happen while status is up will have their fanfare gain delayed until t=36f
  - t=6f: fanfare gain from t=1f happens
  - t=10f: hp drain happens, debounce status is up so queued fanfare gain to happen at t=31f
  - t=15f: hp drain happens, debounce status is up so queued fanfare gain to happen at t=31f
  - t=36f: fanfare gain from t=10f and t=15f happens, debounce status expires
  
from running dbcompare the diff for avg team dps seems to be around -1% so it's not too big of a nerf