### PR TITLE
Skirk c2 fix

### DIFF
--- a/internal/characters/skirk/burst.go
+++ b/internal/characters/skirk/burst.go
@@ -125,7 +125,14 @@ func (c *char) BurstInit() {
 func (c *char) BurstExtinction(p map[string]int) (action.Info, error) {
 	c.AddStatus(burstExtinctKey, 12.5*60, false)
 	c.burstCount = 10
-	c.burstVoids = c.absorbVoidRift()
+
+	// absorb void rifts constantly during the burst animation
+	for i := range burstSkillFrames[action.ActionAttack] {
+		c.QueueCharTask(func() {
+			c.burstVoids += c.absorbVoidRift()
+			c.burstVoids = min(c.burstVoids, 3)
+		}, i)
+	}
 
 	c.c2OnBurstExtinction()
 	c.SetCDWithDelay(action.ActionBurst, 15*60, 0)

--- a/internal/characters/skirk/cons.go
+++ b/internal/characters/skirk/cons.go
@@ -66,17 +66,19 @@ func (c *char) c2OnBurstExtinction() {
 	if c.Base.Cons < 2 {
 		return
 	}
-
-	c.AddStatMod(character.StatMod{
-		Base:         modifier.NewBase(c2Key, 12.5*60),
-		AffectedStat: attributes.ATKP,
-		Amount: func() ([]float64, bool) {
-			if !c.StatusIsActive(skillKey) {
-				return nil, false
-			}
-			return c.c2Atk, true
-		},
-	})
+	// delay buff to the end of burst. c1 hits from burst don't benefit from c2
+	c.QueueCharTask(func() {
+		c.AddStatMod(character.StatMod{
+			Base:         modifier.NewBase(c2Key, 12.5*60),
+			AffectedStat: attributes.ATKP,
+			Amount: func() ([]float64, bool) {
+				if !c.StatusIsActive(skillKey) {
+					return nil, false
+				}
+				return c.c2Atk, true
+			},
+		})
+	}, 39)
 }
 
 func (c *char) c4Init() {


### PR DESCRIPTION
From Cronkhinator on Discord:

On gcsim, the 70% ATK Skirk gets from using her mini burst also applies to the Void Rifts absorbed by that burst.
This does not happen ingame. Ingame, any Void Rifts absorbed by using her mini burst do not benefit from the 70% ATK buff.
I have compared the damage numbers ingame to what optimizer is giving me, and have confirmed that the damage caused by a C1 proc by her burst is missing exactly 70% ATK.

Here is a link to my gcsim config:
https://gcsim.app/sh/h8JwLmPjfcfw

I have also uploaded a video to google drive showing ingame behavior.
You can see the two void rifts absorbed by her burst hitting for 39640 damage, while the one absorbed by her charged attack a few seconds later hits for 49545 damage.
https://drive.google.com/file/d/1FsTRwRUaqQQ8W6gdOfHhGkD3jVpshprZ/view?usp=sharing