### PR TITLE
adjust raiden Q N1 > CA cancel frame and Q CA-2 hitmark

### DIFF
--- a/internal/characters/raiden/attack.go
+++ b/internal/characters/raiden/attack.go
@@ -104,7 +104,7 @@ func init() {
 	// NA cancels (burst)
 	swordFrames = make([][]int, normalHitNum)
 
-	swordFrames[0] = frames.InitNormalCancelSlice(swordHitmarks[0][0], 24)
+	swordFrames[0] = frames.InitNormalCancelSlice(swordHitmarks[0][0], 21)
 	swordFrames[0][action.ActionAttack] = 19
 
 	swordFrames[1] = frames.InitNormalCancelSlice(swordHitmarks[1][0], 26)

--- a/internal/characters/raiden/charge.go
+++ b/internal/characters/raiden/charge.go
@@ -57,7 +57,7 @@ func (c *char) ChargeAttack(p map[string]int) (action.Info, error) {
 }
 
 var swordCAFrames []int
-var swordCAHitmarks = []int{24, 31}
+var swordCAHitmarks = []int{24, 32}
 
 func init() {
 	// charge (burst) -> x


### PR DESCRIPTION
cancel frame adjustment is from https://discord.com/channels/845087716541595668/1376292247938666496, intent is to make 6N1CD possible.

It seems a video was recorded of Q N1 > CA being 21f, and the old counts were deprecated, though the code was not updated: https://www.youtube.com/watch?v=tb1bGGVNJoA

Frame counts:
N1 5904, CA 5925, difference 21f
N1 6165, CA 6185, difference 20f
N1 6454, CA 6475, difference 21f

hitmark adjustment is from https://discord.com/channels/845087716541595668/884485336657444894/1228166173535764480, also better matches frame sheet trials

nothing significant changes in dbcompare