### PR TITLE
Fix Vivid Notions skill/burst buff

### DIFF
--- a/internal/weapons/catalyst/vividnotions/vividnotions.go
+++ b/internal/weapons/catalyst/vividnotions/vividnotions.go
@@ -70,12 +70,12 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 		return false
 	}, fmt.Sprintf("vividnotions-plunge-%s", char.Base.Key.String()))
 
-	c.Events.Subscribe(event.OnPlunge, func(args ...interface{}) bool {
+	c.Events.Subscribe(event.OnSkill, func(args ...interface{}) bool {
 		char.AddStatus(skillBurstBuff, 15*60, true)
 		return false
 	}, fmt.Sprintf("vividnotions-skill-%s", char.Base.Key.String()))
 
-	c.Events.Subscribe(event.OnPlunge, func(args ...interface{}) bool {
+	c.Events.Subscribe(event.OnBurst, func(args ...interface{}) bool {
 		char.AddStatus(skillBurstBuff, 15*60, true)
 		return false
 	}, fmt.Sprintf("vividnotions-burst-%s", char.Base.Key.String()))


### PR DESCRIPTION
Hi!
I believe the Vivid Notions implementation has a bug where the 40% Crit Dmg buff is granted on plunge rather than on skill or burst. This change should fix it