### PR TITLE
Fix go mod to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/genshinsim/gcsim
 
-go 1.22
+go 1.22.0
 
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 


### PR DESCRIPTION
on windows/x86_64, go doesn't run after updating to 1.22.

```
go: downloading go1.22 (windows/amd64)
go: download go1.22 for windows/amd64: toolchain not available
```
per https://github.com/golang/go/issues/65568, changing to 1.22.0 fixes the issue.