### PR TITLE
Add Ororon high jump and high_plunge.

### DIFF
--- a/internal/artifacts/obsidiancodex/obsidiancodex.go
+++ b/internal/artifacts/obsidiancodex/obsidiancodex.go
@@ -36,7 +36,8 @@ func NewSet(c *core.Core, char *character.CharWrapper, count int, param map[stri
 		char.AddStatMod(character.StatMod{
 			Base: modifier.NewBase("obsidiancodex-2pc", -1),
 			Amount: func() ([]float64, bool) {
-				if !char.StatusIsActive(nightsoul.NightsoulBlessingStatus) {
+				if !(char.StatusIsActive(nightsoul.NightsoulBlessingStatus) ||
+					char.StatusIsActive(nightsoul.NightsoulTransmissionStatus)) {
 					return nil, false
 				}
 				if c.Player.Active() != char.Index {

--- a/internal/artifacts/scrolloftheheroofcindercity/scrolloftheheroofcindercity.go
+++ b/internal/artifacts/scrolloftheheroofcindercity/scrolloftheheroofcindercity.go
@@ -74,7 +74,8 @@ func (s *Set) buffCB(react reactions.ReactionType, gadgetEmit bool) func(args ..
 			return false
 		}
 
-		hasNightsoul := s.char.StatusIsActive(nightsoul.NightsoulBlessingStatus)
+		hasNightsoul := s.char.StatusIsActive(nightsoul.NightsoulBlessingStatus) ||
+			s.char.StatusIsActive(nightsoul.NightsoulTransmissionStatus)
 		for _, other := range s.c.Player.Chars() {
 			elements := reactToElements[react]
 			for _, ele := range elements {

--- a/internal/characters/ororon/config.yml
+++ b/internal/characters/ororon/config.yml
@@ -10,6 +10,10 @@ action_param_keys:
     - param: "weakspot"
   skill:
     - param: "travel"
+  jump:
+    - param: "hold"
+  high_plunge:
+    - param: "fall"
 skill_data_mapping:
   attack:
     aim:

--- a/internal/characters/ororon/jump.go
+++ b/internal/characters/ororon/jump.go
@@ -55,6 +55,7 @@ func (c *char) highJump(hold int) (action.Info, error) {
 		}
 
 		fallParam := map[string]int{"fall": 1}
+		// Ideally this would inject the action into the queue of actions to take from the config file, rather than calling exec directly
 		c.Core.Player.Exec(action.ActionHighPlunge, c.Base.Key, fallParam)
 	}
 	// TODO: Is this hitlag extended? Does this skip if the action is canceled?

--- a/internal/characters/ororon/jump.go
+++ b/internal/characters/ororon/jump.go
@@ -1,7 +1,12 @@
 package ororon
 
 import (
+	"fmt"
+
+	"github.com/genshinsim/gcsim/internal/frames"
 	"github.com/genshinsim/gcsim/pkg/core/action"
+	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player"
 )
 
@@ -11,17 +16,47 @@ const jumpNsStatusTag = "Ororon-Status-NS-Jump"
 // Set a CB to cancel high jump if max duration exceeded.
 // Grant airborne status.
 // Consume stamina.
+// Hold defines when fall action will automatically be called.
 func (c *char) highJump(hold int) (action.Info, error) {
-	if hold > maxJumpFrames-minCancelFrames {
+	if (hold > maxJumpFrames-minCancelFrames) || (hold < 0) {
 		hold = maxJumpFrames - minCancelFrames
 	}
+
+	// If player runs out of stamina, delay fall. Still allow high_plunge.
+	minFallFramesAdjust := 0
+	if c.Core.Player.Stam <= jumpStamDrainAmt {
+		minFallFramesAdjust = jumpNoStamFallDelayFrames
+		c.Core.Log.NewEvent(fmt.Sprintf("High jump has consumed all stamina. Earliest fall will be delayed by %d frames.", minFallFramesAdjust), glog.LogCooldownEvent, c.Index)
+	}
+	// Earliest user can trigger fall from GCSL
+	c.allowFallFrame = c.Core.F + minCancelFrames + minFallFramesAdjust
+
+	if hold < minFallFramesAdjust {
+		hold = minFallFramesAdjust
+	}
+
 	jumpDur := minCancelFrames + hold
 	c.jmpSrc = c.Core.F
 	src := c.jmpSrc
 	c.Core.Player.SetAirborne(player.AirborneOroron)
 
 	c.QueueCharTask(func() { c.AddStatus(jumpNsStatusTag, jumpNsDuration, true) }, jumpNsDelay)
-	c.QueueCharTask(func() { c.Core.Player.Stam -= jumpStamDrainAmt }, jumpStamDrainDelay)
+
+	jumpStamDrainCb := func() {
+		h := c.Core.Player
+		h.Stam -= jumpStamDrainAmt
+		// While in high jump, ororon cannot start resuming stamina regen until after landing.
+		h.LastStamUse = *h.F + jumpDur + fallFrames - player.StamCDFrames
+		h.Events.Emit(event.OnStamUse, action.ActionJump)
+	}
+	c.QueueCharTask(jumpStamDrainCb, jumpStamDrainDelay)
+
+	act := action.Info{
+		Frames:          frames.NewAbilFunc(jumpHoldFrames[0]),
+		AnimationLength: jumpDur + fallFrames,
+		CanQueueAfter:   minCancelFrames, // earliest cancel
+		State:           action.JumpState,
+	}
 
 	// Trigger a fall after max jump duration
 	fallCb := func() {
@@ -32,23 +67,16 @@ func (c *char) highJump(hold int) (action.Info, error) {
 		fallParam := map[string]int{"fall": 1}
 		c.Core.Player.Exec(action.ActionHighPlunge, c.Base.Key, fallParam)
 	}
-	c.QueueCharTask(fallCb, jumpDur)
-
-	act := action.Info{
-		Frames: func(a action.Action) int {
-			return jumpHoldFrames[0][a]
-		},
-		AnimationLength: maxJumpFrames + fallFrames,
-		CanQueueAfter:   jumpHoldFrames[0][action.ActionHighPlunge], // earliest cancel
-		State:           action.JumpState,
-	}
+	// TODO: Is this hitlag extended? Does this skip if the action is canceled?
+	act.QueueAction(fallCb, jumpDur)
+	// c.QueueCharTask(fallCb, jumpDur)
 	return act, nil
 }
 
 // TODO: How does it work if xinyuan airborne buff is active and hold jump is used?
 func (c *char) Jump(p map[string]int) (action.Info, error) {
 	hold := p["hold"]
-	if hold <= 0 {
+	if hold == 0 {
 		return c.Character.Jump(p)
 	} else {
 		return c.highJump(hold - 1)

--- a/internal/characters/ororon/jump.go
+++ b/internal/characters/ororon/jump.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/genshinsim/gcsim/internal/frames"
+	"github.com/genshinsim/gcsim/internal/template/nightsoul"
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player"
 )
 
-const jumpNsStatusTag = "Ororon-Status-NS-Jump"
+const jumpNsStatusTag = nightsoul.NightsoulTransmissionStatus
 
 // Add NS status.
 // Set a CB to cancel high jump if max duration exceeded.
@@ -40,6 +41,8 @@ func (c *char) highJump(hold int) (action.Info, error) {
 	src := c.jmpSrc
 	c.Core.Player.SetAirborne(player.AirborneOroron)
 
+	// Jump cannot be cancelled before NS status is added, so no need to check src here.
+	jumpNsDuration := jumpDur - jumpNsDelay
 	c.QueueCharTask(func() { c.AddStatus(jumpNsStatusTag, jumpNsDuration, true) }, jumpNsDelay)
 
 	jumpStamDrainCb := func() {

--- a/internal/characters/ororon/jump.go
+++ b/internal/characters/ororon/jump.go
@@ -1,0 +1,56 @@
+package ororon
+
+import (
+	"github.com/genshinsim/gcsim/pkg/core/action"
+	"github.com/genshinsim/gcsim/pkg/core/player"
+)
+
+const jumpNsStatusTag = "Ororon-Status-NS-Jump"
+
+// Add NS status.
+// Set a CB to cancel high jump if max duration exceeded.
+// Grant airborne status.
+// Consume stamina.
+func (c *char) highJump(hold int) (action.Info, error) {
+	if hold > maxJumpFrames-minCancelFrames {
+		hold = maxJumpFrames - minCancelFrames
+	}
+	jumpDur := minCancelFrames + hold
+	c.jmpSrc = c.Core.F
+	src := c.jmpSrc
+	c.Core.Player.SetAirborne(player.AirborneOroron)
+
+	c.QueueCharTask(func() { c.AddStatus(jumpNsStatusTag, jumpNsDuration, true) }, jumpNsDelay)
+	c.QueueCharTask(func() { c.Core.Player.Stam -= jumpStamDrainAmt }, jumpStamDrainDelay)
+
+	// Trigger a fall after max jump duration
+	fallCb := func() {
+		if src != c.jmpSrc {
+			return
+		}
+
+		fallParam := map[string]int{"fall": 1}
+		c.Core.Player.Exec(action.ActionHighPlunge, c.Base.Key, fallParam)
+	}
+	c.QueueCharTask(fallCb, jumpDur)
+
+	act := action.Info{
+		Frames: func(a action.Action) int {
+			return jumpHoldFrames[0][a]
+		},
+		AnimationLength: maxJumpFrames + fallFrames,
+		CanQueueAfter:   jumpHoldFrames[0][action.ActionHighPlunge], // earliest cancel
+		State:           action.JumpState,
+	}
+	return act, nil
+}
+
+// TODO: How does it work if xinyuan airborne buff is active and hold jump is used?
+func (c *char) Jump(p map[string]int) (action.Info, error) {
+	hold := p["hold"]
+	if hold <= 0 {
+		return c.Character.Jump(p)
+	} else {
+		return c.highJump(hold - 1)
+	}
+}

--- a/internal/characters/ororon/jump.go
+++ b/internal/characters/ororon/jump.go
@@ -45,6 +45,9 @@ func (c *char) highJump(hold int) (action.Info, error) {
 	jumpStamDrainCb := func() {
 		h := c.Core.Player
 		h.Stam -= jumpStamDrainAmt
+		if h.Stam < 0 {
+			h.Stam = 0
+		}
 		// While in high jump, ororon cannot start resuming stamina regen until after landing.
 		h.LastStamUse = *h.F + jumpDur + fallFrames - player.StamCDFrames
 		h.Events.Emit(event.OnStamUse, action.ActionJump)

--- a/internal/characters/ororon/jump.go
+++ b/internal/characters/ororon/jump.go
@@ -1,13 +1,10 @@
 package ororon
 
 import (
-	"fmt"
-
 	"github.com/genshinsim/gcsim/internal/frames"
 	"github.com/genshinsim/gcsim/internal/template/nightsoul"
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/event"
-	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player"
 )
 
@@ -21,19 +18,6 @@ const jumpNsStatusTag = nightsoul.NightsoulTransmissionStatus
 func (c *char) highJump(hold int) (action.Info, error) {
 	if (hold > maxJumpFrames-minCancelFrames) || (hold < 0) {
 		hold = maxJumpFrames - minCancelFrames
-	}
-
-	// If player runs out of stamina, delay fall. Still allow high_plunge.
-	minFallFramesAdjust := 0
-	if c.Core.Player.Stam <= jumpStamDrainAmt {
-		minFallFramesAdjust = jumpNoStamFallDelayFrames
-		c.Core.Log.NewEvent(fmt.Sprintf("High jump has consumed all stamina. Earliest fall will be delayed by %d frames.", minFallFramesAdjust), glog.LogCooldownEvent, c.Index)
-	}
-	// Earliest user can trigger fall from GCSL
-	c.allowFallFrame = c.Core.F + minCancelFrames + minFallFramesAdjust
-
-	if hold < minFallFramesAdjust {
-		hold = minFallFramesAdjust
 	}
 
 	jumpDur := minCancelFrames + hold

--- a/internal/characters/ororon/ororon.go
+++ b/internal/characters/ororon/ororon.go
@@ -56,7 +56,6 @@ type char struct {
 	c6stacks           *stacks.MultipleRefreshNoRemove
 	c6bonus            []float64
 	jmpSrc             int
-	allowFallFrame     int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ info.CharacterProfile) error {

--- a/internal/characters/ororon/ororon.go
+++ b/internal/characters/ororon/ororon.go
@@ -18,12 +18,11 @@ var jumpHoldFrames [][]int
 // TODO: find real Frame delays
 const (
 	jumpNsDelay        = 10
-	jumpNsDuration     = 18
 	jumpStamDrainDelay = 5
 	jumpStamDrainAmt   = 75
 	jumpStamReqAmt     = 1 // TODO: Find real value
 
-	maxJumpFrames   = 60
+	maxJumpFrames   = 60 * 5
 	minCancelFrames = 15 // assume is the same as minPlungeFrames.
 	// minPlungeFrames = 17
 	jumpNoStamFallDelayFrames = maxJumpFrames // If ororon has 0 stam, fall cancel takes longer.

--- a/internal/characters/ororon/ororon.go
+++ b/internal/characters/ororon/ororon.go
@@ -25,7 +25,6 @@ const (
 	maxJumpFrames   = 60 * 5
 	minCancelFrames = 15 // assume is the same as minPlungeFrames.
 	// minPlungeFrames = 17
-	jumpNoStamFallDelayFrames = maxJumpFrames // If ororon has 0 stam, fall cancel takes longer.
 
 	fallFrames = 60 // Time it takes from cancelling high jump to hitting the ground.
 
@@ -43,9 +42,9 @@ func init() {
 	jumpHoldFrames[0][action.ActionHighPlunge] = minCancelFrames
 	// Fall -> X
 	jumpHoldFrames[1] = frames.InitAbilSlice(fallFrames)
-	jumpHoldFrames[1][action.ActionAttack] = 158
-	jumpHoldFrames[1][action.ActionBurst] = 159
-	jumpHoldFrames[1][action.ActionSwap] = 155
+	jumpHoldFrames[1][action.ActionAttack] = fallFrames + 10
+	jumpHoldFrames[1][action.ActionBurst] = fallFrames + 7
+	jumpHoldFrames[1][action.ActionSwap] = fallFrames
 }
 
 type char struct {

--- a/internal/characters/ororon/ororon.go
+++ b/internal/characters/ororon/ororon.go
@@ -1,9 +1,11 @@
 package ororon
 
 import (
+	"github.com/genshinsim/gcsim/internal/frames"
 	tmpl "github.com/genshinsim/gcsim/internal/template/character"
 	"github.com/genshinsim/gcsim/internal/template/nightsoul"
 	"github.com/genshinsim/gcsim/pkg/core"
+	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/info"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
@@ -11,8 +13,35 @@ import (
 	"github.com/genshinsim/gcsim/pkg/model"
 )
 
+var jumpHoldFrames [][]int
+
+// TODO: find real Frame delays
+const (
+	jumpNsDelay        = 10
+	jumpNsDuration     = 18
+	jumpStamDrainDelay = 5
+	jumpStamDrainAmt   = 75
+
+	maxJumpFrames   = 60
+	minCancelFrames = 15 // assume is the same as minPlungeFrames
+	// minPlungeFrames = 17
+
+	fallFrames = 60 // Time it takes from cancelling high jump to hitting the ground
+)
+
 func init() {
 	core.RegisterCharFunc(keys.Ororon, NewChar)
+
+	// Hold Jump
+	jumpHoldFrames = make([][]int, 2)
+	// Hold Jump -> X
+	jumpHoldFrames[0] = frames.InitAbilSlice(60 * 10) // set to very high number for most abilities
+	jumpHoldFrames[0][action.ActionHighPlunge] = minCancelFrames
+	// Fall -> X
+	jumpHoldFrames[1] = frames.InitAbilSlice(fallFrames)
+	jumpHoldFrames[1][action.ActionAttack] = 158
+	jumpHoldFrames[1][action.ActionBurst] = 159
+	jumpHoldFrames[1][action.ActionSwap] = 155
 }
 
 type char struct {
@@ -22,6 +51,7 @@ type char struct {
 	c2Bonus            []float64
 	c6stacks           *stacks.MultipleRefreshNoRemove
 	c6bonus            []float64
+	jmpSrc             int
 }
 
 func NewChar(s *core.Core, w *character.CharWrapper, _ info.CharacterProfile) error {
@@ -54,4 +84,21 @@ func (c *char) AnimationStartDelay(k model.AnimationDelayKey) int {
 		return 14
 	}
 	return c.Character.AnimationStartDelay(k)
+}
+
+func (c *char) ActionStam(a action.Action, p map[string]int) float64 {
+	if a == action.ActionJump && p["hold"] != 0 {
+		return 75
+	}
+	return c.Character.ActionStam(a, p)
+}
+
+// Ororon is in NS if either he has it through high jump or if he has it through his ascention.
+// Each has independent duration, so must be checked for in parallel.
+func (c *char) StatusIsActive(key string) bool {
+	if key == nightsoul.NightsoulBlessingStatus {
+		return (c.Character.StatusIsActive(nightsoul.NightsoulBlessingStatus) ||
+			c.Character.StatusIsActive(jumpNsStatusTag))
+	}
+	return c.Character.StatusIsActive(key)
 }

--- a/internal/characters/ororon/plunge.go
+++ b/internal/characters/ororon/plunge.go
@@ -26,7 +26,8 @@ func (c *char) fall() (action.Info, error) {
 		Frames: func(next action.Action) int {
 			return frames.NewAbilFunc(jumpHoldFrames[1])(next)
 		},
-		AnimationLength: jumpHoldFrames[1][action.InvalidAction],
+		// Is this supposed to be whatever the max over Frames is?
+		AnimationLength: jumpHoldFrames[1][action.ActionAttack],
 		CanQueueAfter:   jumpHoldFrames[1][action.ActionSwap],
 		State:           action.JumpState,
 	}, nil
@@ -38,7 +39,12 @@ func (c *char) HighPlungeAirborneOroron(p map[string]int) (action.Info, error) {
 
 	c.Core.Player.LastStamUse = c.Core.F + plungeStamResumeDelay - player.StamCDFrames
 
-	return action.Info{}, nil
+	return action.Info{
+		Frames:          frames.NewAbilFunc(plungeFrames),
+		AnimationLength: plungeFrames[action.ActionSwap],
+		CanQueueAfter:   plungeFrames[action.ActionSwap],
+		State:           action.PlungeAttackState,
+	}, nil
 }
 
 func (c *char) HighPlungeAttack(p map[string]int) (action.Info, error) {

--- a/internal/characters/ororon/plunge.go
+++ b/internal/characters/ororon/plunge.go
@@ -1,1 +1,66 @@
 package ororon
+
+import (
+	"fmt"
+
+	"github.com/genshinsim/gcsim/internal/frames"
+	"github.com/genshinsim/gcsim/pkg/core/action"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
+	"github.com/genshinsim/gcsim/pkg/core/player"
+)
+
+const (
+	plungeStamResumeDelay = 5 // When stam can start resuming after a plunge.
+)
+
+var plungeFrames []int
+
+func init() {
+	// Plunge -> X
+	plungeFrames = frames.InitAbilSlice(75) // set to very high number for most abilities
+}
+
+func (c *char) fall() (action.Info, error) {
+	// If character cannot begin falling yet because they had no stamina, delay start of fall.
+	delay := c.allowFallFrame - c.Core.F
+	if delay < 0 {
+		delay = 0
+	}
+	if delay > 0 {
+		c.Core.Log.NewEvent(fmt.Sprintf("Cannot execute fall immediately, delaying by %d frames", delay), glog.LogCooldownEvent, c.Index)
+	}
+	c.Core.Player.SetAirborne(player.Grounded)
+	c.QueueCharTask(func() { c.DeleteStatus(jumpNsStatusTag) }, delay)
+	c.Core.Player.LastStamUse = c.Core.F + fallStamResumeDelay - player.StamCDFrames
+
+	return action.Info{
+		Frames: func(next action.Action) int {
+			return frames.NewAbilFunc(jumpHoldFrames[1])(next) + delay
+		},
+		AnimationLength: jumpHoldFrames[1][action.InvalidAction] + delay,
+		CanQueueAfter:   jumpHoldFrames[1][action.ActionSwap] + delay,
+		State:           action.JumpState,
+	}, nil
+}
+
+func (c *char) HighPlungeAirborneOroron(p map[string]int) (action.Info, error) {
+	c.Core.Player.SetAirborne(player.Grounded)
+	c.DeleteStatus(jumpNsStatusTag)
+	c.allowFallFrame = 0
+
+	c.Core.Player.LastStamUse = c.Core.F + plungeStamResumeDelay - player.StamCDFrames
+
+	return action.Info{}, nil
+}
+
+func (c *char) HighPlungeAttack(p map[string]int) (action.Info, error) {
+	if c.Core.Player.Airborne() != player.AirborneOroron {
+		return c.Character.HighPlungeAttack(p)
+	}
+
+	if p["fall"] != 0 {
+		return c.fall()
+	}
+
+	return c.HighPlungeAirborneOroron(p)
+}

--- a/internal/characters/ororon/plunge.go
+++ b/internal/characters/ororon/plunge.go
@@ -1,0 +1,1 @@
+package ororon

--- a/internal/characters/ororon/plunge.go
+++ b/internal/characters/ororon/plunge.go
@@ -1,11 +1,8 @@
 package ororon
 
 import (
-	"fmt"
-
 	"github.com/genshinsim/gcsim/internal/frames"
 	"github.com/genshinsim/gcsim/pkg/core/action"
-	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player"
 )
 
@@ -21,24 +18,16 @@ func init() {
 }
 
 func (c *char) fall() (action.Info, error) {
-	// If character cannot begin falling yet because they had no stamina, delay start of fall.
-	delay := c.allowFallFrame - c.Core.F
-	if delay < 0 {
-		delay = 0
-	}
-	if delay > 0 {
-		c.Core.Log.NewEvent(fmt.Sprintf("Cannot execute fall immediately, delaying by %d frames", delay), glog.LogCooldownEvent, c.Index)
-	}
 	c.Core.Player.SetAirborne(player.Grounded)
-	c.QueueCharTask(func() { c.DeleteStatus(jumpNsStatusTag) }, delay)
+	c.DeleteStatus(jumpNsStatusTag)
 	c.Core.Player.LastStamUse = c.Core.F + fallStamResumeDelay - player.StamCDFrames
 
 	return action.Info{
 		Frames: func(next action.Action) int {
-			return frames.NewAbilFunc(jumpHoldFrames[1])(next) + delay
+			return frames.NewAbilFunc(jumpHoldFrames[1])(next)
 		},
-		AnimationLength: jumpHoldFrames[1][action.InvalidAction] + delay,
-		CanQueueAfter:   jumpHoldFrames[1][action.ActionSwap] + delay,
+		AnimationLength: jumpHoldFrames[1][action.InvalidAction],
+		CanQueueAfter:   jumpHoldFrames[1][action.ActionSwap],
 		State:           action.JumpState,
 	}, nil
 }
@@ -46,7 +35,6 @@ func (c *char) fall() (action.Info, error) {
 func (c *char) HighPlungeAirborneOroron(p map[string]int) (action.Info, error) {
 	c.Core.Player.SetAirborne(player.Grounded)
 	c.DeleteStatus(jumpNsStatusTag)
-	c.allowFallFrame = 0
 
 	c.Core.Player.LastStamUse = c.Core.F + plungeStamResumeDelay - player.StamCDFrames
 

--- a/internal/characters/ororon/testconfig.txt
+++ b/internal/characters/ororon/testconfig.txt
@@ -1,0 +1,127 @@
+# Team
+ororon char lvl=90/90 cons=6 talent=9,9,9;
+ororon add weapon="stringless" refine=3 lvl=90/90;
+ororon add set="scroll" count=4;
+
+nahida char lvl=90/90 cons=0 talent=9,9,9;
+nahida add weapon="athousandfloatingdreams" refine=1 lvl=90/90;
+
+barbara char lvl=90/90 cons=0 talent=9,9,9;
+barbara add weapon="widsith" refine=1 lvl=90/90;
+
+# Options
+options iteration=10; 
+options swap_delay=12;
+options ignore_burst_energy=true;
+
+# Targets
+target lvl=100 resist=0.1 radius=2 pos=0,2.4 hp=100000000;
+active ororon;
+
+#Passed Checks
+
+#Passed Checks
+print("Debug: Wait for NS scroll blessing.");
+delay(60*15);
+nahida skill;
+ororon burst, jump[hold=-1];
+while !.ororon.status.scroll-4pc-nightsoul-dendro {
+  wait(1);
+}
+if .airborne {
+  ororon high_plunge[fall=1];
+}
+
+print("Debug: short jump X 10");
+ororon jump[hold=1]:10;
+print("Debug: short jump X 10 ended");
+
+print("Debug: nahida skill, ororon burst normal jump");
+delay(60*3);
+nahida skill;
+ororon burst, jump[hold=0];
+
+print("Debug: nahida skill, ororon burst long jump");
+delay(60*15);
+nahida skill;
+ororon burst, jump[hold=-1];
+
+print("Debug: nahida skill, ororon burst shortest jump");
+delay(60*15);
+nahida skill;
+ororon burst, jump[hold=1];
+
+print("Debug: nahida skill, ororon burst long jump, early fall");
+delay(60*15);
+nahida skill;
+ororon burst, jump[hold=-1], high_plunge[fall=1];
+#ororon high_plunge;
+
+print("Debug: nahida skill, ororon burst long jump with no stamina, early fall");
+delay(60*15);
+ororon jump[hold=1]:5;
+nahida skill;
+ororon burst, jump[hold=-1], high_plunge[fall=1];
+#ororon high_plunge;
+
+print("Debug: nahida skill, ororon burst long jump, early plunge");
+delay(60*15);
+nahida skill;
+ororon burst, jump[hold=-1], high_plunge;
+#ororon high_plunge[fall=1];
+
+
+print("Debug: barbara skill, ororon burst");
+delay(60*15);
+barbara skill;
+ororon burst;
+wait(60*15);
+
+
+print("Debug: barbara skill, ororon burst normal jump");
+delay(60*15);
+barbara skill;
+ororon burst, jump;
+wait(60*15);
+
+
+print("Debug: barbara skill, ororon burst short jump");
+delay(60*15);
+barbara skill;
+ororon burst, jump[hold=1];
+wait(60*15);
+
+print("Debug: barbara skill, ororon burst long jump");
+delay(60*15);
+barbara skill;
+ororon burst, jump[hold=-1];
+wait(60*15);
+
+print("Debug: Repeated long jump, early cancel, end on long jump.");
+delay(60*15);
+nahida skill;
+ororon burst, jump[hold=-1], high_plunge[fall=1], jump[hold=-1], high_plunge, jump[hold=-1], high_plunge[fall=1], jump[hold=-1];
+
+print("Debug: Long Jump->Non-plunge Action.");
+delay(60*15);
+nahida skill;
+ororon burst, jump[hold=-1], attack;
+
+print("Debug: Long Jump->->Early fall->Non-plunge Action.");
+delay(60*15);
+nahida skill;
+ororon jump[hold=-1];
+wait(10);
+ororon high_plunge[fall=1], burst;
+
+print("Debug: Long Jump->->Early plunge->Non-plunge Action.");
+delay(60*15);
+nahida skill;
+ororon jump[hold=-1];
+wait(10);
+ororon high_plunge[fall=1];
+nahida swap;
+
+
+
+wait(60*10);

--- a/internal/template/nightsoul/nightsoul.go
+++ b/internal/template/nightsoul/nightsoul.go
@@ -11,6 +11,10 @@ import (
 
 const NightsoulBlessingStatus = "nightsoul-blessing"
 
+// Nightsoul transmission status is handled by the character, not the NS package.
+// If in Nightsoul Transmission state or have the regular Nightsoul Blessing Status, return true for having Nightsoul Blessing.
+const NightsoulTransmissionStatus = "nightsoul-transmission"
+
 type State struct {
 	char            *character.CharWrapper
 	c               *core.Core
@@ -41,7 +45,8 @@ func (s *State) ExitBlessing() {
 }
 
 func (s *State) HasBlessing() bool {
-	return s.char.StatusIsActive(NightsoulBlessingStatus)
+	return s.char.StatusIsActive(NightsoulBlessingStatus) ||
+		s.char.StatusIsActive(NightsoulTransmissionStatus)
 }
 
 func (s *State) GeneratePoints(amount float64) {

--- a/internal/weapons/claymore/athousandblazingsuns/athousandblazingsuns.go
+++ b/internal/weapons/claymore/athousandblazingsuns/athousandblazingsuns.go
@@ -47,7 +47,8 @@ func (w *Weapon) extendOffField(src int) func() {
 		if src != w.tickSrc {
 			return
 		}
-		if w.char.StatusIsActive(nightsoul.NightsoulBlessingStatus) {
+		if w.char.StatusIsActive(nightsoul.NightsoulBlessingStatus) ||
+			w.char.StatusIsActive(nightsoul.NightsoulTransmissionStatus) {
 			active := w.char.ExtendStatus(BuffKey, tickInterval)
 			if !active {
 				return
@@ -81,7 +82,8 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 			Amount: func() ([]float64, bool) {
 				m[attributes.ATKP] = 0.21 + 0.07*r
 				m[attributes.CD] = 0.15 + 0.05*r
-				if char.StatusIsActive(nightsoul.NightsoulBlessingStatus) {
+				if char.StatusIsActive(nightsoul.NightsoulBlessingStatus) ||
+					char.StatusIsActive(nightsoul.NightsoulTransmissionStatus) {
 					m[attributes.ATKP] *= 1.75
 					m[attributes.CD] *= 1.75
 				}

--- a/pkg/core/player/player.go
+++ b/pkg/core/player/player.go
@@ -306,6 +306,7 @@ const (
 	AirborneVenti
 	AirborneKazuha
 	AirborneXianyun
+	AirborneOroron
 	TerminateAirborne
 )
 

--- a/ui/packages/docs/src/components/Actions/character_data.json
+++ b/ui/packages/docs/src/components/Actions/character_data.json
@@ -2138,7 +2138,7 @@
     },
     {
       "ability": "aim",
-      "legal": true
+      "notes": "Mid-air aim not implemented."
     },
     {
       "ability": "skill",
@@ -2163,6 +2163,10 @@
     {
       "ability": "swap",
       "legal": true
+    },
+    {
+      "ability": "high_plunge",
+      "notes": "Previous action must be an Ororon High Jump. Plunge from Xianyun's burst is not implemented."
     }
   ],
   "qiqi": [

--- a/ui/packages/docs/src/components/Params/character_data.json
+++ b/ui/packages/docs/src/components/Params/character_data.json
@@ -1096,6 +1096,21 @@
       "ability": "skill",
       "param": "travel",
       "desc": "Travel time of bounce between targets in frames. Default: 10."
+    },
+    {
+      "ability": "skill",
+      "param": "hold",
+      "desc": "0 for a normal jump (default), nonzero for an extended leap as buffed from his Night Realm's Gift. Airborne Frames = hold-1. -1 for a max-duration jump. Grants status AirborneOroron. A high_plunge action with fall=true will be called automatically if another action is not taken within Ororon's jump duration."
+    },
+    {
+      "ability": "high_plunge",
+      "param": "collision",
+      "desc": "0 for no collision dmg (default), 1 for collision dmg."
+    },
+    {
+      "ability": "high_plunge",
+      "param": "fall",
+      "desc": "0 for a normal high_plunge, 1 to simulate a damageless release from high jump. After fall has begun, high_plunge cannot be used until Ororon is airborne again."
     }
   ],
   "qiqi": [


### PR DESCRIPTION
WIP
 
When Ororon uses a hold jump in-game, he initiates a form of NS transmission, leaping high in the air and gaining the NS Blessing status. This NS Blessing exists independently of the NS Blessing from his A1 passive but can still allow the extended Scroll of the Hero of the Cinder City 4pc effect to trigger. 

While airborne, he can fall, high plunge, or aim. Aim is not implemented here. Ororon cannot cancel his high jump before reaching max height, so low_plunge is also not implemented. To prevent implementation of movement tech, ororon is forcefully transitioned into the fall state on the frame he would open his glider.

When Ororon uses high jump, he drains 75 stamina. Stamina does not resume regeneration until he initiates another action. He does not require all 75 stamina to initiate a high jump and will drain to 0 if less than 75 stamina remains. When Ororon has drained all stamina, ~~he is unable to initiate a normal fall cancel and will only be able to plunge~~ Ororon can't cancel normally but can initiate an equivalent fall cancel by attempting to walk (glide) forward.

Implementation details:
Ororon's high jump code schedules a callback to a Player.exec() call as a proof of concept of forcefully changing the player's animation state. The concepts used should be applicable to any character who automatically executes an action outside of a GCSL statement, such as Mavuika Charge starting in the NA state and transitioning to the CA state, or Chasca transitioning from the charge state to a falling state upon NS expiry. This is not strictly needed for Ororon, and can be changed upon request. 

~~Extended functionality of implementation is still being tested.~~ Behavior for fake frame data has been validated in the added sample config.txt. Stamina behavior has not been validated.

GCSL notes:
jump:
param hold:
 - 0 (default): Initiates a normal jump, calls already-implemented code.
 - < 0: Sets hold to MaxHold. Fall through to below case.
 - \> 0: Subtract 1. Hold=1 implies minimum length hover before fall cancel. Fall will be initiated MinFallCancelFrames + Hold frames after the jump begins.

High_Plunge:
param fall:
- 0 (default) Perform a normal high-plunge.
- 1: Simulate a pressing the jump button after reaching max jump height, initiating free-fall. A plunge cannot be used after a fall has been initiated. 

Frames todo:
- [ ] All jump[hold!=0]->X frames.
- [ ] All high_plunge->X frames.
- [ ] All high_plunge[fall=1]->X frames.
- [ ] NS Transmission start and end relative to action frames. 
- [ ] Stam drain and allowable resume frames.
Other todo:
- [ ] Min required stamina to initiate high jump (Drains 75, but able to initiate with less than 75)
- [ ] High Plunge[fall=0]. Currently, does nothing.
- [ ] Stamina drain adjustment when stamina mods are in effect (e.g. anemo resonance)
- [ ] Update mode_gcsim.js with shortcuts for syntax highlighting (Does this need to be done for new Params?)
- [x] Update documentation

### Code implemented:
### JUMP
- [x] add hold parameter to JUMP action
- [x] Require <75 stam before using high jump. Only requires 1? 5? TBD
- [x] Automatically transition from JUMP[hold != 0] to FALL action when NS transmission expires, if user does not manually exit (through plunge or plunge[fall=1]) first)
- [x] Grant AirborneOroron 

### STAMINA
- [x] Remove 75 stamina.
- [x] Prevent stamina regen.
- [x] WONTDO: Stam check should actually happen a little after jump is initiated.

### NS BLESSING
- [x] Give NS Transmission blessing status while airborne
- [x] Overload get_status method to identify ororon as having Nightsoul Blessing state when either he has Nightsoul Blessing status OR when he has NS Transmission status
- [x] Remove NS Transmission status when NS transmission ends


### High PLUNGE
- [ ] Implement AirborneOroron plunge (code currently works, no attack sent out, no collision done).
- [x] Implement AirborneOroron plunge[fall!=0] param
- [x] Require AirborneOroron status to use plunge

### STAMINA
- [x] Allow stamina to regen again after plunge
- [x] Allow stamina to regen again after plunge[fall=1]

### NS BLESSING
- [x] Remove NS Transmission on plunge // Assume it happens immediately
- [x] Remove NS Transmission on fall // Assume it happens immediately

Notes: Stamina is probably terribly bugged and also overcomplicated. My ability to accurately test stamina drain and resume timings is hampered by https://library.keqingmains.com/evidence/combat-mechanics/damage/other/client-and-server#high-ping-interactions
