### PR TITLE
Fixed Ororon c6 buff application

### DIFF
--- a/internal/characters/ororon/cons.go
+++ b/internal/characters/ororon/cons.go
@@ -147,8 +147,11 @@ func (c *char) c6onHypersense() {
 		char.AddStatMod(character.StatMod{
 			Base: modifier.NewBaseWithHitlag(c6Key, 9*60),
 			Amount: func() ([]float64, bool) {
+				if c.Core.Player.Active() != char.Index {
+					return nil, false
+				}
 				c.c6bonus[attributes.ATKP] = float64(c.c6stacks.Count()) * 0.1
-				return c.c6bonus, c.Core.Player.Active() == char.Index
+				return c.c6bonus, true
 			},
 		})
 	}

--- a/internal/characters/ororon/cons.go
+++ b/internal/characters/ororon/cons.go
@@ -143,6 +143,7 @@ func (c *char) c6onHypersense() {
 
 	c.c6stacks.Add(9 * 60)
 
+	// TODO: Is this buff hitlag affected per character? Or is it hitlag affected on Ororon only?
 	for _, char := range c.Core.Player.Chars() {
 		char.AddStatMod(character.StatMod{
 			Base: modifier.NewBaseWithHitlag(c6Key, 9*60),

--- a/internal/characters/ororon/cons.go
+++ b/internal/characters/ororon/cons.go
@@ -140,13 +140,16 @@ func (c *char) c6onHypersense() {
 	if c.Base.Ascension < 1 {
 		return
 	}
-	active := c.Core.Player.ActiveChar()
+
 	c.c6stacks.Add(9 * 60)
-	active.AddStatMod(character.StatMod{
-		Base: modifier.NewBaseWithHitlag(c6Key, 9*60),
-		Amount: func() ([]float64, bool) {
-			c.c6bonus[attributes.ATKP] = float64(c.c6stacks.Count()) * 0.1
-			return c.c6bonus, true
-		},
-	})
+
+	for _, char := range c.Core.Player.Chars() {
+		char.AddStatMod(character.StatMod{
+			Base: modifier.NewBaseWithHitlag(c6Key, 9*60),
+			Amount: func() ([]float64, bool) {
+				c.c6bonus[attributes.ATKP] = float64(c.c6stacks.Count()) * 0.1
+				return c.c6bonus, c.Core.Player.Active() == char.Index
+			},
+		})
+	}
 }


### PR DESCRIPTION
https://discord.com/channels/845087716541595668/1410785446237175818/1410785446237175818

> The buff is only for the current active unit. The sim has the buff persist for the unit that swapped off and needs Ororon’s passive to proc for it to be applied to the new onfielder.
 https://gcsim.app/db/MjnNK8gfdPnL



