### PR TITLE
Fix division, dummy enemy profile, travelerelectro c2

### DIFF
--- a/internal/characters/traveler/common/electro/burst.go
+++ b/internal/characters/traveler/common/electro/burst.go
@@ -130,7 +130,11 @@ func (c *Traveler) burstProc() {
 		//  dealt by the next Falling Thunder, which will deal 200% of its original DMG and will restore
 		//  an additional 1 Energy to the current character.
 		c.c6Damage(&atk)
-		atk.Callbacks = append(atk.Callbacks, c.fallingThunderEnergy(), c.c2(), c.c6Energy())
+		for _, cb := range []combat.AttackCBFunc{c.fallingThunderEnergy(), c.c2(), c.c6Energy()} {
+			if cb != nil {
+				atk.Callbacks = append(atk.Callbacks, cb)
+			}
+		}
 
 		c.Core.QueueAttackEvent(&atk, 1)
 

--- a/pkg/enemy/types.go
+++ b/pkg/enemy/types.go
@@ -22,10 +22,11 @@ func ConfigureTarget(profile *info.EnemyProfile, name string, params TargetParam
 		profile.Modified = true
 		profile.ParticleDropThreshold = 0
 		profile.ParticleDropCount = 0
-		profile.ParticleElement = 0
+		profile.ParticleElement = attributes.NoElement
 		profile.ParticleDrops = nil
 		profile.HP = 562949953421311
-		for elem := attributes.Electro; elem <= attributes.Physical; elem++ {
+		res := []attributes.Element{attributes.Electro, attributes.Cryo, attributes.Hydro, attributes.Physical, attributes.Pyro, attributes.Geo, attributes.Dendro, attributes.Anemo}
+		for _, elem := range res {
 			profile.Resist[elem] = 0.1
 		}
 		return nil

--- a/pkg/gcs/expr.go
+++ b/pkg/gcs/expr.go
@@ -173,6 +173,9 @@ func (e *Eval) evalBinaryExpr(b *ast.BinaryExpr, env *Env) (Obj, error) {
 	case ast.ItemAsterisk:
 		return mul(l, r), nil
 	case ast.ItemForwardSlash:
+		if !r.isFloat && r.ival == 0 {
+			return nil, fmt.Errorf("division by zero")
+		}
 		return div(l, r), nil
 	case ast.OpGreaterThan:
 		return gt(l, r), nil

--- a/pkg/gcs/op.go
+++ b/pkg/gcs/op.go
@@ -87,11 +87,15 @@ func mul(l, r *number) *number {
 }
 
 func div(l, r *number) *number {
-	return &number{
-		ival:    l.ival / r.ival,
-		fval:    l.fval / r.fval,
+	n := &number{
 		isFloat: l.isFloat || r.isFloat,
 	}
+	if n.isFloat {
+		n.fval = ntof(l) / ntof(r)
+	} else {
+		n.ival = l.ival / r.ival
+	}
+	return n
 }
 
 func sub(l, r *number) *number {


### PR DESCRIPTION
* Resolves #2139
* Fix dummy enemy profile (defaults to clear particles. used to be electro)
* Fix travelerelectro c2 causing a panic when disabled