### PR TITLE
add show_substat_scalars option to optimizer (default 1)

### DIFF
--- a/cmd/gcsim/main.go
+++ b/cmd/gcsim/main.go
@@ -77,7 +77,8 @@ func mainImpl() error {
 - total_liquid_substats (default = 20): Total liquid substats available to be assigned across all substats
 - indiv_liquid_cap (default = 10): Total liquid substats that can be assigned to a single substat
 - fixed_substats_count (default = 2): Amount of fixed substats that are assigned to all substats
-- fine_tune (default = 1): Set to 0 to disable fine tune step of substat optimizer.`)
+- fine_tune (default = 1): Set to 0 to disable fine tune step of substat optimizer.
+- show_substat_scalars (default = 1): Set to 0 to disable formatting substats by their scalars in the resulting config.`)
 	flag.StringVar(&opt.cpuprofile, "cpuprofile", "", `write cpu profile to a file. supply file path (otherwise empty string for disabled). 
 can be viewed in the browser via "go tool pprof -http=localhost:3000 cpu.prof" (insert your desired host/port/filename, requires Graphviz)`)
 	flag.StringVar(&opt.memprofile, "memprofile", "", `write memory profile to a file. supply file path (otherwise empty string for disabled). 

--- a/pkg/optimization/substatoptimizer.go
+++ b/pkg/optimization/substatoptimizer.go
@@ -23,6 +23,7 @@ func RunSubstatOptim(simopt simulator.Options, verbose bool, additionalOptions s
 		"fixed_substats_count":  2,
 		"verbose":               0,
 		"fine_tune":             1,
+		"show_substat_scalars":  1,
 	}
 
 	if verbose {

--- a/pkg/optimization/substats.go
+++ b/pkg/optimization/substats.go
@@ -99,7 +99,11 @@ func (o *SubstatOptimizer) PrettyPrint(output string, statsFinal *SubstatOptimiz
 				continue
 			}
 			value *= statsFinal.charSubstatRarityMod[idxChar]
-			finalString += fmt.Sprintf(" %v=%.6g", attributes.StatTypeString[idxSubstat], value*float64(statsFinal.fixedSubstatCount+statsFinal.charSubstatFinal[idxChar][idxSubstat]))
+			if o.optionsMap["show_substat_scalars"] > 0 {
+				finalString += fmt.Sprintf(" %v=%.6g*%v", attributes.StatTypeString[idxSubstat], value, float64(statsFinal.fixedSubstatCount+statsFinal.charSubstatFinal[idxChar][idxSubstat]))
+			} else {
+				finalString += fmt.Sprintf(" %v=%.6g", attributes.StatTypeString[idxSubstat], value*float64(statsFinal.fixedSubstatCount+statsFinal.charSubstatFinal[idxChar][idxSubstat]))
+			}
 		}
 
 		fmt.Println(finalString + ";")

--- a/ui/packages/docs/docs/guides/substat_optimizer.md
+++ b/ui/packages/docs/docs/guides/substat_optimizer.md
@@ -175,6 +175,12 @@ This is due to gcsim:
 - modelling the actual particle rng (example: Fischl Oz) by running the config for many times.
 :::
 
+:::info
+In the resulting config, the optimizer will format substats by their scalars (e.g. `cr=0.0331*10 cd=0.0662*12`) by default.
+It is possible to disable this with `-options="show_substat_scalars=0"` to output the multiplied values like `cr=0.331 cd=0.7944` instead.
+Please refer to [this page](/reference/cli#additional-options-for-substat-optimizer--options) for more information.
+:::
+
 ## Verbose Output
 In the [Example](#example) above, if you also add the flag for verbose output:
 ```

--- a/ui/packages/docs/docs/reference/cli.md
+++ b/ui/packages/docs/docs/reference/cli.md
@@ -63,9 +63,10 @@ The option list has the following format: `<option>=<value>` with `;` as the sep
 | `indiv_liquid_cap` | Total liquid substats that can be assigned to a single substat. | 10 |  
 | `fixed_substats_count` | Amount of fixed substats that are assigned to all substats. | 2 |
 | `fine_tune` | 0 to disable and 1 to enable the fine-tune step. This step will compare ER vs DMG substats after having allocated all substats and cover when the initial ER heuristic fails due to not replacing `.<char>.burst.ready` with `.<char>.burst.ready && .<char>.energy == .<char>.energymax` in conditionals (Instead of `<char>`, put the name of the affected character). | 1 |
+| `show_substat_scalars` | 0 to disable and 1 to enable formatting substats by their scalars in the resulting config. | 1 |
 
 #### Example
 
 ```
-./gcsim.exe -c test.txt -s -substatOptimFull -options="total_liquid_substats=10;fixed_substats_count=4;fine_tune=0"
+./gcsim.exe -c test.txt -s -substatOptimFull -options="total_liquid_substats=10;fixed_substats_count=4;fine_tune=0;show_substat_scalars=0"
 ```


### PR DESCRIPTION
Causes the optimizer to write substats into its resulting config formatted with their scalar multiplied by their substat count like this:
```
mizuki add stats def%=0.062*2 def=19.68*2 hp=253.94*2 hp%=0.0496*2 atk=16.54*2 atk%=0.0496*12 er=0.0551*4 em=19.82*6 cr=0.0331*3 cd=0.0662*5;
furina add stats def%=0.062*2 def=19.68*2 hp=253.94*2 hp%=0.0496*4 atk=16.54*2 atk%=0.0496*2 er=0.0551*2 em=19.82*2 cr=0.0331*12 cd=0.0662*10;
fischl add stats def%=0.062*2 def=19.68*2 hp=253.94*2 hp%=0.0496*2 atk=16.54*2 atk%=0.0496*4 er=0.0551*2 em=19.82*2 cr=0.0331*10 cd=0.0662*12;
xilonen add stats def%=0.062*10 def=19.68*2 hp=253.94*2 hp%=0.0496*2 atk=16.54*2 atk%=0.0496*2 er=0.0551*2 em=19.82*2 cr=0.0331*10 cd=0.0662*6;
```
-options="show_substat_scalars=0" will use the previous formatting.