### PR TITLE
Fix missing heal main stat in optimizer

### DIFF
--- a/pkg/optimization/substats.go
+++ b/pkg/optimization/substats.go
@@ -178,6 +178,7 @@ func NewSubstatOptimizerDetails(
 	s.mainstatValues[attributes.GeoP] = 0.466
 	s.mainstatValues[attributes.DendroP] = 0.466
 	s.mainstatValues[attributes.PhyP] = 0.583
+	s.mainstatValues[attributes.Heal] = 0.359
 
 	s.mainstatTol = 0.005       // current main stat tolerance is 0.5%
 	s.fourstarMod = 0.746514762 // The average coefficient to convert 5* main stats to 4* main stats


### PR DESCRIPTION
This caused erroneous warnings about only 4x main stats when the character had a healing circlet.