### PR TITLE
add wasm build to Taskfile to be windows-compatible

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,4 +23,11 @@ tasks:
   pipeline:
     cmds:
       - go run pipeline/cmd/generate/main.go
-
+  wasm:
+    dir: cmd/wasm
+    cmds:
+      - go build -o '{{.OUT | default "main.wasm"}}' -ldflags="-X 'main.shareKey=${{if eq OS "windows"}}env:{{end}}GCSIM_SHARE_KEY'"
+      - echo "compiled wasm successfully!"
+    env:
+      GOOS: js 
+      GOARCH: wasm

--- a/ui/packages/executors/package.json
+++ b/ui/packages/executors/package.json
@@ -4,7 +4,7 @@
   "packageManager": "yarn@3.2.4",
   "private": true,
   "scripts": {
-    "build:wasm:web": "cd ../../../cmd/wasm && ./build.sh -o ../../ui/packages/web/public/main.wasm && echo \"compiled wasm successfully!\"",
+    "build:wasm:web": "task wasm OUT=../../ui/packages/web/public/main.wasm",
     "watch:web": "watch \"yarn run build:wasm:web\" ../../../pkg ../../../internal ../../../cmd/wasm"
   },
   "dependencies": {


### PR DESCRIPTION
closes #1687 
- use Taskfile in web for wasm build (requires Task to be installed on the machine)