### PR TITLE
add max hp debt

### DIFF
--- a/internal/template/character/hp.go
+++ b/internal/template/character/hp.go
@@ -33,6 +33,8 @@ func (c *Character) ModifyHPByRatio(r float64) {
 func (c *Character) clampHPDebt() {
 	if c.currentHPDebt < 0 {
 		c.currentHPDebt = 0
+	} else if c.currentHPDebt > c.MaxHP()*2 {
+		c.currentHPDebt = c.MaxHP() * 2
 	}
 }
 


### PR DESCRIPTION
The max value of Bond of Life is 200% of a character's Max HP
![image](https://github.com/genshinsim/gcsim/assets/39216134/f3a31427-bf93-4f4f-a340-592a44e29c7e)
