### PR TITLE
adjust kinich cannon snapshot frame & refactor c2

### DIFF
--- a/internal/characters/kinich/cons.go
+++ b/internal/characters/kinich/cons.go
@@ -6,7 +6,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
-	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/enemy"
 	"github.com/genshinsim/gcsim/pkg/modifier"
@@ -59,21 +58,6 @@ func (c *char) c2ResShredCB(a combat.AttackCB) {
 		Ele:   attributes.Dendro,
 		Value: -0.3,
 	})
-}
-
-func (c *char) c2Bonus(ai *combat.AttackInfo) (combat.Snapshot, float64) {
-	s := c.Snapshot(ai)
-	if c.Base.Cons < 2 {
-		return s, 3.0
-	}
-	if c.c2AoeIncreased {
-		return s, 3.0
-	}
-	c.c2AoeIncreased = true
-	s.Stats[attributes.DmgP] += 1.0
-	c.Core.Log.NewEvent("Kinich C2 Damage Bonus", glog.LogCharacterEvent, c.Index).
-		Write("final", s.Stats[attributes.DmgP])
-	return s, 5.0
 }
 
 func (c *char) c4() {

--- a/internal/characters/kinich/kinich.go
+++ b/internal/characters/kinich/kinich.go
@@ -7,6 +7,7 @@ import (
 	"github.com/genshinsim/gcsim/internal/template/nightsoul"
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/action"
+	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/info"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
@@ -27,6 +28,8 @@ type char struct {
 	normalSCounter           int
 	characterAngularPosition float64 // [0, 360)
 	blindSpotAngularPosition float64 // [0, 360)
+	cannonRadius             float64
+	cannonSnap               combat.Snapshot
 	particlesGenerated       bool
 	c2AoeIncreased           bool
 }

--- a/internal/characters/kinich/kinich.go
+++ b/internal/characters/kinich/kinich.go
@@ -7,7 +7,6 @@ import (
 	"github.com/genshinsim/gcsim/internal/template/nightsoul"
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/action"
-	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/info"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
@@ -28,8 +27,6 @@ type char struct {
 	normalSCounter           int
 	characterAngularPosition float64 // [0, 360)
 	blindSpotAngularPosition float64 // [0, 360)
-	cannonRadius             float64
-	cannonSnap               combat.Snapshot
 	particlesGenerated       bool
 	c2AoeIncreased           bool
 }


### PR DESCRIPTION
from https://discord.com/channels/845087716541595668/1380299775802609786

currently Kinich's Scalespiker Cannon snapshots on cast, but it should snap after nightsoul points are drained.

This PR:
1. Changes Scalespiker Cannon to snap at same frame nightsoul points are drained.
2. Refactors C2, otherwise moving the snap frame would lead to using the radius variable before it is set.
3. Changes cannon `travel` time to start when nightsoul is drained, otherwise `travel=0` would land before the snapshot. 
4. Changes blindspot creation task to queue when nightsoul is drained instead of 1 frame earlier. There is functionally no difference here.

3 means that configs using `travel` will land 1 frame later than before. The default travel time is unchanged

[dbcompare.txt](https://github.com/user-attachments/files/20634913/dbcompare.txt)