### PR TITLE
add sucrose walk cancels

### DIFF
--- a/internal/characters/sucrose/attack.go
+++ b/internal/characters/sucrose/attack.go
@@ -36,6 +36,7 @@ func init() {
 
 	attackFrames[3] = frames.InitNormalCancelSlice(attackHitmarks[2], 65) // walk
 	attackFrames[3][action.ActionAttack] = 51
+	attackFrames[3][action.ActionCharge] = 54
 }
 
 func (c *char) Attack(p map[string]int) (action.Info, error) {

--- a/internal/characters/sucrose/attack.go
+++ b/internal/characters/sucrose/attack.go
@@ -24,6 +24,7 @@ func init() {
 	// TODO: check if hitmarks for NA->CA and CA->CA lines up
 	attackFrames[0] = frames.InitNormalCancelSlice(attackHitmarks[0], 28) // walk
 	attackFrames[0][action.ActionAttack] = 17
+	attackFrames[0][action.ActionCharge] = 20
 
 	attackFrames[1] = frames.InitNormalCancelSlice(attackHitmarks[1], 38) // walk
 	attackFrames[1][action.ActionAttack] = 26

--- a/internal/characters/sucrose/attack.go
+++ b/internal/characters/sucrose/attack.go
@@ -22,16 +22,18 @@ func init() {
 	attackFrames = make([][]int, normalHitNum)
 
 	// TODO: check if hitmarks for NA->CA and CA->CA lines up
-	attackFrames[0] = frames.InitNormalCancelSlice(attackHitmarks[0], 20)
+	attackFrames[0] = frames.InitNormalCancelSlice(attackHitmarks[0], 28) // walk
 	attackFrames[0][action.ActionAttack] = 17
 
-	attackFrames[1] = frames.InitNormalCancelSlice(attackHitmarks[1], 26)
+	attackFrames[1] = frames.InitNormalCancelSlice(attackHitmarks[1], 38) // walk
+	attackFrames[1][action.ActionAttack] = 26
 	attackFrames[1][action.ActionCharge] = 18
 
-	attackFrames[2] = frames.InitNormalCancelSlice(attackHitmarks[2], 33)
+	attackFrames[2] = frames.InitNormalCancelSlice(attackHitmarks[2], 46) // walk
+	attackFrames[2][action.ActionAttack] = 33
 	attackFrames[2][action.ActionCharge] = 28
 
-	attackFrames[3] = frames.InitNormalCancelSlice(attackHitmarks[2], 54)
+	attackFrames[3] = frames.InitNormalCancelSlice(attackHitmarks[2], 65) // walk
 	attackFrames[3][action.ActionAttack] = 51
 }
 

--- a/internal/characters/sucrose/burst.go
+++ b/internal/characters/sucrose/burst.go
@@ -13,7 +13,8 @@ import (
 var burstFrames []int
 
 func init() {
-	burstFrames = frames.InitAbilSlice(49)
+	burstFrames = frames.InitAbilSlice(65) // walk
+	burstFrames[action.ActionAttack] = 49
 	burstFrames[action.ActionCharge] = 48
 	burstFrames[action.ActionSkill] = 48
 	burstFrames[action.ActionDash] = 47

--- a/internal/characters/sucrose/charge.go
+++ b/internal/characters/sucrose/charge.go
@@ -15,7 +15,8 @@ var chargeFrames []int
 const chargeHitmark = 54
 
 func init() {
-	chargeFrames = frames.InitAbilSlice(69)
+	chargeFrames = frames.InitAbilSlice(71) // walk
+	chargeFrames[action.ActionAttack] = 69
 	chargeFrames[action.ActionCharge] = 66
 	chargeFrames[action.ActionSkill] = 60
 	chargeFrames[action.ActionBurst] = 61

--- a/internal/characters/sucrose/skill.go
+++ b/internal/characters/sucrose/skill.go
@@ -15,7 +15,8 @@ var skillFrames []int
 const particleICDKey = "sucrose-particle-icd"
 
 func init() {
-	skillFrames = frames.InitAbilSlice(57)
+	skillFrames = frames.InitAbilSlice(68) // walk
+	skillFrames[action.ActionAttack] = 57
 	skillFrames[action.ActionCharge] = 56
 	skillFrames[action.ActionSkill] = 56
 	skillFrames[action.ActionDash] = 11

--- a/internal/characters/sucrose/skill.go
+++ b/internal/characters/sucrose/skill.go
@@ -19,6 +19,7 @@ func init() {
 	skillFrames[action.ActionAttack] = 57
 	skillFrames[action.ActionCharge] = 56
 	skillFrames[action.ActionSkill] = 56
+	skillFrames[action.ActionBurst] = 57
 	skillFrames[action.ActionDash] = 11
 	skillFrames[action.ActionJump] = 11
 	skillFrames[action.ActionSwap] = 56

--- a/ui/packages/docs/src/components/Actions/character_data.json
+++ b/ui/packages/docs/src/components/Actions/character_data.json
@@ -2713,7 +2713,7 @@
     },
     {
       "ability": "walk",
-      "notes": "No action followed by walk (except low_plunge and high_plunge) has proper frames."
+      "legal": true
     },
     {
       "ability": "swap",

--- a/ui/packages/docs/src/components/Frames/character_data.json
+++ b/ui/packages/docs/src/components/Frames/character_data.json
@@ -1305,6 +1305,12 @@
       "count_credit": "kolibri._.",
       "vid": "https://youtu.be/3ah-MfdDfis",
       "count": "https://docs.google.com/spreadsheets/d/16ZDmEBZOD4xeUcodxFJVuLC7IIqM9LGLilkct65mElg/edit?usp=sharing"
+    },
+    {
+      "vid_credit": "soloxcx",
+      "count_credit": "soloxcx",
+      "vid": "https://youtu.be/zCuAAX2FUTE",
+      "count": "https://docs.google.com/spreadsheets/d/1w2kx5-gLYqyuxYisKb5gnOfA-jsM1VdpCWv04aJVcIY/edit?usp=sharing"
     }
   ],
   "tartaglia": [


### PR DESCRIPTION
Video https://youtu.be/zCuAAX2FUTE
Counts https://docs.google.com/spreadsheets/d/1w2kx5-gLYqyuxYisKb5gnOfA-jsM1VdpCWv04aJVcIY/edit?usp=sharing

[dbcompare.txt](https://github.com/user-attachments/files/20765912/dbcompare.txt)

A handful of configs were erroneously using walk cancels in the db so they will take a damage hit, particularly this one loses ~13% dps <https://gcsim.app/db/r7kCdHHm9kpq>
