### PR TITLE
fix generating ns for pyro mc

### DIFF
--- a/internal/characters/traveler/common/pyro/skill.go
+++ b/internal/characters/traveler/common/pyro/skill.go
@@ -251,7 +251,7 @@ func (c *Traveler) particleCB(a combat.AttackCB) {
 
 func (c *Traveler) enterNightsoul(src int) {
 	c.nightsoulSrc = src
-	c.nightsoulState.EnterTimedBlessing(42, 12*60, c.exitNightsoul)
+	c.nightsoulState.EnterTimedBlessing(c.nightsoulState.Points()+42, 12*60, c.exitNightsoul)
 	c.QueueCharTask(c.nightsoulPointReduceFunc(c.nightsoulSrc), nightsoulReduceDelay)
 }
 


### PR DESCRIPTION
skill resets nightsoul points instead of adding them https://discord.com/channels/845087716541595668/1413255472525348885/1413255472525348885