### PR TITLE
fix heizou burst behavior when nothing is absorbed

### DIFF
--- a/internal/characters/heizou/burst.go
+++ b/internal/characters/heizou/burst.go
@@ -123,6 +123,7 @@ func (c *char) irisDmg(t combat.Target) {
 			glog.LogCharacterEvent,
 			c.Index,
 		).Write("target", t.Key())
+		return
 	}
 
 	c.Core.QueueAttack(aiAbs, combat.NewCircleHitOnTarget(t, nil, 2.5), 0, 40) // if any of this is wrong blame Koli


### PR DESCRIPTION
- Windmuster Iris missing return when nothing is absorbed