### PR TITLE
Abil name cleanup

### DIFF
--- a/internal/characters/albedo/asc.go
+++ b/internal/characters/albedo/asc.go
@@ -27,7 +27,7 @@ func (c *char) a1() {
 				return nil, false
 			}
 			// Can't be triggered by itself when refreshing
-			if atk.Info.Abil == "Abiogenesis: Solar Isotoma" {
+			if atk.Info.Abil == skillAbil {
 				return nil, false
 			}
 			if e, ok := t.(*enemy.Enemy); !(ok && e.HP()/e.MaxHP() < .5) {

--- a/internal/characters/albedo/asc.go
+++ b/internal/characters/albedo/asc.go
@@ -27,7 +27,7 @@ func (c *char) a1() {
 				return nil, false
 			}
 			// Can't be triggered by itself when refreshing
-			if atk.Info.Abil == skillAbil {
+			if atk.Info.Abil == skillAbilInitial {
 				return nil, false
 			}
 			if e, ok := t.(*enemy.Enemy); !(ok && e.HP()/e.MaxHP() < .5) {

--- a/internal/characters/albedo/skill.go
+++ b/internal/characters/albedo/skill.go
@@ -24,16 +24,16 @@ func init() {
 }
 
 const (
-	skillICDKey    = "albedo-skill-icd"
-	particleICDKey = "albedo-particle-icd"
-	skillAbil      = "Abiogenesis: Solar Isotoma"
-	skillAbilTick  = "Abiogenesis: Solar Isotoma (Tick)"
+	skillICDKey      = "albedo-skill-icd"
+	particleICDKey   = "albedo-particle-icd"
+	skillAbilInitial = "Abiogenesis: Solar Isotoma (Initial)"
+	skillAbilTick    = "Abiogenesis: Solar Isotoma (Tick)"
 )
 
 func (c *char) Skill(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       skillAbil,
+		Abil:       skillAbilInitial,
 		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,
@@ -114,7 +114,7 @@ func (c *char) skillHook() {
 			return false
 		}
 		// Can't be triggered by itself when refreshing
-		if atk.Info.Abil == skillAbil {
+		if atk.Info.Abil == skillAbilInitial {
 			return false
 		}
 		if dmg == 0 {

--- a/internal/characters/albedo/skill.go
+++ b/internal/characters/albedo/skill.go
@@ -26,12 +26,14 @@ func init() {
 const (
 	skillICDKey    = "albedo-skill-icd"
 	particleICDKey = "albedo-particle-icd"
+	skillAbil      = "Abiogenesis: Solar Isotoma"
+	skillAbilTick  = "Abiogenesis: Solar Isotoma (Tick)"
 )
 
 func (c *char) Skill(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Abiogenesis: Solar Isotoma",
+		Abil:       skillAbil,
 		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,
@@ -53,7 +55,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	c.Core.QueueAttackWithSnap(ai, c.bloomSnapshot, combat.NewCircleHitOnTarget(skillPos, nil, 5), skillHitmark)
 
 	// snapshot for ticks
-	ai.Abil = "Abiogenesis: Solar Isotoma (Tick)"
+	ai.Abil = skillAbilTick
 	ai.ICDTag = attacks.ICDTagElementalArt
 	ai.Mult = skillTick[c.TalentLvlSkill()]
 	ai.UseDef = true
@@ -112,7 +114,7 @@ func (c *char) skillHook() {
 			return false
 		}
 		// Can't be triggered by itself when refreshing
-		if atk.Info.Abil == "Abiogenesis: Solar Isotoma" {
+		if atk.Info.Abil == skillAbil {
 			return false
 		}
 		if dmg == 0 {

--- a/internal/characters/ayaka/burst.go
+++ b/internal/characters/ayaka/burst.go
@@ -54,7 +54,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	if c.Base.Cons >= 2 {
 		aiC2 = ai
 		aiC2.Mult = burstBloom[c.TalentLvlBurst()] * .2
-		aiC2.Abil = "C2 Mini-Frostflake Seki no To (Bloom)"
+		aiC2.Abil = "Mini-Frostflake Seki no To (Bloom) (C2)"
 		// TODO: Not sure about the positioning/size...
 		for range 2 {
 			c.Core.QueueAttack(
@@ -93,7 +93,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 		if c.Base.Cons >= 2 {
 			aiC2.Mult = burstCut[c.TalentLvlBurst()] * .2
 			aiC2.StrikeType = attacks.StrikeTypeSlash
-			aiC2.Abil = "C2 Mini-Frostflake Seki no To (Cutting)"
+			aiC2.Abil = "Mini-Frostflake Seki no To (Cutting) (C2)"
 			// TODO: Not sure about the positioning/size...
 			for range 2 {
 				c.Core.QueueAttack(

--- a/internal/characters/baizhu/cons.go
+++ b/internal/characters/baizhu/cons.go
@@ -35,7 +35,7 @@ func (c *char) c2() {
 		}
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Gossamer Sprite: Splice. (Baizhu's C2)",
+			Abil:       "Gossamer Sprite: Splice. (C2)",
 			AttackTag:  attacks.AttackTagElementalArt,
 			ICDTag:     attacks.ICDTagElementalArt,
 			ICDGroup:   attacks.ICDGroupBaizhuC2,

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -16,11 +16,9 @@ import (
 var burstFrames []int
 
 const (
-	burstHitmark     = 28
-	burstKey         = "beidouburst"
-	burstICDKey      = "beidou-burst-icd"
-	burstInitialAbil = "Stormbreaker (Initial)"
-	burstBounceAbil  = "Stormbreaker (Bounce)"
+	burstHitmark = 28
+	burstKey     = "beidouburst"
+	burstICDKey  = "beidou-burst-icd"
 )
 
 func init() {
@@ -34,7 +32,7 @@ func init() {
 func (c *char) Burst(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               burstInitialAbil,
+		Abil:               "Stormbreaker (Initial)",
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,
@@ -59,7 +57,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 
 	procAI := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       burstBounceAbil,
+		Abil:       "Stormbreaker (Bounce)",
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagElementalBurst,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -32,7 +32,7 @@ func init() {
 func (c *char) Burst(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Stormbreaker (Q)",
+		Abil:               "Stormbreaker Initial",
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,
@@ -57,7 +57,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 
 	procAI := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Stormbreak Proc (Q)",
+		Abil:       "Stormbreaker Bounce",
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagElementalBurst,
 		ICDGroup:   attacks.ICDGroupDefault,
@@ -79,7 +79,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 			Target:     -1,
 			Src:        c.Core.F,
 			ShieldType: shield.BeidouC1,
-			Name:       "Beidou C1",
+			Name:       "Sea Beast's Scourge (Shield)",
 			HP:         .16 * c.MaxHP(),
 			Ele:        attributes.Electro,
 			Expires:    c.Core.F + dur,

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -32,7 +32,7 @@ func init() {
 func (c *char) Burst(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Stormbreaker Initial",
+		Abil:               "Stormbreaker (Initial)",
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,
@@ -57,7 +57,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 
 	procAI := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Stormbreaker Bounce",
+		Abil:       "Stormbreaker (Bounce)",
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagElementalBurst,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/beidou/burst.go
+++ b/internal/characters/beidou/burst.go
@@ -16,9 +16,11 @@ import (
 var burstFrames []int
 
 const (
-	burstHitmark = 28
-	burstKey     = "beidouburst"
-	burstICDKey  = "beidou-burst-icd"
+	burstHitmark     = 28
+	burstKey         = "beidouburst"
+	burstICDKey      = "beidou-burst-icd"
+	burstInitialAbil = "Stormbreaker (Initial)"
+	burstBounceAbil  = "Stormbreaker (Bounce)"
 )
 
 func init() {
@@ -32,7 +34,7 @@ func init() {
 func (c *char) Burst(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Stormbreaker (Initial)",
+		Abil:               burstInitialAbil,
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,
@@ -57,7 +59,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 
 	procAI := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Stormbreaker (Bounce)",
+		Abil:       burstBounceAbil,
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagElementalBurst,
 		ICDGroup:   attacks.ICDGroupDefault,
@@ -128,7 +130,7 @@ func (c *char) burstProc() {
 			return false
 		}
 		if c.StatusIsActive(burstICDKey) {
-			c.Core.Log.NewEvent("beidou Q (active) on icd", glog.LogCharacterEvent, c.Index())
+			c.Core.Log.NewEvent("Stormbreaker (active) on icd", glog.LogCharacterEvent, c.Index())
 			return false
 		}
 
@@ -142,7 +144,7 @@ func (c *char) burstProc() {
 		}
 		c.Core.QueueAttackEvent(&atk, 1)
 
-		c.Core.Log.NewEvent("beidou Q proc'd", glog.LogCharacterEvent, c.Index()).
+		c.Core.Log.NewEvent("Stormbreaker bounce triggered", glog.LogCharacterEvent, c.Index()).
 			Write("char", ae.Info.ActorIndex).
 			Write("attack tag", ae.Info.AttackTag)
 

--- a/internal/characters/beidou/cons.go
+++ b/internal/characters/beidou/cons.go
@@ -47,7 +47,7 @@ func (c *char) makeC4Callback() info.AttackCBFunc {
 			Write("char", c.Index())
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Beidou C4",
+			Abil:       "Stunning Revenge (C4)",
 			AttackTag:  attacks.AttackTagNone,
 			ICDTag:     attacks.ICDTagElementalBurst,
 			ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/beidou/skill.go
+++ b/internal/characters/beidou/skill.go
@@ -39,7 +39,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Tidecaller (E)",
+		Abil:               "Tidecaller",
 		AttackTag:          attacks.AttackTagElementalArt,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,
@@ -66,7 +66,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 		Target:     c.Index(),
 		Src:        c.Core.F,
 		ShieldType: shield.BeidouThunderShield,
-		Name:       "Beidou Skill",
+		Name:       "Tidecaller (Shield)",
 		HP:         shieldPer[c.TalentLvlSkill()]*c.MaxHP() + shieldBase[c.TalentLvlSkill()],
 		Ele:        attributes.Electro,
 		Expires:    c.Core.F + skillHitmark, // last until hitmark

--- a/internal/characters/candace/burst.go
+++ b/internal/characters/candace/burst.go
@@ -33,7 +33,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	c.waveCount = 0
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Sacred Rite: Wagtail's Tide (Q)",
+		Abil:               "Sacred Rite: Wagtail's Tide (Initial)",
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/candace/skill.go
+++ b/internal/characters/candace/skill.go
@@ -45,7 +45,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Sacred Rite: Heron's Sanctum (E)",
+		Abil:               "Sacred Rite: Heron's Sanctum",
 		AttackTag:          attacks.AttackTagElementalArt,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,
@@ -73,7 +73,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 		particleCount = 2
 	case 1:
 		ai.PoiseDMG = 300
-		ai.Abil = "Sacred Rite: Heron's Sanctum Charged Up (E)"
+		ai.Abil = "Sacred Rite: Heron's Sanctum (Charged)"
 		ap = combat.NewCircleHitOnTarget(
 			c.Core.Combat.Player(),
 			info.Point{Y: skillOffsets[chargeLevel]},
@@ -100,7 +100,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 		ActorIndex: c.Index(),
 		Target:     c.Index(),
 		Src:        c.Core.F,
-		Name:       "Candace Skill",
+		Name:       "Sacred Rite: Heron's Sanctum (Shield)",
 		ShieldType: shield.CandaceSkill,
 		HP:         skillShieldPct[c.TalentLvlSkill()]*c.MaxHP() + skillShieldFlat[c.TalentLvlSkill()],
 		Ele:        attributes.Hydro,

--- a/internal/characters/charlotte/cons.go
+++ b/internal/characters/charlotte/cons.go
@@ -16,7 +16,7 @@ const (
 	c1StatusKey     = "charlotte-c1"
 	c1HealMsg       = "Verification"
 	c6HealMsg       = "charlotte-c6-heal"
-	c6CoordinateAtk = "charlotte-c6-coordinate-atk"
+	c6CoordinateAtk = "A Summation of Interest (C6)"
 	c6IcdKey        = "charlotte-c6-icd"
 	c6AttackRadius  = 3.5
 	c6HealRadius    = 5

--- a/internal/characters/charlotte/cons.go
+++ b/internal/characters/charlotte/cons.go
@@ -13,13 +13,12 @@ import (
 )
 
 const (
-	c1StatusKey     = "charlotte-c1"
-	c1HealMsg       = "Verification"
-	c6HealMsg       = "charlotte-c6-heal"
-	c6CoordinateAtk = "A Summation of Interest (C6)"
-	c6IcdKey        = "charlotte-c6-icd"
-	c6AttackRadius  = 3.5
-	c6HealRadius    = 5
+	c1StatusKey    = "charlotte-c1"
+	c1HealMsg      = "Verification"
+	c6HealMsg      = "charlotte-c6-heal"
+	c6IcdKey       = "charlotte-c6-icd"
+	c6AttackRadius = 3.5
+	c6HealRadius   = 5
 )
 
 func (c *char) c1Heal(char *character.CharWrapper) func() {
@@ -136,7 +135,7 @@ func (c *char) c6() {
 		c.AddStatus(c6IcdKey, 6*60, true)
 		ai := info.AttackInfo{
 			ActorIndex:         c.Index(),
-			Abil:               c6CoordinateAtk,
+			Abil:               "A Summation of Interest (C6)",
 			AttackTag:          attacks.AttackTagElementalBurst,
 			ICDTag:             attacks.ICDTagNone,
 			ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/citlali/shield.go
+++ b/internal/characters/citlali/shield.go
@@ -18,7 +18,7 @@ func (c *char) addShield() {
 			ActorIndex: c.Index(),
 			Target:     -1,
 			Src:        c.Core.F,
-			Name:       "Citalali Skill Shield",
+			Name:       "Dawnfrost Darkstar (Shield)",
 			ShieldType: shield.CitlaliSkill,
 			HP:         shieldHP,
 			Ele:        attributes.Cryo,

--- a/internal/characters/clorinde/burst.go
+++ b/internal/characters/clorinde/burst.go
@@ -34,7 +34,7 @@ func init() {
 func (c *char) Burst(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex:       c.Index(),
-		Abil:             "Burst",
+		Abil:             "Last Lightfall",
 		AttackTag:        attacks.AttackTagElementalBurst,
 		ICDTag:           attacks.ICDTagElementalBurst,
 		ICDGroup:         attacks.ICDGroupDefault,

--- a/internal/characters/cyno/plunge.go
+++ b/internal/characters/cyno/plunge.go
@@ -157,7 +157,7 @@ func (c *char) lowPlungeBXY(p map[string]int) action.Info {
 
 	ai := info.AttackInfo{
 		ActorIndex:     c.Index(),
-		Abil:           "Low Plunge (Q)",
+		Abil:           "Low Plunge (Burst)",
 		AttackTag:      attacks.AttackTagPlunge,
 		ICDTag:         attacks.ICDTagNone,
 		ICDGroup:       attacks.ICDGroupDefault,
@@ -248,7 +248,7 @@ func (c *char) highPlungeBXY(p map[string]int) action.Info {
 
 	ai := info.AttackInfo{
 		ActorIndex:     c.Index(),
-		Abil:           "High Plunge (Q)",
+		Abil:           "High Plunge (Burst)",
 		AttackTag:      attacks.AttackTagPlunge,
 		ICDTag:         attacks.ICDTagNone,
 		ICDGroup:       attacks.ICDGroupDefault,

--- a/internal/characters/cyno/plunge.go
+++ b/internal/characters/cyno/plunge.go
@@ -157,7 +157,7 @@ func (c *char) lowPlungeBXY(p map[string]int) action.Info {
 
 	ai := info.AttackInfo{
 		ActorIndex:     c.Index(),
-		Abil:           "Low Plunge (Burst)",
+		Abil:           "Low Plunge (Pactsworn Pathclearer)",
 		AttackTag:      attacks.AttackTagPlunge,
 		ICDTag:         attacks.ICDTagNone,
 		ICDGroup:       attacks.ICDGroupDefault,
@@ -248,7 +248,7 @@ func (c *char) highPlungeBXY(p map[string]int) action.Info {
 
 	ai := info.AttackInfo{
 		ActorIndex:     c.Index(),
-		Abil:           "High Plunge (Burst)",
+		Abil:           "High Plunge (Pactsworn Pathclearer)",
 		AttackTag:      attacks.AttackTagPlunge,
 		ICDTag:         attacks.ICDTagNone,
 		ICDGroup:       attacks.ICDGroupDefault,

--- a/internal/characters/diona/skill.go
+++ b/internal/characters/diona/skill.go
@@ -122,7 +122,7 @@ func (c *char) pawsPewPew(f, travel, pawCount int) {
 					Target:     -1,
 					Src:        c.Core.F,
 					ShieldType: shield.DionaSkill,
-					Name:       "Diona Skill",
+					Name:       "Icy Paws (Shield)",
 					HP:         shdHp,
 					Ele:        attributes.Cryo,
 					Expires:    c.Core.F + dur, // 15 sec

--- a/internal/characters/dori/cons.go
+++ b/internal/characters/dori/cons.go
@@ -19,7 +19,7 @@ func (c *char) c1() {
 func (c *char) c2(travel int) {
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Special Franchise",
+		Abil:       "Special Franchise (C2)",
 		AttackTag:  attacks.AttackTagNone,
 		ICDTag:     attacks.ICDTagDoriC2,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/emilie/asc.go
+++ b/internal/characters/emilie/asc.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	a1Abil   = "Cleardew Cologne (A1)"
 	a4ModKey = "emilie-a4"
 
 	a1Hitmark = 18
@@ -24,7 +25,7 @@ func (c *char) a1() {
 
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Cleardew Cologne (A1)",
+		Abil:       a1Abil,
 		AttackTag:  attacks.AttackTagNone,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/emilie/cons.go
+++ b/internal/characters/emilie/cons.go
@@ -67,7 +67,7 @@ func (c *char) c1A1() {
 	c.AddAttackMod(character.AttackMod{
 		Base: modifier.NewBase(c1ModKey, -1),
 		Amount: func(atk *info.AttackEvent, t info.Target) ([]float64, bool) {
-			if atk.Info.AttackTag != attacks.AttackTagElementalArt && atk.Info.Abil != "Cleardew Cologne (A1)" {
+			if atk.Info.AttackTag != attacks.AttackTagElementalArt && atk.Info.Abil != a1Abil {
 				return nil, false
 			}
 			return m, true

--- a/internal/characters/eula/burst.go
+++ b/internal/characters/eula/burst.go
@@ -14,8 +14,10 @@ import (
 var burstFrames []int
 
 const (
-	burstHitmark     = 100
-	lightfallHitmark = 35
+	burstHitmark       = 100
+	lightfallHitmark   = 35
+	burstInitialAbil   = "Glacial Illumination (Initial)"
+	burstLightfallAbil = "Glacial Illumination (Lightfall)"
 )
 
 func init() {
@@ -43,7 +45,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	// add initial damage
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Glacial Illumination",
+		Abil:       burstInitialAbil,
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,
@@ -98,7 +100,7 @@ func (c *char) triggerBurst() {
 	}
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Glacial Illumination (Lightfall)",
+		Abil:       burstLightfallAbil,
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/eula/cons.go
+++ b/internal/characters/eula/cons.go
@@ -15,7 +15,7 @@ func (c *char) c4() {
 		c.AddAttackMod(character.AttackMod{
 			Base: modifier.NewBase("eula-c4", -1),
 			Amount: func(atk *info.AttackEvent, t info.Target) ([]float64, bool) {
-				if atk.Info.Abil != "Glacial Illumination (Lightfall)" {
+				if atk.Info.Abil != burstInitialAbil {
 					return nil, false
 				}
 				if !c.Core.Combat.DamageMode {

--- a/internal/characters/faruzan/burst.go
+++ b/internal/characters/faruzan/burst.go
@@ -43,7 +43,7 @@ func init() {
 func (c *char) Burst(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "The Wind's Secret Ways (Q)",
+		Abil:       "The Wind's Secret Ways",
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/faruzan/skill.go
+++ b/internal/characters/faruzan/skill.go
@@ -44,7 +44,7 @@ func init() {
 func (c *char) Skill(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Wind Realm of Nasamjnin (E)",
+		Abil:       "Wind Realm of Nasamjnin",
 		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/fischl/asc.go
+++ b/internal/characters/fischl/asc.go
@@ -41,7 +41,7 @@ func (c *char) a4() {
 
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Fischl A4",
+			Abil:       "Thundering Retribution (A4)",
 			AttackTag:  attacks.AttackTagElementalArt,
 			ICDTag:     attacks.ICDTagNone,
 			ICDGroup:   attacks.ICDGroupFischl,

--- a/internal/characters/fischl/attack.go
+++ b/internal/characters/fischl/attack.go
@@ -63,7 +63,7 @@ func (c *char) Attack(p map[string]int) (action.Info, error) {
 	if c.Base.Cons >= 1 && !c.StatusIsActive(ozActiveKey) {
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Fischl C1",
+			Abil:       "Gaze of the Deep (C1)",
 			AttackTag:  attacks.AttackTagNormal,
 			ICDTag:     attacks.ICDTagNone,
 			ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/fischl/cons.go
+++ b/internal/characters/fischl/cons.go
@@ -10,7 +10,7 @@ import (
 func (c *char) c6Wave() {
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Fischl C6",
+		Abil:       "Evernight Raven (C6)",
 		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagElementalArt,
 		ICDGroup:   attacks.ICDGroupFischl,

--- a/internal/characters/gaming/burst.go
+++ b/internal/characters/gaming/burst.go
@@ -44,7 +44,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 		c.Core.Player.Heal(info.HealInfo{
 			Caller:  c.Index(),
 			Target:  c.Index(),
-			Message: "Suanni's Gilded Dance (Q)",
+			Message: "Suanni's Gilded Dance",
 			Type:    info.HealTypePercent,
 			Src:     0.3,
 			Bonus:   c.Stat(attributes.Heal),
@@ -55,7 +55,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Suanni's Gilded Dance (Q)",
+		Abil:       "Suanni's Gilded Dance",
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagElementalBurst,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/hutao/plunge.go
+++ b/internal/characters/hutao/plunge.go
@@ -142,7 +142,7 @@ func (c *char) lowPlungeBXY(p map[string]int) action.Info {
 
 	ai := info.AttackInfo{
 		ActorIndex:     c.Index(),
-		Abil:           "Low Plunge (E)",
+		Abil:           "Low Plunge (Paramita Papilio)",
 		AttackTag:      attacks.AttackTagPlunge,
 		ICDTag:         attacks.ICDTagNone,
 		ICDGroup:       attacks.ICDGroupDefault,
@@ -233,7 +233,7 @@ func (c *char) highPlungeBXY(p map[string]int) action.Info {
 
 	ai := info.AttackInfo{
 		ActorIndex:     c.Index(),
-		Abil:           "High Plunge (E)",
+		Abil:           "High Plunge (Paramita Papilio)",
 		AttackTag:      attacks.AttackTagPlunge,
 		ICDTag:         attacks.ICDTagNone,
 		ICDGroup:       attacks.ICDGroupDefault,

--- a/internal/characters/kaeya/cons.go
+++ b/internal/characters/kaeya/cons.go
@@ -92,7 +92,7 @@ func (c *char) c4() {
 				Target:     c.Index(),
 				Src:        c.Core.F,
 				ShieldType: shield.KaeyaC4,
-				Name:       "Kaeya C4",
+				Name:       "Frozen Kiss (Shield)",
 				HP:         .3 * maxhp,
 				Ele:        attributes.Cryo,
 				Expires:    c.Core.F + 1200,

--- a/internal/characters/kaveh/burst.go
+++ b/internal/characters/kaveh/burst.go
@@ -35,7 +35,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Painted Dome (Q)",
+		Abil:       "Painted Dome",
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/kaveh/skill.go
+++ b/internal/characters/kaveh/skill.go
@@ -29,7 +29,7 @@ func init() {
 
 func (c *char) Skill(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
-		Abil:       "Artistic Ingenuity (E)",
+		Abil:       "Artistic Ingenuity",
 		ActorIndex: c.Index(),
 		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagNone,

--- a/internal/characters/kazuha/burst.go
+++ b/internal/characters/kazuha/burst.go
@@ -50,7 +50,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	c.Core.QueueAttack(ai, ap, burstHitmark, burstHitmark)
 
 	// apply dot and check for absorb
-	ai.Abil = "Kazuha Slash (Dot)"
+	ai.Abil = "Kazuha Slash (DoT)"
 	ai.StrikeType = attacks.StrikeTypeDefault
 	ai.Mult = burstDot[c.TalentLvlBurst()]
 	ai.Durability = 25
@@ -58,7 +58,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	ai.HitlagHaltFrames = 0
 
 	aiAbsorb := ai
-	aiAbsorb.Abil = "Kazuha Slash (Absorb Dot)"
+	aiAbsorb.Abil = "Kazuha Slash (Absorb DoT)"
 	aiAbsorb.Mult = burstEleDot[c.TalentLvlBurst()]
 	aiAbsorb.Element = attributes.NoElement
 

--- a/internal/characters/kazuha/plunge.go
+++ b/internal/characters/kazuha/plunge.go
@@ -218,7 +218,7 @@ func (c *char) skillPlunge(p map[string]int) (action.Info, error) {
 	if c.a1Absorb != attributes.NoElement {
 		ai := info.AttackInfo{
 			ActorIndex:     c.Index(),
-			Abil:           "Kazuha A1",
+			Abil:           "Soumon Swordsmanship (A1)",
 			AttackTag:      attacks.AttackTagPlunge,
 			ICDTag:         attacks.ICDTagNone,
 			ICDGroup:       attacks.ICDGroupDefault,

--- a/internal/characters/klee/burst.go
+++ b/internal/characters/klee/burst.go
@@ -134,7 +134,7 @@ func (c *char) onExitField() {
 			// blow up
 			ai := info.AttackInfo{
 				ActorIndex:         c.Index(),
-				Abil:               "Sparks'n'Splash C4",
+				Abil:               "Sparks'n'Splash (C4)",
 				AttackTag:          attacks.AttackTagNone,
 				ICDTag:             attacks.ICDTagNone,
 				ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/klee/burst.go
+++ b/internal/characters/klee/burst.go
@@ -134,7 +134,7 @@ func (c *char) onExitField() {
 			// blow up
 			ai := info.AttackInfo{
 				ActorIndex:         c.Index(),
-				Abil:               "Sparks'n'Splash (C4)",
+				Abil:               "Sparkly Explosion (C4)",
 				AttackTag:          attacks.AttackTagNone,
 				ICDTag:             attacks.ICDTagNone,
 				ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/klee/cons.go
+++ b/internal/characters/klee/cons.go
@@ -23,7 +23,7 @@ func (c *char) c1(delay int) {
 
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Sparks'n'Splash C1",
+		Abil:               "Sparkly Explosion (C1)",
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagElementalBurst,
 		ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/klee/cons.go
+++ b/internal/characters/klee/cons.go
@@ -23,7 +23,7 @@ func (c *char) c1(delay int) {
 
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Sparkly Explosion (C1)",
+		Abil:               "Sparks'n'Splash (C1)",
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagElementalBurst,
 		ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/klee/skill.go
+++ b/internal/characters/klee/skill.go
@@ -49,7 +49,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	for i := range bounceAttacks {
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Jumpy Dumpty",
+			Abil:       "Jumpy Dumpty (Bounce)",
 			AttackTag:  attacks.AttackTagElementalArt,
 			ICDTag:     attacks.ICDTagKleeFireDamage,
 			ICDGroup:   attacks.ICDGroupDefault,
@@ -80,7 +80,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	mineAttacks := make([]attackData, minehits)
 	mineAi := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Jumpy Dumpty Mine Hit",
+		Abil:               "Jumpy Dumpty (Mine)",
 		AttackTag:          attacks.AttackTagElementalArt,
 		ICDTag:             attacks.ICDTagKleeFireDamage,
 		ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/kuki/cons.go
+++ b/internal/characters/kuki/cons.go
@@ -42,7 +42,7 @@ func (c *char) c4() {
 		// TODO:frames for this and ICD tag
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Thundergrass Mark",
+			Abil:       "Thundergrass Mark (C4)",
 			AttackTag:  attacks.AttackTagElementalArt,
 			ICDTag:     attacks.ICDTagNone,
 			ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/lanyan/shield.go
+++ b/internal/characters/lanyan/shield.go
@@ -11,7 +11,7 @@ func (c *char) genShield(ele attributes.Element) {
 		Target:     -1,
 		Src:        c.Core.F,
 		ShieldType: shield.LanyanShield,
-		Name:       "Lanyan Skill",
+		Name:       "Swallow-Wisp Pinion Dance (Shield)",
 		HP:         c.shieldHP(),
 		Ele:        ele,
 		Expires:    c.Core.F + 12.5*60,

--- a/internal/characters/layla/cons.go
+++ b/internal/characters/layla/cons.go
@@ -48,7 +48,7 @@ func (c *char) c6() {
 	c.AddAttackMod(character.AttackMod{
 		Base: modifier.NewBase("layla-c6", -1),
 		Amount: func(atk *info.AttackEvent, t info.Target) ([]float64, bool) {
-			if atk.Info.AttackTag != attacks.AttackTagElementalBurst && atk.Info.Abil != "Shooting Star" {
+			if atk.Info.AttackTag != attacks.AttackTagElementalBurst && atk.Info.Abil != shootingStarsAbil {
 				return nil, false
 			}
 			return m, true

--- a/internal/characters/layla/shield.go
+++ b/internal/characters/layla/shield.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	nightStars    = "nightstars"
-	starSkillIcd  = "nightstar-skill-icd"
-	starBurstIcd  = "nightstar-burst-icd"
-	shootingStars = "shooting-stars"
+	nightStars        = "nightstars"
+	starSkillIcd      = "nightstar-skill-icd"
+	starBurstIcd      = "nightstar-burst-icd"
+	shootingStars     = "shooting-stars"
+	shootingStarsAbil = "Shooting Star"
 )
 
 var starsTravel = []int{35, 33, 30, 28}
@@ -42,7 +43,7 @@ func (c *char) newShield(base float64, dur int) *shd {
 	n.ShieldType = shield.LaylaSkill
 	n.Ele = attributes.Cryo
 	n.HP = base
-	n.Name = "Layla Skill"
+	n.Name = "Curtain of Slumber (Shield)"
 	n.Expires = c.Core.F + dur
 	n.c = c
 	return n
@@ -117,7 +118,7 @@ func (c *char) shootStars(src int, last info.Enemy, particleCB info.AttackCBFunc
 
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Shooting Star",
+			Abil:       shootingStarsAbil,
 			AttackTag:  attacks.AttackTagElementalArt,
 			ICDTag:     attacks.ICDTagElementalArt,
 			ICDGroup:   attacks.ICDGroupLayla,

--- a/internal/characters/lisa/skill.go
+++ b/internal/characters/lisa/skill.go
@@ -22,6 +22,8 @@ const (
 	skillPressHitmark = 22
 	skillHoldHitmark  = 117
 	particleICDKey    = "lisa-particle-icd"
+	skillPressAbil    = "Violet Arc (Press)"
+	skillHoldAbil     = "Violet Arc (Hold)"
 )
 
 func init() {
@@ -66,7 +68,7 @@ func (c *char) particleCB(a info.AttackCB) {
 func (c *char) skillPress() action.Info {
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Violet Arc",
+		Abil:       skillPressAbil,
 		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagLisaElectro,
 		ICDGroup:   attacks.ICDGroupDefault,
@@ -115,7 +117,7 @@ func (c *char) skillHold() action.Info {
 	// no multiplier as that's target dependent
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Violet Arc (Hold)",
+		Abil:       skillHoldAbil,
 		AttackTag:  attacks.AttackTagElementalArt,
 		ICDTag:     attacks.ICDTagNone,
 		ICDGroup:   attacks.ICDGroupDefault,
@@ -179,7 +181,7 @@ func (c *char) skillHoldMult() {
 		if !ok {
 			return false
 		}
-		if atk.Info.Abil != "Violet Arc (Hold)" {
+		if atk.Info.Abil != skillHoldAbil {
 			return false
 		}
 		stacks := t.GetTag(conductiveTag)

--- a/internal/characters/lyney/cons.go
+++ b/internal/characters/lyney/cons.go
@@ -139,7 +139,7 @@ func (c *char) c6(c6Travel int) {
 	}
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Pyrotechnic Strike: Reprised",
+		Abil:       "Pyrotechnic Strike: Reprised (C6)",
 		AttackTag:  attacks.AttackTagExtra,
 		ICDTag:     attacks.ICDTagLyneyEndBoom,
 		ICDGroup:   attacks.ICDGroupLyneyExtra,

--- a/internal/characters/nahida/burst.go
+++ b/internal/characters/nahida/burst.go
@@ -52,7 +52,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 					c.AddAttackMod(character.AttackMod{
 						Base: modifier.NewBaseWithHitlag(burstKey, 60),
 						Amount: func(atk *info.AttackEvent, t info.Target) ([]float64, bool) {
-							return c.pyroBurstBuff, atk.Info.Abil == "Tri-Karma Purification"
+							return c.pyroBurstBuff, atk.Info.Abil == triKarmaAbil
 						},
 					})
 				}

--- a/internal/characters/nahida/skill.go
+++ b/internal/characters/nahida/skill.go
@@ -43,6 +43,7 @@ const (
 	skillMarkKey        = "nahida-e"
 	skillICDKey         = "nahida-e-icd"
 	triKarmaParticleICD = "nahida-e-particle-icd"
+	triKarmaAbil        = "Tri-Karma Purification"
 )
 
 func (c *char) Skill(p map[string]int) (action.Info, error) {
@@ -214,7 +215,7 @@ func (c *char) triggerTriKarmaDamageIfAvail(t *enemy.Enemy) {
 
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Tri-Karma Purification",
+			Abil:       triKarmaAbil,
 			AttackTag:  attacks.AttackTagElementalArt,
 			ICDTag:     attacks.ICDTagNahidaSkill,
 			ICDGroup:   attacks.ICDGroupNahidaSkill,

--- a/internal/characters/navia/cons.go
+++ b/internal/characters/navia/cons.go
@@ -46,7 +46,7 @@ func (c *char) c2() info.AttackCBFunc {
 		c.AddStatus(c2IcdKey, 0.25*60, true)
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "The President's Pursuit of Victory",
+			Abil:       "Cannon Fire Support (C2)",
 			AttackTag:  attacks.AttackTagElementalBurst,
 			ICDTag:     attacks.ICDTagElementalBurst,
 			ICDGroup:   attacks.ICDGroupNaviaBurst,

--- a/internal/characters/nilou/cons.go
+++ b/internal/characters/nilou/cons.go
@@ -20,7 +20,7 @@ func (c *char) c1() {
 	c.AddAttackMod(character.AttackMod{
 		Base: modifier.NewBase("nilou-c1", -1),
 		Amount: func(atk *info.AttackEvent, t info.Target) ([]float64, bool) {
-			if atk.Info.Abil != "Luminous Illusion" {
+			if atk.Info.Abil != skillIllusionAbil {
 				return nil, false
 			}
 			return m, true

--- a/internal/characters/nilou/skill.go
+++ b/internal/characters/nilou/skill.go
@@ -44,6 +44,8 @@ const (
 	initialParticleICDKey   = "nilou-initial-particle-icd"
 	pirouetteParticleICDKey = "nilou-pirouette-particle-icd"
 
+	skillIllusionAbil = "Lumnious Illusion"
+
 	delayDance = 30 // Lunar Prayer (8s) / Tranquility (12/18s) / A1 (30s) timers all start here
 	delaySteps = 40
 )
@@ -213,7 +215,7 @@ func (c *char) SwordDance(p map[string]int) action.Info {
 	}
 	centerTarget := c.Core.Combat.Player()
 	if s == 2 {
-		ai.Abil = "Luminous Illusion"
+		ai.Abil = skillIllusionAbil
 		ai.StrikeType = attacks.StrikeTypePierce
 		centerTarget = c.Core.Combat.PrimaryTarget()
 

--- a/internal/characters/noelle/asc.go
+++ b/internal/characters/noelle/asc.go
@@ -35,7 +35,7 @@ func (c *char) a1() {
 		c.AddStatus(a1IcdKey, 3600, false)
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "A1 Shield",
+			Abil:       "Devotion (A1)",
 			AttackTag:  attacks.AttackTagNone,
 		}
 		snap := c.Snapshot(&ai)
@@ -46,7 +46,7 @@ func (c *char) a1() {
 			Target:     active.Index(),
 			Src:        c.Core.F,
 			ShieldType: shield.NoelleA1,
-			Name:       "Noelle A1",
+			Name:       "Devotion (Shield)",
 			HP:         snap.Stats.TotalDEF() * 4,
 			Ele:        attributes.Cryo,
 			Expires:    c.Core.F + 1200, // 20 sec

--- a/internal/characters/raiden/plunge.go
+++ b/internal/characters/raiden/plunge.go
@@ -147,7 +147,7 @@ func (c *char) lowPlungeBXY(p map[string]int) action.Info {
 
 	ai := info.AttackInfo{
 		ActorIndex:     c.Index(),
-		Abil:           "Low Plunge (Q)",
+		Abil:           "Low Plunge (Musou Isshin)",
 		AttackTag:      attacks.AttackTagElementalBurst,
 		ICDTag:         attacks.ICDTagNone,
 		ICDGroup:       attacks.ICDGroupDefault,
@@ -241,7 +241,7 @@ func (c *char) highPlungeBXY(p map[string]int) action.Info {
 
 	ai := info.AttackInfo{
 		ActorIndex:     c.Index(),
-		Abil:           "High Plunge (Q)",
+		Abil:           "High Plunge (Musou Isshin)",
 		AttackTag:      attacks.AttackTagElementalBurst,
 		ICDTag:         attacks.ICDTagNone,
 		ICDGroup:       attacks.ICDGroupDefault,

--- a/internal/characters/rosaria/burst.go
+++ b/internal/characters/rosaria/burst.go
@@ -28,7 +28,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	// For now assume that everything hits all targets
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Rites of Termination (Hit 1)",
+		Abil:               "Rites of Termination (Initial 1)",
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,
@@ -56,7 +56,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 		c6CB,
 	)
 
-	ai.Abil = "Rites of Termination (Hit 2)"
+	ai.Abil = "Rites of Termination (Initial 2)"
 	ai.StrikeType = attacks.StrikeTypeDefault
 	ai.Mult = burst[1][c.TalentLvlBurst()]
 	// no more hitlag after first hit

--- a/internal/characters/sara/skill.go
+++ b/internal/characters/sara/skill.go
@@ -42,7 +42,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	if c.Base.Cons >= 2 {
 		ai := info.AttackInfo{
 			ActorIndex: c.Index(),
-			Abil:       "Tengu Juurai: Ambush C2",
+			Abil:       "Tengu Juurai: Ambush (C2)",
 			AttackTag:  attacks.AttackTagElementalArt,
 			ICDTag:     attacks.ICDTagNone,
 			ICDGroup:   attacks.ICDGroupDefault,
@@ -108,7 +108,7 @@ func (c *char) attackBuff(a info.AttackPattern, delay int) {
 		// TODO: change this to a ST attack later
 		c.Core.Player.Drain(info.DrainInfo{
 			ActorIndex: active.Index(),
-			Abil:       "Tengu Juurai: Ambush",
+			Abil:       "Tengu Juurai: Ambush (C2)",
 			Amount:     0,
 			External:   true,
 		})

--- a/internal/characters/sigewinne/shield.go
+++ b/internal/characters/sigewinne/shield.go
@@ -21,7 +21,7 @@ func (c *char) addC2Shield() {
 			ActorIndex: c.Index(),
 			Target:     c.Index(),
 			Src:        c.Core.F,
-			Name:       "Sigewinne C2 shield",
+			Name:       "Bubbly Shield (C2)",
 			ShieldType: shield.SigewinneC2,
 			HP:         shieldHP,
 			Ele:        attributes.Hydro,

--- a/internal/characters/skirk/cons.go
+++ b/internal/characters/skirk/cons.go
@@ -22,7 +22,7 @@ func (c *char) c1() {
 	}
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Far to Fall",
+		Abil:               "Far to Fall (C1)",
 		Mult:               5,
 		AttackTag:          attacks.AttackTagExtra,
 		ICDTag:             attacks.ICDTagSkirkCons,

--- a/internal/characters/traveler/common/dendro/lealotus.go
+++ b/internal/characters/traveler/common/dendro/lealotus.go
@@ -13,6 +13,11 @@ import (
 	"github.com/genshinsim/gcsim/pkg/gadget"
 )
 
+const (
+	burstAbil          = "Lea Lotus Lamp"
+	burstExplosionAbil = "Lea Lotus Lamp (Explosion)"
+)
+
 type LeaLotus struct {
 	*gadget.Gadget
 	info.Reactable
@@ -63,7 +68,7 @@ func (c *Traveler) newLeaLotusLamp() *LeaLotus {
 
 	procAI := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Lea Lotus Lamp",
+		Abil:       burstAbil,
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagElementalBurst,
 		ICDGroup:   attacks.ICDGroupDefault,
@@ -223,7 +228,7 @@ func (s *LeaLotus) TryBurning(a *info.AttackEvent) {
 	if !s.Reactable.TryBurning(a) {
 		return
 	}
-	s.burstAtk.Info.Abil = "Lea Lotus Lamp Explosion"
+	s.burstAtk.Info.Abil = burstExplosionAbil
 	s.burstAtk.Info.Durability = 50
 	s.burstAtk.Info.ICDTag = attacks.ICDTagNone
 	s.burstAtk.Info.Mult = burstExplode[s.char.TalentLvlBurst()]

--- a/internal/characters/traveler/common/electro/burst.go
+++ b/internal/characters/traveler/common/electro/burst.go
@@ -61,7 +61,7 @@ func (c *Traveler) Burst(p map[string]int) (action.Info, error) {
 	c.Core.Status.Add("travelerelectroburst", 720) // 12s, starts on cast
 	procAI := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Falling Thunder Proc (Q)",
+		Abil:       "Falling Thunder",
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagElementalBurst,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/xiao/xiao.go
+++ b/internal/characters/xiao/xiao.go
@@ -73,7 +73,7 @@ func (c *char) Snapshot(a *info.AttackInfo) info.Snapshot {
 		switch a.AttackTag {
 		case attacks.AttackTagNormal:
 			// QN1-1 has different hitlag from N1-1
-			if a.Abil == "Normal 0" {
+			if a.Abil == "Normal 0" { // TODO: replace this with something that isn't reliant on abil name
 				// this also overwrites N1-2 HitlagHaltFrames but they have the same value so it's fine
 				a.HitlagHaltFrames = 0.01 * 60
 			}

--- a/internal/characters/xinyan/burst.go
+++ b/internal/characters/xinyan/burst.go
@@ -29,7 +29,7 @@ func init() {
 func (c *char) Burst(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Riff Revolution",
+		Abil:               "Riff Revolution (Initial)",
 		AttackTag:          attacks.AttackTagElementalBurst,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/xinyan/skill.go
+++ b/internal/characters/xinyan/skill.go
@@ -30,7 +30,7 @@ func init() {
 func (c *char) Skill(p map[string]int) (action.Info, error) {
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Sweeping Fervor",
+		Abil:               "Sweeping Fervor (Initial)",
 		AttackTag:          attacks.AttackTagElementalArt,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,

--- a/internal/characters/yanfei/cons.go
+++ b/internal/characters/yanfei/cons.go
@@ -48,7 +48,7 @@ func (c *char) c4() {
 		Target:     -1,
 		Src:        c.Core.F,
 		ShieldType: shield.YanfeiC4,
-		Name:       "Yanfei C4",
+		Name:       "Supreme Amnesty (Shield)",
 		HP:         c.MaxHP() * .45,
 		Ele:        attributes.Pyro,
 		Expires:    c.Core.F + 15*60,

--- a/internal/characters/yelan/burst.go
+++ b/internal/characters/yelan/burst.go
@@ -118,7 +118,7 @@ func (c *char) summonExquisiteThrow() {
 		)
 	}
 	if c.Base.Cons >= 2 && c.c2icd <= c.Core.F {
-		ai.Abil = "Yelan C2 Proc"
+		ai.Abil = "Exquisite Throw (C2)"
 		ai.ICDTag = attacks.ICDTagNone
 		ai.ICDGroup = attacks.ICDGroupDefault
 		ai.FlatDmg = 14.0 / 100 * hp

--- a/internal/characters/yoimiya/burst.go
+++ b/internal/characters/yoimiya/burst.go
@@ -31,7 +31,7 @@ func (c *char) Burst(p map[string]int) (action.Info, error) {
 	// assume it does skill dmg at end of it's animation
 	ai := info.AttackInfo{
 		ActorIndex: c.Index(),
-		Abil:       "Aurous Blaze",
+		Abil:       "Aurous Blaze (Initial)",
 		AttackTag:  attacks.AttackTagElementalBurst,
 		ICDTag:     attacks.ICDTagElementalBurst,
 		ICDGroup:   attacks.ICDGroupDefault,

--- a/internal/characters/yunjin/skill.go
+++ b/internal/characters/yunjin/skill.go
@@ -57,7 +57,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 
 	ai := info.AttackInfo{
 		ActorIndex:         c.Index(),
-		Abil:               "Opening Flourish Press (E)",
+		Abil:               "Opening Flourish (Press)",
 		AttackTag:          attacks.AttackTagElementalArt,
 		ICDTag:             attacks.ICDTagNone,
 		ICDGroup:           attacks.ICDGroupDefault,
@@ -84,13 +84,13 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 		} else {
 			count = 3
 		}
-		ai.Abil = "Opening Flourish Level 1 (E)"
+		ai.Abil = "Opening Flourish (Level 1)"
 		ai.HitlagHaltFrames = 0.09 * 60
 		radius = 6
 	case 2:
 		count = 3
 		ai.Durability = 100
-		ai.Abil = "Opening Flourish Level 2 (E)"
+		ai.Abil = "Opening Flourish (Level 2)"
 		ai.HitlagHaltFrames = 0.12 * 60
 		radius = 8
 	}
@@ -108,7 +108,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 		ActorIndex: c.Index(),
 		Target:     c.Index(),
 		Src:        c.Core.F,
-		Name:       "Yun Jin Skill",
+		Name:       "Opening Flourish (Shield)",
 		ShieldType: shield.YunjinSkill,
 		HP:         skillShieldPct[c.TalentLvlSkill()]*c.MaxHP() + skillShieldFlat[c.TalentLvlSkill()],
 		Ele:        attributes.Geo,

--- a/internal/tests/characters/beidou_test.go
+++ b/internal/tests/characters/beidou_test.go
@@ -46,7 +46,7 @@ func TestBeidouBounce(t *testing.T) {
 		if !ok {
 			return false
 		}
-		if ae.Info.Abil == burstBounceAbil {
+		if ae.Info.Abil == "Stormbreaker (Bounce)" {
 			dmgCount[t.Key()]++
 		}
 

--- a/internal/tests/characters/beidou_test.go
+++ b/internal/tests/characters/beidou_test.go
@@ -46,7 +46,7 @@ func TestBeidouBounce(t *testing.T) {
 		if !ok {
 			return false
 		}
-		if ae.Info.Abil == "Stormbreaker (Bounce)" {
+		if ae.Info.Abil == burstBounceAbil {
 			dmgCount[t.Key()]++
 		}
 

--- a/internal/tests/characters/beidou_test.go
+++ b/internal/tests/characters/beidou_test.go
@@ -46,7 +46,7 @@ func TestBeidouBounce(t *testing.T) {
 		if !ok {
 			return false
 		}
-		if ae.Info.Abil == "Stormbreak Proc (Q)" {
+		if ae.Info.Abil == "Stormbreaker (Bounce)" {
 			dmgCount[t.Key()]++
 		}
 

--- a/internal/tests/characters/travelerdendro_test.go
+++ b/internal/tests/characters/travelerdendro_test.go
@@ -109,7 +109,7 @@ func TestTravelerDendroBurstPyro(t *testing.T) {
 	dmgCount := 0
 	c.Events.Subscribe(event.OnEnemyDamage, func(args ...any) bool {
 		atk := args[1].(*info.AttackEvent)
-		if atk.Info.Abil == burstExplosionAbil {
+		if atk.Info.Abil == "Lea Lotus Lamp (Explosion)" {
 			dmgCount++
 			log.Println("big boom at: ", c.F)
 		}
@@ -193,7 +193,7 @@ func TestTravelerDendroBurstTicks(t *testing.T) {
 	dmgCount := 0
 	c.Events.Subscribe(event.OnEnemyDamage, func(args ...any) bool {
 		atk := args[1].(*info.AttackEvent)
-		if atk.Info.Abil == burstAbil {
+		if atk.Info.Abil == "Lea Lotus Lamp" {
 			dmgCount++
 			log.Println("boom at (adjusted): ", c.F-54-1)
 		}
@@ -239,7 +239,7 @@ func TestTravelerDendroBurstElectroTicks(t *testing.T) {
 	dmgCount := 0
 	c.Events.Subscribe(event.OnEnemyDamage, func(args ...any) bool {
 		atk := args[1].(*info.AttackEvent)
-		if atk.Info.Abil == burstAbil {
+		if atk.Info.Abil == "Lea Lotus Lamp" {
 			dmgCount++
 			log.Println("boom at (adjusted): ", c.F-54-1)
 		}

--- a/internal/tests/characters/travelerdendro_test.go
+++ b/internal/tests/characters/travelerdendro_test.go
@@ -109,7 +109,7 @@ func TestTravelerDendroBurstPyro(t *testing.T) {
 	dmgCount := 0
 	c.Events.Subscribe(event.OnEnemyDamage, func(args ...any) bool {
 		atk := args[1].(*info.AttackEvent)
-		if atk.Info.Abil == "Lea Lotus Lamp Explosion" {
+		if atk.Info.Abil == burstExplosionAbil {
 			dmgCount++
 			log.Println("big boom at: ", c.F)
 		}
@@ -193,7 +193,7 @@ func TestTravelerDendroBurstTicks(t *testing.T) {
 	dmgCount := 0
 	c.Events.Subscribe(event.OnEnemyDamage, func(args ...any) bool {
 		atk := args[1].(*info.AttackEvent)
-		if atk.Info.Abil == "Lea Lotus Lamp" {
+		if atk.Info.Abil == burstAbil {
 			dmgCount++
 			log.Println("boom at (adjusted): ", c.F-54-1)
 		}
@@ -239,7 +239,7 @@ func TestTravelerDendroBurstElectroTicks(t *testing.T) {
 	dmgCount := 0
 	c.Events.Subscribe(event.OnEnemyDamage, func(args ...any) bool {
 		atk := args[1].(*info.AttackEvent)
-		if atk.Info.Abil == "Lea Lotus Lamp" {
+		if atk.Info.Abil == burstAbil {
 			dmgCount++
 			log.Println("boom at (adjusted): ", c.F-54-1)
 		}


### PR DESCRIPTION
Cleans up a handful of abil names that were more obviously dissimilar from typical abil names
- Removes references to keybinds e.g. (Q), (E)
- Adds (Initial) if necessary
- Adds missing parenthesis if necessary
- Adds the tooltip name to certain abils if missing e.g `Kazuha A1` -> `Soumon Swordsmanship (A1)`
- Adds (Shield) to shields 