### PR TITLE
fix .char.dash.cd and .char.dash.ready fields

### DIFF
--- a/internal/template/character/ready.go
+++ b/internal/template/character/ready.go
@@ -34,6 +34,14 @@ func (c *Character) ActionReady(a action.Action, p map[string]int) (bool, action
 				Write("have", c.Core.Player.Stam)
 			return false, action.InsufficientStamina
 		}
+		if c.Core.Player.Active() == c.Index && c.Core.Player.DashLockout && c.Core.Player.DashCDExpirationFrame > c.Core.F {
+			c.Core.Log.NewEvent("dash on cooldown", glog.LogWarnings, -1).
+				Write("dash_cd_expiration", c.Core.Player.DashCDExpirationFrame-c.Core.F)
+			return false, action.DashCD
+		}
+		if c.Core.Player.Active() != c.Index && c.DashLockout && c.RemainingDashCD > 0 {
+			return false, action.DashCD
+		}
 	}
 	return true, action.NoFailure
 }

--- a/pkg/conditional/character.go
+++ b/pkg/conditional/character.go
@@ -135,14 +135,6 @@ func evalCharacterAbil(c *core.Core, char *character.CharWrapper, act action.Act
 		if act == action.ActionSwap {
 			return c.Player.SwapCD == 0 || c.Player.Active() == char.Index, nil
 		}
-		if act == action.ActionDash {
-			if c.Player.Active() == char.Index && c.Player.DashLockout {
-				return c.Player.DashCDExpirationFrame == 0, nil
-			}
-			if c.Player.Active() != char.Index && char.DashLockout {
-				return char.RemainingDashCD == 0, nil
-			}
-		}
 		// TODO: nil map may cause problems here??
 		ok, _ := char.ActionReady(act, nil)
 		return ok, nil

--- a/pkg/conditional/character.go
+++ b/pkg/conditional/character.go
@@ -119,12 +119,29 @@ func evalCharacterAbil(c *core.Core, char *character.CharWrapper, act action.Act
 		if act == action.ActionSwap {
 			return c.Player.SwapCD, nil
 		}
+		if act == action.ActionDash {
+			if c.Player.Active() == char.Index && c.Player.DashLockout {
+				return c.Player.DashCDExpirationFrame - c.F, nil
+			}
+			if c.Player.Active() != char.Index && char.DashLockout {
+				return char.RemainingDashCD, nil
+			}
+			return 0, nil
+		}
 		return char.Cooldown(act), nil
 	case "charge":
 		return char.Charges(act), nil
 	case "ready":
 		if act == action.ActionSwap {
 			return c.Player.SwapCD == 0 || c.Player.Active() == char.Index, nil
+		}
+		if act == action.ActionDash {
+			if c.Player.Active() == char.Index && c.Player.DashLockout {
+				return c.Player.DashCDExpirationFrame == 0, nil
+			}
+			if c.Player.Active() != char.Index && char.DashLockout {
+				return char.RemainingDashCD == 0, nil
+			}
 		}
 		// TODO: nil map may cause problems here??
 		ok, _ := char.ActionReady(act, nil)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/60450053-3140-40a3-9623-67eebe58b3c4)


closes #2000 

config for testing

```
options iteration=100;
energy every interval=480,720 amount=1;

hutao char lvl=90/90 cons=1 talent=9,9,9;
hutao add weapon="favlance" refine=3 lvl=90/90;

furina char lvl=90/90 cons=1 talent=9,9,9;
furina add weapon="favsword" refine=3 lvl=90/90;

target lvl=100 resist=0.1 hp=100000000 pos=0,2;

active hutao;

# Test dash fields when hitting cooldown+lockout
hutao skill;
for let i = 0; i < 3; i = i + 1 {
  hutao attack, charge;
  print("hutao.dash.ready: ", .hutao.dash.ready);
  print("hutao.dash.cd: ", .hutao.dash.cd);
  hutao dash;
}

wait(800);

# Test dash fields when low stamina
for let i = 0; i < 6; i = i + 1 {
  hutao attack, charge;
  print("stamina: ", .stam);
  print("hutao.dash.ready: ", .hutao.dash.ready);
  print("hutao.dash.cd: ", .hutao.dash.cd);
  hutao dash;
}

wait(500);

# Test swapping to different character when hitting cooldown+lockout
hutao skill, attack, charge, dash,
  attack, charge, dash;

print("hutao.dash.ready: ", .hutao.dash.ready);
print("hutao.dash.cd: ", .hutao.dash.cd);
print("furina.dash.ready: ", .furina.dash.ready);
print("furina.dash.cd: ", .furina.dash.cd);

furina swap;

print("hutao.dash.ready: ", .hutao.dash.ready);
print("hutao.dash.cd: ", .hutao.dash.cd);
print("furina.dash.ready: ", .furina.dash.ready);
print("furina.dash.cd: ", .furina.dash.cd);

furina dash;
```