### PR TITLE
Bump go mod to go 1.25.0 for tools directive. 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,7 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "go.lintTool": "golangci-lint",
+  "go.lintTool": "golangci-lint-v2",
   "go.lintFlags": [
     "--path-mode=abs",
     "--fast-only"
@@ -30,7 +30,7 @@
   "go.lintOnSave": "package",
   "go.formatTool": "custom",
   "go.alternateTools": {
-    "customFormatter": "golangci-lint"
+    "customFormatter": "golangci-lint-v2"
   },
   "go.formatFlags": [
     "fmt",

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,26 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import inputs.systems;
       perSystem =
-        { pkgs, ... }:
+        {
+          lib,
+          pkgs,
+          self',
+          ...
+        }:
         {
           formatter = pkgs.nixfmt-tree;
+
+          packages.golangci-lint-v2 =
+            with pkgs;
+            stdenv.mkDerivation {
+              name = "golangci-lint-v2";
+              buildInputs = [ golangci-lint ];
+              phases = [ "installPhase" ];
+              installPhase = ''
+                mkdir -p $out/bin
+                cp ${lib.getExe golangci-lint} $out/bin/$name
+              '';
+            };
 
           devShells.default = pkgs.mkShell {
             nativeBuildInputs =
@@ -34,6 +51,7 @@
                 go-task
                 gofumpt
                 golangci-lint
+                self'.packages.golangci-lint-v2
                 gopls
                 gotools
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/genshinsim/gcsim
 
-go 1.22.0
+go 1.24.0
 
 require (
 	github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/genshinsim/gcsim
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794


### PR DESCRIPTION
Fix vscode golangci-lint to use v2