### PR TITLE
added fixed seed for gradients

### DIFF
--- a/pkg/optimization/details.go
+++ b/pkg/optimization/details.go
@@ -84,8 +84,10 @@ func (stats *SubstatOptimizerDetails) calculateSubstatGradientsForChar(
 	amount int,
 ) []float64 {
 	stats.simcfg.Characters = stats.charProfilesCopy
+
+	seed := time.Now().UnixNano()
 	init := optstats.NewDamageAggBuffer(stats.simcfg)
-	optstats.RunWithConfigCustomStats(context.TODO(), stats.cfg, stats.simcfg, stats.gcsl, stats.simopt, time.Now(), optstats.OptimizerDmgStat, init.Add)
+	optstats.RunWithConfigCustomStats(context.TODO(), stats.cfg, stats.simcfg, stats.gcsl, stats.simopt, seed, optstats.OptimizerDmgStat, init.Add)
 	init.Flush()
 	// TODO: Test if median or mean gives better results
 	initialMean := mean(init.ExpectedDps)
@@ -97,7 +99,7 @@ func (stats *SubstatOptimizerDetails) calculateSubstatGradientsForChar(
 		stats.simcfg.Characters = stats.charProfilesCopy
 
 		a := optstats.NewDamageAggBuffer(stats.simcfg)
-		optstats.RunWithConfigCustomStats(context.TODO(), stats.cfg, stats.simcfg, stats.gcsl, stats.simopt, time.Now(), optstats.OptimizerDmgStat, a.Add)
+		optstats.RunWithConfigCustomStats(context.TODO(), stats.cfg, stats.simcfg, stats.gcsl, stats.simopt, seed, optstats.OptimizerDmgStat, a.Add)
 		a.Flush()
 
 		substatGradients[idxSubstat] = mean(a.ExpectedDps) - initialMean

--- a/pkg/optimization/opt_energy.go
+++ b/pkg/optimization/opt_energy.go
@@ -78,8 +78,9 @@ func (stats *SubstatOptimizerDetails) findOptimalERforChars() {
 	// characters start at minimum ER
 	stats.simcfg.Characters = stats.charProfilesERBaseline
 
+	seed := time.Now().UnixNano()
 	a := optstats.NewEnergyAggBuffer(stats.simcfg)
-	optstats.RunWithConfigCustomStats(context.TODO(), stats.cfg, stats.simcfg, stats.gcsl, stats.simopt, time.Now(), optstats.OptimizerERStat, a.Add)
+	optstats.RunWithConfigCustomStats(context.TODO(), stats.cfg, stats.simcfg, stats.gcsl, stats.simopt, seed, optstats.OptimizerERStat, a.Add)
 	a.Flush()
 	for idxChar := range stats.charProfilesERBaseline {
 		// erDiff is the amount of ER we need

--- a/pkg/optimization/optstats/simulator.go
+++ b/pkg/optimization/optstats/simulator.go
@@ -38,22 +38,17 @@ func RunWithConfigCustomStats[T any](ctx context.Context, cfg string, simcfg *in
 	pool := WorkerNewWithCustomStats(simcfg.Settings.NumberOfWorkers, respCh, errCh, customCh)
 	pool.StopCh = make(chan bool)
 
-	seeds := make([]int64, simcfg.Settings.Iterations)
-	src := rand.NewSource(seed)
-	for i := 0; i < simcfg.Settings.Iterations; i++ {
-		seeds[i] = src.Int63()
-	}
-
 	// spin off a go func that will queue jobs for as long as the total queued < iter
 	// this should block as queue gets full
 	go func() {
+		src := rand.NewSource(seed)
 		// make all the seeds
 		wip := 0
 		for wip < simcfg.Settings.Iterations {
 			pool.QueueCh <- JobCustomStats[T]{
 				Cfg:     simcfg.Copy(),
 				Actions: gcsl.Copy(),
-				Seed:    seeds[wip],
+				Seed:    src.Int63(),
 				Cstat:   cstat,
 			}
 			wip++


### PR DESCRIPTION
When calculating gradients, the seeds are all the same now for that one gradient. This reduces unstable and non-optimal results when optimizing sims with random delays.

Seeds are created by time.Now().UnixNanos()