### PR TITLE
Fix BOL event emitting even if HPdebt didn't change

### DIFF
--- a/internal/template/character/hp.go
+++ b/internal/template/character/hp.go
@@ -45,9 +45,9 @@ func (c *Character) ModifyHPDebtByAmount(amt float64) {
 	if amt == 0 {
 		return
 	}
-	newHPDebt := c.currentHPDebt + amt
-	c.setHPDebtByAmount(newHPDebt)
-	c.Core.Events.Emit(event.OnHPDebt, c.Index, amt)
+	prevHPDebt := c.currentHPDebt
+	c.setHPDebtByAmount(c.currentHPDebt + amt)
+	c.Core.Events.Emit(event.OnHPDebt, c.Index, prevHPDebt-c.currentHPDebt)
 }
 
 func (c *Character) ModifyHPDebtByRatio(r float64) {


### PR DESCRIPTION
The current implementation emits a negative value when HPDebt=0 and amt is negative. However, in this case, the HPDebt didn't change, so the event should emit 0 HPDebt change