### PR TITLE
Adjusted hE/eQ void rift absorb 

### DIFF
--- a/internal/characters/skirk/asc.go
+++ b/internal/characters/skirk/asc.go
@@ -43,18 +43,23 @@ func (c *char) absorbVoidRiftCB(a combat.AttackCB) {
 	if a.Target.Type() != targets.TargettableEnemy {
 		return
 	}
-	c.absorbVoidRift()
+	c.absorbVoidRifts()
 }
 
-func (c *char) absorbVoidRift() int {
+func (c *char) absorbVoidRifts() int {
 	filter := func(src int) bool {
 		return src+a1Dur >= c.Core.F
 	}
 	count := c.voidRifts.Count(filter)
 	c.voidRifts.Clear()
 
+	c.onVoidAbsorb(count)
+	return count
+}
+
+func (c *char) onVoidAbsorb(count int) {
 	if count <= 0 {
-		return 0
+		return
 	}
 
 	c.AddSerpentsSubtlety("a1-void-rifts", float64(count)*8.0)
@@ -63,10 +68,13 @@ func (c *char) absorbVoidRift() int {
 		c.c1()
 		c.c6OnVoidAbsorb()
 	}
-	return count
 }
 
 func (c *char) createVoidRift() {
+	// absorb the rift immediately if currently in the E-Burst animation
+	if c.StatusIsActive(absorbRiftAnimKey) {
+		c.onVoidAbsorb(1)
+	}
 	c.voidRifts.Push(c.Core.F)
 }
 

--- a/internal/characters/skirk/asc.go
+++ b/internal/characters/skirk/asc.go
@@ -71,9 +71,13 @@ func (c *char) onVoidAbsorb(count int) {
 }
 
 func (c *char) createVoidRift() {
-	// absorb the rift immediately if currently in the E-Burst animation
-	if c.StatusIsActive(absorbRiftAnimKey) {
+	// absorb the rift immediately if currently in the hE/ or E-Burst animation
+	if c.StatusIsActive(skillAbsorbRiftAnimKey) {
 		c.onVoidAbsorb(1)
+	}
+	if c.StatusIsActive(burstAbsorbRiftAnimKey) {
+		c.onVoidAbsorb(1)
+		c.burstVoids = min(c.burstVoids+1, 3)
 	}
 	c.voidRifts.Push(c.Core.F)
 }

--- a/internal/characters/skirk/burst.go
+++ b/internal/characters/skirk/burst.go
@@ -128,7 +128,7 @@ func (c *char) BurstExtinction(p map[string]int) (action.Info, error) {
 	c.burstCount = 10
 	c.burstVoids = c.absorbVoidRifts()
 	// status used to absorb void rifts constantly during the burst animation
-	c.AddStatus(burstAbsorbRiftAnimKey, 39, true)
+	c.AddStatus(burstAbsorbRiftAnimKey, burstSkillFrames[action.InvalidAction], true)
 
 	c.c2OnBurstExtinction()
 	c.SetCDWithDelay(action.ActionBurst, 15*60, 0)
@@ -138,5 +138,6 @@ func (c *char) BurstExtinction(p map[string]int) (action.Info, error) {
 		AnimationLength: burstSkillFrames[action.InvalidAction],
 		CanQueueAfter:   burstSkillFrames[action.ActionAttack], // earliest cancel
 		State:           action.BurstState,
+		OnRemoved:       func(next action.AnimationState) { c.DeleteStatus(burstAbsorbRiftAnimKey) },
 	}, nil
 }

--- a/internal/characters/skirk/burst.go
+++ b/internal/characters/skirk/burst.go
@@ -16,10 +16,11 @@ var burstSkillFrames []int
 var burstHitmarks = []int{109, 109 + 2, 109 + 2 + 3, 109 + 2 + 3 + 11, 109 + 2 + 3 + 11 + 10}
 
 const (
-	burstHitmarkFinal = 109 + 2 + 3 + 11 + 10 + 23
-	burstExtinctKey   = "skirk-burst-extinction"
-	burstRuinKey      = "skirk-burst-ruin"
-	burstICDKey       = "skirk-burst-extinction-icd"
+	burstHitmarkFinal      = 109 + 2 + 3 + 11 + 10 + 23
+	burstExtinctKey        = "skirk-burst-extinction"
+	burstRuinKey           = "skirk-burst-ruin"
+	burstICDKey            = "skirk-burst-extinction-icd"
+	burstAbsorbRiftAnimKey = "skirk-burst-extinction-anim"
 )
 
 func init() {
@@ -127,7 +128,7 @@ func (c *char) BurstExtinction(p map[string]int) (action.Info, error) {
 	c.burstCount = 10
 	c.burstVoids = c.absorbVoidRifts()
 	// status used to absorb void rifts constantly during the burst animation
-	c.AddStatus(absorbRiftAnimKey, 39, true)
+	c.AddStatus(burstAbsorbRiftAnimKey, 39, true)
 
 	c.c2OnBurstExtinction()
 	c.SetCDWithDelay(action.ActionBurst, 15*60, 0)

--- a/internal/characters/skirk/burst.go
+++ b/internal/characters/skirk/burst.go
@@ -125,14 +125,9 @@ func (c *char) BurstInit() {
 func (c *char) BurstExtinction(p map[string]int) (action.Info, error) {
 	c.AddStatus(burstExtinctKey, 12.5*60, false)
 	c.burstCount = 10
-
-	// absorb void rifts constantly during the burst animation
-	for i := range burstSkillFrames[action.ActionAttack] {
-		c.QueueCharTask(func() {
-			c.burstVoids += c.absorbVoidRift()
-			c.burstVoids = min(c.burstVoids, 3)
-		}, i)
-	}
+	c.burstVoids = c.absorbVoidRifts()
+	// status used to absorb void rifts constantly during the burst animation
+	c.AddStatus(absorbRiftAnimKey, 39, true)
 
 	c.c2OnBurstExtinction()
 	c.SetCDWithDelay(action.ActionBurst, 15*60, 0)

--- a/internal/characters/skirk/skill.go
+++ b/internal/characters/skirk/skill.go
@@ -24,6 +24,7 @@ const (
 	particleICD         = 15 * 60
 	particleICDKey      = "skirk-particle-icd"
 	skillHoldGainSS     = 18
+	absorbRiftAnimKey   = "absorb-rift-anim"
 )
 
 func init() {
@@ -107,13 +108,11 @@ func (c *char) skillHold(p map[string]int) (action.Info, error) {
 	c.QueueCharTask(func() {
 		c.AddSerpentsSubtlety(c.Base.Key.String()+"-skill-hold", 45.0)
 		c.c2OnSkill()
-		c.absorbVoidRift()
+		c.absorbVoidRifts()
 	}, skillHoldGainSS)
 
-	for i := range extraDuration {
-		// absorb void rifts constantly
-		c.QueueCharTask(func() { c.absorbVoidRift() }, skillHoldGainSS+i+1)
-	}
+	// status used to absorb void rifts constantly during the hold E animation
+	c.AddStatus(absorbRiftAnimKey, extraDuration, true)
 
 	c.SetCDWithDelay(action.ActionSkill, 8*60, extraDuration+skillHoldGainSS)
 

--- a/internal/characters/skirk/skill.go
+++ b/internal/characters/skirk/skill.go
@@ -16,15 +16,15 @@ var skillFrames []int
 var skillHoldFrames []int
 
 const (
-	maxSerpentsSubtlety = 100
-	skillGainSS         = 25
-	skillKey            = "seven-phase-flash"
-	skillDelay          = 19
-	skillDur            = 754
-	particleICD         = 15 * 60
-	particleICDKey      = "skirk-particle-icd"
-	skillHoldGainSS     = 18
-	absorbRiftAnimKey   = "absorb-rift-anim"
+	maxSerpentsSubtlety    = 100
+	skillGainSS            = 25
+	skillKey               = "seven-phase-flash"
+	skillDelay             = 19
+	skillDur               = 754
+	particleICD            = 15 * 60
+	particleICDKey         = "skirk-particle-icd"
+	skillHoldGainSS        = 18
+	skillAbsorbRiftAnimKey = "skirk-hold-e-anim"
 )
 
 func init() {
@@ -112,7 +112,7 @@ func (c *char) skillHold(p map[string]int) (action.Info, error) {
 	}, skillHoldGainSS)
 
 	// status used to absorb void rifts constantly during the hold E animation
-	c.AddStatus(absorbRiftAnimKey, extraDuration, true)
+	c.AddStatus(skillAbsorbRiftAnimKey, extraDuration, true)
 
 	c.SetCDWithDelay(action.ActionSkill, 8*60, extraDuration+skillHoldGainSS)
 


### PR DESCRIPTION
Void rift absorb triggers immediately when a void generated during animation of hE or eQ