### PR TITLE
fix nightsoul burst event key typo

### DIFF
--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -359,7 +359,7 @@ func setupNightsoulBurst(core *core.Core) {
 		core.Events.Emit(event.OnNightsoulBurst, t, atk)
 		core.Status.Add(nightsoulBurstICDStatus, triggerCD)
 		return false
-	}, "nigthsoul-burst")
+	}, "nightsoul-burst")
 }
 
 func (s *Simulation) handleEnergy() {


### PR DESCRIPTION
- Nothing references this key so it doesn't change anything