### PR TITLE
fix echoes icd bug

### DIFF
--- a/internal/artifacts/echoes/echoes.go
+++ b/internal/artifacts/echoes/echoes.go
@@ -98,9 +98,11 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 		}
 
 		if c.Rand.Float64() > s.prob {
+			s.icd = c.F + 12 // 0.2s
 			s.prob += 0.2
 			c.Log.NewEvent("echoes 4pc failed to proc due to chance", glog.LogArtifactEvent, char.Index).
-				Write("probabability_now", s.prob)
+				Write("probabability_now", s.prob).
+				Write("icd_up", s.icd)
 			return false
 		}
 

--- a/internal/artifacts/echoes/echoes.go
+++ b/internal/artifacts/echoes/echoes.go
@@ -101,7 +101,7 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 			s.icd = c.F + 12 // 0.2s
 			s.prob += 0.2
 			c.Log.NewEvent("echoes 4pc failed to proc due to chance", glog.LogArtifactEvent, char.Index).
-				Write("probabability_now", s.prob).
+				Write("probability_now", s.prob).
 				Write("icd_up", s.icd)
 			return false
 		}


### PR DESCRIPTION
Add icd check when the Valley Rite fails to be triggered.

Fix #2165.