### PR TITLE
Update reaction multipliers

### DIFF
--- a/pkg/reactable/electrocharged.go
+++ b/pkg/reactable/electrocharged.go
@@ -65,7 +65,7 @@ func (r *Reactable) TryAddEC(a *combat.AttackEvent) bool {
 	char := r.core.Player.ByIndex(a.Info.ActorIndex)
 	em := char.Stat(attributes.EM)
 	flatdmg, snap := calcReactionDmg(char, atk, em)
-	atk.FlatDmg = 1.2 * flatdmg
+	atk.FlatDmg = 2.0 * flatdmg
 	r.ecAtk = atk
 	r.ecSnapshot = snap
 

--- a/pkg/reactable/freeze.go
+++ b/pkg/reactable/freeze.go
@@ -87,7 +87,7 @@ func (r *Reactable) ShatterCheck(a *combat.AttackEvent) bool {
 		char := r.core.Player.ByIndex(a.Info.ActorIndex)
 		em := char.Stat(attributes.EM)
 		flatdmg, snap := calcReactionDmg(char, ai, em)
-		ai.FlatDmg = 1.5 * flatdmg
+		ai.FlatDmg = 3.0 * flatdmg
 		// shatter is a self attack
 		r.core.QueueAttackWithSnap(
 			ai,

--- a/pkg/reactable/overload.go
+++ b/pkg/reactable/overload.go
@@ -58,7 +58,7 @@ func (r *Reactable) TryOverload(a *combat.AttackEvent) bool {
 		char := r.core.Player.ByIndex(a.Info.ActorIndex)
 		em := char.Stat(attributes.EM)
 		flatdmg, snap := calcReactionDmg(char, atk, em)
-		atk.FlatDmg = 2 * flatdmg
+		atk.FlatDmg = 2.75 * flatdmg
 		r.core.QueueAttackWithSnap(atk, snap, combat.NewCircleHitOnTarget(r.self, nil, 3), 1)
 	}
 

--- a/pkg/reactable/superconduct.go
+++ b/pkg/reactable/superconduct.go
@@ -90,6 +90,6 @@ func (r *Reactable) queueSuperconduct(a *combat.AttackEvent) {
 	char := r.core.Player.ByIndex(a.Info.ActorIndex)
 	em := char.Stat(attributes.EM)
 	flatdmg, snap := calcReactionDmg(char, atk, em)
-	atk.FlatDmg = 0.5 * flatdmg
+	atk.FlatDmg = 1.5 * flatdmg
 	r.core.QueueAttackWithSnap(atk, snap, combat.NewCircleHitOnTarget(r.self, nil, 3), 1)
 }


### PR DESCRIPTION
- Superconduct: 0.5 → 1.5
- Shatter: 1.5 → 3
- Electro-Charged: 1.2 → 2
- Overload: 2 → 2.75

These changes apply to both characters and enemies
Reference: Bloom 2 | Burgeon 3 | Hyperbloom 3

