### PR TITLE
Add timed Nightsoul Blessing

### DIFF
--- a/internal/characters/kinich/burst.go
+++ b/internal/characters/kinich/burst.go
@@ -2,6 +2,7 @@ package kinich
 
 import (
 	"github.com/genshinsim/gcsim/internal/frames"
+	"github.com/genshinsim/gcsim/internal/template/nightsoul"
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
@@ -33,8 +34,10 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	c.AddStatus(burstKey, ajawDuration, false)
 	if c.nightsoulState.HasBlessing() {
 		// extend Nightsoul's Blessing time limit countdown
-		duration := (c.exitStateF - c.Core.F) + 1.7*60
-		c.setNightsoulExitTimer(duration)
+		duration := c.StatusDuration(nightsoul.NightsoulBlessingStatus)
+		if duration > 0 {
+			c.nightsoulState.SetNightsoulExitTimer(duration+1.7*60, c.cancelNightsoul)
+		}
 	}
 
 	ai := combat.AttackInfo{

--- a/internal/characters/kinich/burst.go
+++ b/internal/characters/kinich/burst.go
@@ -2,7 +2,6 @@ package kinich
 
 import (
 	"github.com/genshinsim/gcsim/internal/frames"
-	"github.com/genshinsim/gcsim/internal/template/nightsoul"
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
@@ -34,7 +33,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	c.AddStatus(burstKey, ajawDuration, false)
 	if c.nightsoulState.HasBlessing() {
 		// extend Nightsoul's Blessing time limit countdown
-		duration := c.StatusDuration(nightsoul.NightsoulBlessingStatus)
+		duration := c.nightsoulState.Duration()
 		if duration > 0 {
 			c.nightsoulState.SetNightsoulExitTimer(duration+1.7*60, c.cancelNightsoul)
 		}

--- a/internal/characters/kinich/kinich.go
+++ b/internal/characters/kinich/kinich.go
@@ -23,7 +23,6 @@ type char struct {
 	*tmpl.Character
 	nightsoulState           *nightsoul.State
 	nightsoulSrc             int
-	exitStateF               int
 	ajawSrc                  int
 	normalSCounter           int
 	characterAngularPosition float64 // [0, 360)

--- a/internal/characters/kinich/skill.go
+++ b/internal/characters/kinich/skill.go
@@ -70,8 +70,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	c.Core.Tasks.Add(func() {
 		src := c.Core.F
 		c.nightsoulSrc = src
-		c.nightsoulState.EnterBlessing(0.)
-		c.setNightsoulExitTimer(10*60 + 10)
+		c.nightsoulState.EnterTimedBlessing(0., 10*60+10, c.cancelNightsoul)
 		c.c2AoeIncreased = false
 		c.particlesGenerated = false
 		c.SetCD(action.ActionSkill, skillCD)
@@ -182,18 +181,6 @@ func (c *char) cancelNightsoul() {
 	c.nightsoulState.ExitBlessing()
 	c.nightsoulSrc = -1
 	c.blindSpotAngularPosition = -1
-	c.exitStateF = -1
-}
-
-func (c *char) setNightsoulExitTimer(duration int) {
-	src := c.Core.F + duration
-	c.exitStateF = src
-	c.QueueCharTask(func() {
-		if c.exitStateF != src {
-			return
-		}
-		c.cancelNightsoul()
-	}, duration)
 }
 
 func (c *char) particleCB(a combat.AttackCB) {

--- a/internal/characters/xilonen/cons.go
+++ b/internal/characters/xilonen/cons.go
@@ -184,8 +184,8 @@ func (c *char) applyC6() {
 	c.c6FlatDmg() // sets c6 key
 
 	// "pause" Nightsoul's Blessing time limit countdown
-	duration := c.StatusDuration(skillMaxDurKey) + c6Duration
-	c.setNightsoulExitTimer(duration)
+	duration := c.nightsoulState.Duration() + c6Duration
+	c.nightsoulState.SetNightsoulExitTimer(duration, c.exitNightsoul)
 
 	for i := 1; i <= 3; i++ {
 		c.Core.Tasks.Add(func() {

--- a/internal/characters/xilonen/xilonen.go
+++ b/internal/characters/xilonen/xilonen.go
@@ -45,6 +45,8 @@ func NewChar(s *core.Core, w *character.CharWrapper, _ info.CharacterProfile) er
 
 	w.Character = &c
 	c.nightsoulState.MaxPoints = 90
+	extendNsOnStates := []action.AnimationState{action.NormalAttackState, action.PlungeAttackState}
+	c.nightsoulState.SetExtendNsStates(extendNsOnStates)
 
 	return nil
 }

--- a/internal/template/nightsoul/nightsoul.go
+++ b/internal/template/nightsoul/nightsoul.go
@@ -15,8 +15,8 @@ type State struct {
 	char            *character.CharWrapper
 	c               *core.Core
 	nightsoulPoints float64
-
-	MaxPoints float64
+	ExitStateF      int
+	MaxPoints       float64
 }
 
 func New(c *core.Core, char *character.CharWrapper) *State {
@@ -28,14 +28,45 @@ func New(c *core.Core, char *character.CharWrapper) *State {
 	return t
 }
 
-func (s *State) EnterBlessing(amount float64) {
+// Change the current duration of the NS status if applicable, and apply cb on expiry.
+// If NS is not currently active, do nothing.
+func (s *State) SetNightsoulExitTimer(duration int, cb func()) {
+	if !s.char.StatusIsActive(NightsoulBlessingStatus) {
+		return
+	}
+
+	s.char.AddStatus(NightsoulBlessingStatus, duration, true)
+	src := s.c.F + duration
+	s.ExitStateF = src
+	s.char.QueueCharTask(func() {
+		if s.ExitStateF != src {
+			return
+		}
+		cb()
+	}, duration)
+}
+
+// Enters NS blessing with specified points.
+// If duration is not infinite, expire NS upon duration and optionally trigger a CB.
+// CB will not be called if the duration is changed before expiry.
+func (s *State) EnterTimedBlessing(amount float64, duration int, cb func()) {
 	s.nightsoulPoints = amount
-	s.char.AddStatus(NightsoulBlessingStatus, -1, true)
+	s.char.AddStatus(NightsoulBlessingStatus, duration, true)
+
+	if duration > 0 && cb != nil {
+		s.SetNightsoulExitTimer(duration, cb)
+	}
 	s.c.Log.NewEvent("enter nightsoul blessing", glog.LogCharacterEvent, s.char.Index).
-		Write("points", s.nightsoulPoints)
+		Write("points", s.nightsoulPoints).
+		Write("duration", duration)
+}
+
+func (s *State) EnterBlessing(amount float64) {
+	s.EnterTimedBlessing(amount, -1, nil)
 }
 
 func (s *State) ExitBlessing() {
+	s.ExitStateF = 0
 	s.char.DeleteStatus(NightsoulBlessingStatus)
 	s.c.Log.NewEvent("exit nightsoul blessing", glog.LogCharacterEvent, s.char.Index)
 }

--- a/internal/template/nightsoul/nightsoul.go
+++ b/internal/template/nightsoul/nightsoul.go
@@ -67,6 +67,12 @@ func (s *State) SetNightsoulExitTimer(duration int, cb func()) {
 			return
 		}
 
+		// When the char is off-field, state cannot be extended by animation
+		if !s.c.Player.CharIsActive(s.char.Base.Key) {
+			cb()
+			return
+		}
+
 		// If NS shouldn't expire because the player is in the state; delay expiry until state ends
 		evtKey := fmt.Sprintf("%v-%v", delayEventKey, s.char.Base.Key.String())
 		f := func(...interface{}) bool {

--- a/internal/template/nightsoul/nightsoul.go
+++ b/internal/template/nightsoul/nightsoul.go
@@ -47,7 +47,7 @@ func (s *State) Duration() int {
 // If NS is not currently active, do nothing.
 // The callback will not be called if ExitNightsoul() is used
 func (s *State) SetNightsoulExitTimer(duration int, cb func()) {
-	if !s.char.StatusIsActive(NightsoulBlessingStatus) {
+	if !s.HasBlessing() {
 		return
 	}
 
@@ -171,6 +171,8 @@ func (s *State) Condition(fields []string) (any, error) {
 		return s.HasBlessing(), nil
 	case "points":
 		return s.Points(), nil
+	case "duration":
+		return s.Duration(), nil
 	default:
 		return nil, fmt.Errorf("invalid nightsoul condition: %v", fields[1])
 	}

--- a/internal/template/nightsoul/nightsoul.go
+++ b/internal/template/nightsoul/nightsoul.go
@@ -28,6 +28,10 @@ func New(c *core.Core, char *character.CharWrapper) *State {
 	return t
 }
 
+func (s *State) Duration() int {
+	return s.char.StatusDuration(NightsoulBlessingStatus)
+}
+
 // Change the current duration of the NS status if applicable, and apply cb on expiry.
 // If NS is not currently active, do nothing.
 func (s *State) SetNightsoulExitTimer(duration int, cb func()) {

--- a/ui/packages/docs/docs/reference/fields.md
+++ b/ui/packages/docs/docs/reference/fields.md
@@ -54,3 +54,4 @@ For example, if you are looking for the tag for Lisa's A4 (defense shred), then 
 | character name | `skill`/`burst`/`attack`/`charge`/`high_plunge`/`low_plunge`/`aim`/`dash`/`jump`/`swap`/`walk`/`wait` | `cd`/`charge`/`ready` | - | Evaluates to the following things for the specified action of the character: remaining cooldown / remaining charges (example: Sucrose Skill) / `1` if the action is ready, `0` otherwise. |
 | character name | `nightsoul` | `state` | - | `1` if the character is in Nightsoul's Blessing state, `0` otherwise. |
 | character name | `nightsoul` | `point` | - | Evaluates to the character's Nightsoul points. |
+| character name | `nightsoul` | `duration` | - | Evaluates to the duration of the character's Nightsoul Blessing state. |


### PR DESCRIPTION
Add functions to Nightsoul module to allow setting up NS with an optional cb for when NS status ends. This CB will only be called if NS expires via the timer, not if NS is manually expired, and is intended to clean up the character state on Nightsoul expiry. As an alternative, an OnNightsoulExpiry event could be used, or an array of cb functions could be allowed.

Kinich refactored to make use of this functionality.

GCSL users can get remaining NS duration through .<character>.status.nightsoul-blessing.

For now, it's assumed that all NS timers will be hitlag extended. If that is not the case, code can be further refactored to accept a hitlag bool, to be passed through to the char.AddStatus method call.

I manually tested a few Kinich configs and got matching results, but I have not run a full DB compare.
If desired, I can split this PR into two; one for NS changes and one for Kinich changes.