### PR TITLE
Clam and SoDP use total healing before BoL reduction.

### DIFF
--- a/internal/artifacts/oceanhuedclam/oceanhuedclam.go
+++ b/internal/artifacts/oceanhuedclam/oceanhuedclam.go
@@ -67,7 +67,7 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 		// On Heal subscription to start accumulating the healing
 		c.Events.Subscribe(event.OnHeal, func(args ...interface{}) bool {
 			src := args[0].(*info.HealInfo)
-			healAmt := args[2].(float64)
+			healAmt := args[4].(float64)
 
 			if src.Caller != char.Index {
 				return false

--- a/internal/artifacts/songofdayspast/songofdayspast.go
+++ b/internal/artifacts/songofdayspast/songofdayspast.go
@@ -64,7 +64,7 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 func (s *Set) OnHeal() func(args ...interface{}) bool {
 	return func(args ...interface{}) bool {
 		src := args[0].(*info.HealInfo)
-		healAmt := args[2].(float64)
+		healAmt := args[4].(float64)
 		if src.Caller != s.char.Index {
 			return false
 		}

--- a/pkg/core/event/event.go
+++ b/pkg/core/event/event.go
@@ -55,7 +55,7 @@ const (
 	OnCharacterHit     // nil <- this is for when the character is going to get hit but might be shielded from dmg
 	OnCharacterHurt    // amount
 	OnHPDebt           // target character, amount
-	OnHeal             // src char, target character, amount, overheal, debt_cleared
+	OnHeal             // src char, target character, amount, overheal, amount_before_debt
 	OnPlayerPreHPDrain // Draininfo to modify
 	OnPlayerHPDrain    // DrainInfo
 	// ability use


### PR DESCRIPTION
Closes https://github.com/genshinsim/gcsim/issues/2160 