### PR TITLE
gaming man chai bugfixes

### DIFF
--- a/internal/characters/gaming/burst.go
+++ b/internal/characters/gaming/burst.go
@@ -88,6 +88,10 @@ func (c *char) queueManChai() {
 	}
 	c.AddStatus(manChaiKey, c.manChaiWalkBack, false)
 	c.QueueCharTask(func() {
+		// can't link up if off-field
+		if c.Core.Player.Active() != c.Index {
+			return
+		}
 		c.ResetActionCooldown(action.ActionSkill)
 		c.DeleteStatus(manChaiKey)
 		c.c1()

--- a/internal/characters/gaming/burst.go
+++ b/internal/characters/gaming/burst.go
@@ -87,7 +87,7 @@ func (c *char) queueManChai() {
 		return
 	}
 	c.AddStatus(manChaiKey, c.manChaiWalkBack, false)
-	c.QueueCharTask(func() {
+	c.Core.Tasks.Add(func() {
 		// can't link up if off-field
 		if c.Core.Player.Active() != c.Index {
 			return

--- a/internal/characters/gaming/burst.go
+++ b/internal/characters/gaming/burst.go
@@ -35,6 +35,8 @@ func init() {
 func (c *char) Burst(p map[string]int) (action.Info, error) {
 	if p[manChaiParam] > 0 {
 		c.manChaiWalkBack = p[manChaiParam]
+	} else {
+		c.manChaiWalkBack = 100
 	}
 
 	c.Core.Tasks.Add(func() {

--- a/internal/characters/gaming/gaming.go
+++ b/internal/characters/gaming/gaming.go
@@ -26,7 +26,6 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ info.CharacterProfile) er
 	c.BurstCon = 5
 	c.SkillCon = 3
 	c.NormalHitNum = normalHitNum
-	c.manChaiWalkBack = 92 // default assumption
 
 	w.Character = &c
 

--- a/internal/characters/gaming/plunge.go
+++ b/internal/characters/gaming/plunge.go
@@ -189,6 +189,8 @@ func (c *char) plungeCollision(delay int) {
 func (c *char) specialPlunge(p map[string]int) (action.Info, error) {
 	if p[manChaiParam] > 0 {
 		c.manChaiWalkBack = p[manChaiParam]
+	} else {
+		c.manChaiWalkBack = 92
 	}
 
 	ai := combat.AttackInfo{

--- a/ui/packages/docs/src/components/Params/character_data.json
+++ b/ui/packages/docs/src/components/Params/character_data.json
@@ -434,17 +434,17 @@
     {
       "ability": "low_plunge",
       "param": "man_chai_delay",
-      "desc": "Number of frames until Man Chai returns starting from hitmark + 1 frame. Default delay is 92 frames."
+      "desc": "Number of frames until Man Chai returns starting from hitmark + 1 frame. Default delay for this case is 92 frames."
     },
     {
       "ability": "high_plunge",
       "param": "man_chai_delay",
-      "desc": "Number of frames until Man Chai returns starting from hitmark + 1 frame. Default delay is 92 frames."
+      "desc": "Number of frames until Man Chai returns starting from hitmark + 1 frame. Default delay for this case is 92 frames."
     },
     {
       "ability": "burst",
       "param": "man_chai_delay",
-      "desc": "Number of frames until Man Chai returns starting from hitmark + 1 frame. Default delay is 92 frames."
+      "desc": "Number of frames until Man Chai returns starting from hitmark + 1 frame. Default delay for this case is 100 frames."
     }
   ],
   "ganyu": [


### PR DESCRIPTION
- fix gaming man chai link up timing being affected by hitlag
- fix gaming man chai linking up off-field
- fix gaming man chai delay for burst specifically
  - 100f instead of the 92f for the plunge
  - the param value now doesn't persist after specifying once but instead needs to be supplied to every burst/plunge if it should be changed