### PR TITLE
Substatopt allsubtypes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,6 @@ Character PR checklist:
 - [ ] Particles
 - [ ] Frames
 - [ ] Update documentation
-- [ ] Update substat optimizer (charRelevantSubstats) if using hp% / def% as a significant scaling stat 
 - [ ] Xingqiu/Yelan N0 (optional)
 - [ ] Xianyun Plunge (optional)
 
@@ -104,7 +103,6 @@ Character PR checklist:
 - [ ] Particles
 - [ ] Frames
 - [ ] Update documentation
-- [ ] Update substat optimizer (charRelevantSubstats) if using hp% / def% as a significant scaling stat 
 - [ ] Xingqiu/Yelan N0 (optional)
 - [ ] Xianyun Plunge (optional)
 

--- a/pkg/optimization/details.go
+++ b/pkg/optimization/details.go
@@ -17,7 +17,6 @@ type Ordered interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64 | ~string
 }
 type SubstatOptimizerDetails struct {
-	charRelevantSubstats   map[keys.Char][]attributes.Stat
 	artifactSets4Star      []keys.Set
 	substatValues          []float64
 	mainstatValues         []float64
@@ -29,6 +28,7 @@ type SubstatOptimizerDetails struct {
 	charProfilesERBaseline []info.CharacterProfile
 	charProfilesCopy       []info.CharacterProfile
 	charMaxExtraERSubs     []float64
+	charRelevantSubstats   [][]attributes.Stat
 	simcfg                 *info.ActionList
 	gcsl                   ast.Node
 	simopt                 simulator.Options

--- a/pkg/optimization/logger.go
+++ b/pkg/optimization/logger.go
@@ -12,7 +12,6 @@ func newLogger(verbose bool) *zap.SugaredLogger {
 	zapcfg.EncoderConfig.CallerKey = ""
 	zapcfg.EncoderConfig.StacktraceKey = ""
 	zapcfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-
 	if verbose {
 		zapcfg.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
 	}

--- a/pkg/optimization/opt_allstats.go
+++ b/pkg/optimization/opt_allstats.go
@@ -38,12 +38,8 @@ func (stats *SubstatOptimizerDetails) optimizeERAndDMGSubstatsForChar(
 	var opDebug []string
 	opDebug = append(opDebug, fmt.Sprintf("%v", char.Base.Key))
 
-	relevantSubstats := stats.getNonErSubstatsToOptimizeForChar(char)
+	relevantSubstats := stats.charRelevantSubstats[idxChar]
 
-	addlSubstats := stats.charRelevantSubstats[char.Base.Key]
-	if len(addlSubstats) > 0 {
-		relevantSubstats = append(relevantSubstats, addlSubstats...)
-	}
 	totalSubs := stats.getCharSubstatTotal(idxChar)
 	if totalSubs != stats.totalLiquidSubstats {
 		opDebug = append(opDebug, fmt.Sprint("Character has", totalSubs, "total liquid subs allocated but expected", stats.totalLiquidSubstats))

--- a/pkg/optimization/opt_damage.go
+++ b/pkg/optimization/opt_damage.go
@@ -62,6 +62,7 @@ func (stats *SubstatOptimizerDetails) optimizeNonErSubstatsForChar(
 		stats.charProfilesCopy[idxChar].Stats[substat] += float64(stats.charSubstatLimits[idxChar][substat]-stats.charSubstatFinal[idxChar][substat]) * stats.substatValues[substat] * stats.charSubstatRarityMod[idxChar]
 		stats.charSubstatFinal[idxChar][substat] = stats.charSubstatLimits[idxChar][substat]
 	}
+	stats.optimizer.logger.Debug("Liquid Substat Counts: " + PrettyPrintStatsCounts(stats.charSubstatFinal[idxChar]))
 	totalSubs := stats.getCharSubstatTotal(idxChar)
 	stats.optimizer.logger.Debug(char.Base.Key.Pretty())
 	for totalSubs > stats.totalLiquidSubstats {

--- a/pkg/optimization/substats.go
+++ b/pkg/optimization/substats.go
@@ -175,26 +175,6 @@ func NewSubstatOptimizerDetails(
 	s.mainstatValues[attributes.HPP] = 0.466
 	s.mainstatValues[attributes.DEFP] = 0.583
 
-	// Only includes damage related substats scaling. Ignores things like HP for Barbara
-	s.charRelevantSubstats = map[keys.Char][]attributes.Stat{
-		keys.Albedo:      {attributes.DEFP},
-		keys.Hutao:       {attributes.HPP},
-		keys.Kokomi:      {attributes.HPP},
-		keys.Zhongli:     {attributes.HPP},
-		keys.Itto:        {attributes.DEFP},
-		keys.Yunjin:      {attributes.DEFP},
-		keys.Noelle:      {attributes.DEFP},
-		keys.Gorou:       {attributes.DEFP},
-		keys.Yelan:       {attributes.HPP},
-		keys.Candace:     {attributes.HPP},
-		keys.Nilou:       {attributes.HPP},
-		keys.Layla:       {attributes.HPP},
-		keys.Neuvillette: {attributes.HPP},
-		keys.Furina:      {attributes.HPP},
-		keys.Chevreuse:   {attributes.HPP},
-		keys.Chiori:      {attributes.DEFP},
-	}
-
 	// Final output array that holds [character][substat_count]
 	s.charSubstatFinal = make([][]int, len(simcfg.Characters))
 	for i := range simcfg.Characters {
@@ -211,6 +191,22 @@ func NewSubstatOptimizerDetails(
 	s.charProfilesERBaseline = make([]info.CharacterProfile, len(simcfg.Characters))
 	s.charProfilesCopy = make([]info.CharacterProfile, len(simcfg.Characters))
 	s.gcsl = gcsl
+
+	s.charRelevantSubstats = make([][]attributes.Stat, len(simcfg.Characters))
+	for i := range simcfg.Characters {
+		s.charRelevantSubstats[i] = []attributes.Stat{
+			attributes.HPP,
+			attributes.HP,
+			attributes.DEFP,
+			attributes.DEF,
+			attributes.ATKP,
+			attributes.ATK,
+			attributes.CR,
+			attributes.CD,
+			attributes.EM,
+			attributes.ER,
+		}
+	}
 
 	return &s
 }

--- a/pkg/optimization/substats.go
+++ b/pkg/optimization/substats.go
@@ -220,7 +220,7 @@ func (stats *SubstatOptimizerDetails) setStatLimits() bool {
 
 	for i := range stats.simcfg.Characters {
 		stats.charSubstatLimits[i] = make([]int, attributes.EndStatType)
-		for idxStat, stat := range stats.mainstatValues {
+		for idxStat, stat := range stats.substatValues {
 			if stat == 0 {
 				continue
 			}

--- a/pkg/optimization/utils.go
+++ b/pkg/optimization/utils.go
@@ -27,9 +27,12 @@ func (s Slice) Swap(i, j int) {
 }
 
 func newSlice(n ...float64) *Slice {
+	var nDup []float64
+	nDup = append(nDup, n...)
+
 	s := &Slice{
-		slice: sort.Float64Slice(n),
-		idx:   make([]int, len(n)),
+		slice: sort.Float64Slice(nDup),
+		idx:   make([]int, len(nDup)),
 	}
 	for i := range s.idx {
 		s.idx[i] = i


### PR DESCRIPTION
Made updates to allow all substats to be considered for each character. This fixes edge cases like Geo characters using Bennett C6 to vaporize, or Xianyun wanting Flat ATK in some configs, or healing characters needing to build HP for Clammage or Furina Fanfare. Additionally this means that new characters no longer need to update the substat optimizer when they scale beyond the traditional ATK/CR/CD/EM stats.

I ran the current live substat optimizer and the new proposed substat optimizer on my Windows 10 system with AMD Ryzen 7 5800HS with 40 GB of 3200 MHz DDR4 and recorded the results and timings. Time for the Control is the time the sim takes to run 1000 iterations. The Time for the substat optimizer is the time it takes to run the optimizer (`-substatOptim`).

The `LyneyFixed` config takes the above recommendation and modifies the `.lyney.burst.ready` condition to `.lyney.burst.ready && .lyney.energy == .lyney.energymax`
<table>
	<tbody>
		<tr>
			<td rowspan="2">Sim

</td>
			<td colspan="3">Control</td>
			<td colspan="2">New (All Sub Types)</td>
			<td colspan="2">Live</td>
		</tr>
		<tr>
			<td>Link</td>
			<td>DPS</td>
			<td>Time (s)</td>
			<td>DPS</td>
			<td>Time (s)</td>
			<td>DPS</td>
			<td>Time (s)</td>
		</tr>
		<tr>
			<td>95k hyperbloom
</td>
			<td> <a href="url"> https://gcsim.app/db/GQHGLq9kGzRB </a>
</td>
			<td>95037
</td>
			<td>1.811
</td>
			<td>95173
</td>
			<td>8.861
</td>
			<td>95172
</td>
			<td>8.871
</td>
		</tr>
		<tr>
			<td>APLBurstEveryRot
</td>
			<td> <a href="url"> https://gcsim.app/db/t6fqtRGTdWnj </a>
</td>
			<td>71999
</td>
			<td>5.857
</td>
			<td>71103
</td>
			<td>32.654
</td>
			<td>71294
</td>
			<td>33.108
</td>
		</tr>
		<tr>
			<td>LyneyFixed
</td>
			<td><a href="url"> https://gcsim.app/db/t9Ff8tm9fgdd </a>
</td>
			<td>86646
</td>
			<td>1.168
</td>
			<td>86300
</td>
			<td>3.516
</td>
			<td>86309
</td>
			<td>3.819</td>
		</tr>
		<tr>
			<td>RandomDelays
</td>
			<td><a href="url">https://gcsim.app/db/rmLgkH77cgrj</a>
</td>
			<td>79524
</td>
			<td>3.335
</td>
			<td>79646
</td>
			<td>9.506
</td>
			<td>79599
</td>
			<td>9.708
</td>
		</tr>
	</tbody>
</table>
