### PR TITLE
clear kinich a1 on nightsoul blessing expiry

### DIFF
--- a/internal/characters/kinich/asc.go
+++ b/internal/characters/kinich/asc.go
@@ -1,6 +1,7 @@
 package kinich
 
 import (
+	"github.com/genshinsim/gcsim/internal/template/nightsoul"
 	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
@@ -44,6 +45,9 @@ func (c *char) a1() {
 
 func (c *char) a1CB(a combat.AttackCB) {
 	if c.Base.Ascension < 1 {
+		return
+	}
+	if !c.StatusIsActive(nightsoul.NightsoulBlessingStatus) {
 		return
 	}
 	e, ok := a.Target.(*enemy.Enemy)

--- a/internal/characters/kinich/skill.go
+++ b/internal/characters/kinich/skill.go
@@ -9,6 +9,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/targets"
+	"github.com/genshinsim/gcsim/pkg/enemy"
 )
 
 const (
@@ -181,6 +182,13 @@ func (c *char) cancelNightsoul() {
 	c.nightsoulState.ExitBlessing()
 	c.nightsoulSrc = -1
 	c.blindSpotAngularPosition = -1
+
+	// Clear desolation status from all enemies
+	for _, t := range c.Core.Combat.Enemies() {
+		if e, ok := t.(*enemy.Enemy); ok {
+			e.DeleteStatus(desolationKey)
+		}
+	}
 }
 
 func (c *char) particleCB(a combat.AttackCB) {


### PR DESCRIPTION
The desolation status applied by A1 is supposed to clear when nightsoul expires

> When Kinich is in Nightsoul's Blessing state, opponents hit by his Elemental Skill will enter the Desolation state, and when affected by Burning or Burgeon reaction DMG, they will restore 7 Nightsoul points to him. Nightsoul points can be gained this way once every 0.8s. The Desolation state will persist until this instance of Kinich's Nightsoul's Blessing state ends.