### PR TITLE
Add separated substats from import

### DIFF
--- a/ui/packages/ui/src/Pages/Simulator/helper.ts
+++ b/ui/packages/ui/src/Pages/Simulator/helper.ts
@@ -1,32 +1,32 @@
-import { Character } from "@gcsim/types";
+import {Character} from '@gcsim/types';
 
 const statKeys = [
-  "n/a",
-  "def%",
-  "def",
-  "hp",
-  "hp%",
-  "atk",
-  "atk%",
-  "er",
-  "em",
-  "cr",
-  "cd",
-  "heal",
-  "pyro%",
-  "hydro%",
-  "cryo%",
-  "electro%",
-  "anemo%",
-  "geo%",
-  "dendro%",
-  "phys%",
-  "atkspd%",
-  "dmg%",
+  'n/a',
+  'def%',
+  'def',
+  'hp',
+  'hp%',
+  'atk',
+  'atk%',
+  'er',
+  'em',
+  'cr',
+  'cd',
+  'heal',
+  'pyro%',
+  'hydro%',
+  'cryo%',
+  'electro%',
+  'anemo%',
+  'geo%',
+  'dendro%',
+  'phys%',
+  'atkspd%',
+  'dmg%',
 ];
 
 export function charToCfg(char: Character): string {
-  let str = "";
+  let str = '';
   // prettier-ignore
   str += `${char.name} char lvl=${char.level}/${char.max_level} cons=${char.cons} talent=${char.talents.attack},${char.talents.skill},${char.talents.burst};\n`;
   // prettier-ignore
@@ -42,12 +42,24 @@ export function charToCfg(char: Character): string {
   //add stats
   let count = 0;
   let statStr = `${char.name} add stats`;
-  char.stats.forEach((v, i) => {
-    if (v === 0) return;
+  char.stats.forEach(([index, value], i) => {
+    if (value === 0) return;
     count++;
-    statStr += ` ${statKeys[i]}=${v.toPrecision()}`;
+    statStr += ` ${statKeys[index]}=${value.toPrecision()}`;
+
+    // Add ";\n" after main stats, then "\n" after every artifact piece substats
+    if (i === 4) {
+      str += statStr + '; # main stats\n';
+      statStr = `${char.name} add stats`;
+    } else if ((count - 5) % 4 === 0 && i > 4) {
+      str += statStr + ';\n';
+      statStr = `${char.name} add stats`;
+    }
   });
-  if (count > 0) {
+
+  // \n delimiting is under assumption that each artifact has 4 subs.
+  // If that's not the case, add to the end.
+  if (count > 0 && (count - 5) % 4 !== 0) {
     str += statStr + `;\n`;
   }
 


### PR DESCRIPTION
- Description: add feature so that artifact substats that are imported from Enka are written to the config as separate lines.

- The Demand: I think this feature is extremely needed for those who use gcsim to analyze their builds (speaking from my experience doing team reviews on-stream using gcsim). Otherwise, if you want to slightly change the build, you'll always need to use calculator to add and subtract main/sub stats, which is frustrating. Initially, I thought to implement the UI feature, where you can adjust artifact main and sub stats using UI, but, hey, it will take forever and we need to start with something.

- Concerns: I am not familiar with TypeScript. I'm neither looked at the whole front-end code nor Idk how to debug it, so what I'm providing is just a sketch (which I'm not sure if working). I need someone to help me check whether it works and how to fix it/rework it to the acceptable condition. Also, I'm not sure if this concrete change will affect GO import. So, I'm marking this PR as a draft.