### PR TITLE
Yelan burst updates (N0, travel param, C2)

### DIFF
--- a/internal/characters/yelan/burst.go
+++ b/internal/characters/yelan/burst.go
@@ -11,10 +11,11 @@ import (
 )
 
 var burstFrames []int
-var burstDiceHitmarks = []int{25, 30, 36, 41} // c2 hitmark not framecounted
+var burstTravel = 20
 
 // initial hit
 const burstHitmark = 76
+const c2Hitmark = 17
 
 func init() {
 	burstFrames = frames.InitAbilSlice(93) // Q -> N1/CA/D
@@ -39,6 +40,12 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 		HitlagFactor:     0.05,
 		IsDeployable:     true,
 	}
+
+	travel, ok := p["travel"]
+	if ok {
+		burstTravel = travel
+	}
+
 	// apply hydro every 3rd hit
 	// triggered on normal attack or yelan's skill
 
@@ -103,7 +110,7 @@ func (c *char) summonExquisiteThrow() {
 				nil,
 				0.5,
 			),
-			burstDiceHitmarks[i],
+			burstTravel+i*6,
 		)
 	}
 	if c.Base.Cons >= 2 && c.c2icd <= c.Core.F {
@@ -122,7 +129,7 @@ func (c *char) summonExquisiteThrow() {
 				0.5,
 			),
 			0,
-			burstDiceHitmarks[3],
+			c2Hitmark,
 		)
 	}
 }

--- a/internal/characters/yelan/yelan.go
+++ b/internal/characters/yelan/yelan.go
@@ -87,6 +87,9 @@ func (c *char) AnimationStartDelay(k model.AnimationDelayKey) int {
 	if k == model.AnimationXingqiuN0StartDelay {
 		return 9
 	}
+	if k == model.AnimationYelanN0StartDelay {
+		return 6
+	}
 	return c.Character.AnimationStartDelay(k)
 }
 

--- a/ui/packages/docs/src/components/Frames/character_data.json
+++ b/ui/packages/docs/src/components/Frames/character_data.json
@@ -1505,6 +1505,12 @@
       "count_credit": "bowtae",
       "vid": "https://youtu.be/9qen-zpB06w",
       "count": "https://docs.google.com/spreadsheets/d/187T-SngEZUUordjY_K_tF_DdvHjQju9CoBJdp2eJOis/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "soloxcx & zephyr77",
+      "count_credit": "soloxcx",
+      "vid": "https://youtu.be/SnYqKjjoUYk",
+      "count": "https://docs.google.com/spreadsheets/d/1y4r8MNm_sWfFCmELlc3qWnlf_m40veFGV3IW6KOW5Is/edit?usp=sharing"
     }
   ],
   "yoimiya": [


### PR DESCRIPTION
This PR:
- adds a `travel` param to yelan Q. default travel time is 20 frames, a bit shorter than old hitmarks.
- adds yelan N0 timing to herself.
- changes c2 hitmark.
- updates docs.

The default travel time could be different than 20 frames, it's a bit arbitrary. I attached [counts](<https://docs.google.com/spreadsheets/d/1y4r8MNm_sWfFCmELlc3qWnlf_m40veFGV3IW6KOW5Is/edit?usp=sharing>) for the first hitmark in melee range against a downed ruin guard (21 frames) and a downed aeonblight drake (18 frames), so 20 seemed like a nice default.

The subsequent Exquisite Throws will hit 6 frames after each other. In game, this can still vary based on enemy hitbox, but 6f was about the average difference from my ruin guard counts.

I don't own C2 yelan, but the old hitmark for C2 was too long. zephyr77 on discord recorded a clip that should be good enough to improve it. C2 is a projectile but it's so fast that I don't think it needs a travel param.

[Here](<https://docs.google.com/spreadsheets/d/1UKIZULhbafCjygZlZ7WbVfsR53azM_vCcAqhNZ-yVws/edit?usp=sharing>) is a resulting dbcompare. Most notably, vape arlecchino configs that use N2C combos with just yelan are harshly affected, which should be intended as mentioned by #2291. However, they can be updated to use `yelan burst[travel=25]` to replicate the old behavior.

Closes #2291 and #2315.