### PR TITLE
added requirement to be building for wasm for wasm/main.go

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !codeanalysis && wasm
 
 package main
 

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis && wasm
+//go:build !codeanalysis && js && wasm
 
 package main
 


### PR DESCRIPTION
Otherwise gopls wouldn't do renaming since wasm/main,go would have import issues