### PR TITLE
Fix Nilou A4

### DIFF
--- a/internal/characters/nilou/asc.go
+++ b/internal/characters/nilou/asc.go
@@ -1,6 +1,8 @@
 package nilou
 
 import (
+	"slices"
+
 	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
@@ -101,13 +103,7 @@ func (c *char) a4() {
 				}
 
 				// check is bountiful core?
-				var t combat.Gadget
-				for _, v := range c.Core.Combat.Gadgets() {
-					if v != nil && v.Key() == ai.DamageSrc {
-						t = v
-					}
-				}
-				if _, ok := t.(*BountifulCore); !ok {
+				if !slices.Contains(ai.AdditionalTags, attacks.AdditionalTagBountifulBloom) {
 					return 0, false
 				}
 

--- a/internal/characters/nilou/bountifulcore.go
+++ b/internal/characters/nilou/bountifulcore.go
@@ -28,7 +28,7 @@ func newBountifulCore(c *core.Core, p geometry.Point, a *combat.AttackEvent) *Bo
 	char := b.Core.Player.ByIndex(a.Info.ActorIndex)
 	explode := func() {
 		c.Tasks.Add(func() {
-			ai, snap := reactable.NewBloomAttack(char, b)
+			ai, snap := reactable.NewBountifulBloomAttack(char, b)
 			ap := combat.NewCircleHitOnTarget(b.Gadget, nil, 6.5)
 			c.QueueAttackWithSnap(ai, snap, ap, 0)
 

--- a/pkg/core/attacks/attack.go
+++ b/pkg/core/attacks/attack.go
@@ -45,4 +45,5 @@ const (
 	AdditionalTagNone AdditionalTag = iota
 	AdditionalTagNightsoul
 	AdditionalTagKinichCannon
+	AdditionalTagBountifulBloom
 )

--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -233,13 +233,14 @@ const (
 	HyperbloomMultiplier = 3
 )
 
-func NewBloomAttack(char *character.CharWrapper, src combat.Target) (combat.AttackInfo, combat.Snapshot) {
+func NewBloomAttackWithTags(char *character.CharWrapper, src combat.Target, tags []attacks.AdditionalTag) (combat.AttackInfo, combat.Snapshot) {
 	em := char.Stat(attributes.EM)
 	ai := combat.AttackInfo{
 		ActorIndex:       char.Index,
 		DamageSrc:        src.Key(),
 		Element:          attributes.Dendro,
 		AttackTag:        attacks.AttackTagBloom,
+		AdditionalTags:   tags,
 		ICDTag:           attacks.ICDTagBloomDamage,
 		ICDGroup:         attacks.ICDGroupReactionA,
 		StrikeType:       attacks.StrikeTypeDefault,
@@ -249,6 +250,15 @@ func NewBloomAttack(char *character.CharWrapper, src combat.Target) (combat.Atta
 	flatdmg, snap := calcReactionDmg(char, ai, em)
 	ai.FlatDmg = BloomMultiplier * flatdmg
 	return ai, snap
+}
+
+func NewBountifulBloomAttack(char *character.CharWrapper, src combat.Target) (combat.AttackInfo, combat.Snapshot) {
+	tags := []attacks.AdditionalTag{attacks.AdditionalTagBountifulBloom}
+	return NewBloomAttackWithTags(char, src, tags)
+}
+
+func NewBloomAttack(char *character.CharWrapper, src combat.Target) (combat.AttackInfo, combat.Snapshot) {
+	return NewBloomAttackWithTags(char, src, nil)
 }
 
 func NewBurgeonAttack(char *character.CharWrapper, src combat.Target) (combat.AttackInfo, combat.Snapshot) {


### PR DESCRIPTION
Added a custom additional tag to detect Nilou bloom, rather than try to fix gadgets.
Added 2 new public functions in reactables. Only 1 needs to be public, but wasn't sure which was preferred. If desired, I can remove the nilou-specific func entirely and only leave the generic tagging function.