### PR TITLE
Fix Substat Optimizer Energy Data

### DIFF
--- a/pkg/core/player/character/energy.go
+++ b/pkg/core/player/character/energy.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *CharWrapper) ConsumeEnergy(delay int) {
-	c.ConsumeEnergyPartial(delay, c.Energy)
+	c.ConsumeEnergyPartial(delay, c.EnergyMax)
 }
 
 func (c *CharWrapper) ConsumeEnergyPartial(delay int, amount float64) {


### PR DESCRIPTION
Fix how the BurstEnergy event emits consumed energy when IgnoreBurstEnergy flag is on