### PR TITLE
Add aura ownership tracking to reactable

### DIFF
--- a/.github/actions/go-setup-and-test/action.yml
+++ b/.github/actions/go-setup-and-test/action.yml
@@ -9,6 +9,6 @@ runs:
     - name: Run Tests
       working-directory: ./
       shell: bash
-      run: "go test ./internal/... ./pkg/gcs/..."
+      run: "go test ./internal/... ./pkg/gcs/... ./pkg/reactable/..."
       # should run below, need to fix existing tests
       # run: "go test ./backend/... ./internal/... ./pkg/..."

--- a/internal/characters/traveler/common/dendro/lealotus.go
+++ b/internal/characters/traveler/common/dendro/lealotus.go
@@ -36,7 +36,7 @@ func (c *Traveler) newLeaLotusLamp() *LeaLotus {
 	)
 	s.Gadget = gadget.New(c.Core, c.burstPos, 1, info.GadgetTypLeaLotus)
 	s.Reactable = hacks.NewReactable(s, c.Core)
-	s.SetAuraDurability(info.ReactionModKeyDendro, 10)
+	s.SetAuraDurability(info.ReactionModKeyDendro, 10, 0)
 
 	s.Duration = 12 * 60
 	if c.Base.Cons >= 2 {

--- a/internal/characters/xiangling/guoba.go
+++ b/internal/characters/xiangling/guoba.go
@@ -53,9 +53,9 @@ func (p *panda) Tick() {
 	case 103, 203, 303, 403: // swirl window
 		p.Core.Log.NewEvent("guoba self infusion applied", glog.LogElementEvent, p.c.Index()).
 			SetEnded(p.c.Core.F + infuseWindow + 1)
-		p.SetAuraDurability(info.ReactionModKeyPyro, infuseDurability)
+		p.SetAuraDurability(info.ReactionModKeyPyro, infuseDurability, 0)
 		p.Core.Tasks.Add(func() {
-			p.SetAuraDurability(info.ReactionModKeyPyro, 0)
+			p.SetAuraDurability(info.ReactionModKeyPyro, 0, 0)
 		}, infuseWindow+1) // +1 since infuse window is inclusive
 		p.SetDirectionToClosestEnemy()
 		// queue this in advance because that's how it is on live
@@ -109,10 +109,10 @@ func (p *panda) Attack(atk *info.AttackEvent, evt glog.Event) (float64, bool) {
 
 	// cheat a bit, set the durability just enough to match incoming sucrose/faruzan E gauge
 	oldDur := p.GetAuraDurability(info.ReactionModKeyPyro)
-	p.SetAuraDurability(info.ReactionModKeyPyro, infuseDurability)
+	p.SetAuraDurability(info.ReactionModKeyPyro, infuseDurability, 0)
 	p.React(atk)
 	// restore the durability after
-	p.SetAuraDurability(info.ReactionModKeyPyro, oldDur)
+	p.SetAuraDurability(info.ReactionModKeyPyro, oldDur, 0)
 
 	return 0, false
 }

--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -259,13 +259,13 @@ func (p *Player) ApplySelfInfusion(ele attributes.Element, dur info.Durability, 
 	if active > info.ZeroDur {
 		// make sure we're not adding more than incoming
 		if active < dur {
-			p.SetAuraDurability(reactionKey, dur)
+			p.SetAuraDurability(reactionKey, dur, p.Core.Player.Active())
 		}
 		return
 	}
 	// otherwise calculate decay based on specified f (in frames)
 	decay := dur / info.Durability(f)
-	p.SetAuraDurability(reactionKey, dur)
+	p.SetAuraDurability(reactionKey, dur, p.Core.Player.Active())
 	p.SetAuraDecayRate(reactionKey, decay)
 }
 

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -62,8 +62,6 @@ type Reactable interface {
 // 	DefModIsActive(key string) bool
 // }
 
-const MaxTeamSize = 4
-
 type Opt struct {
 	Seed              int64
 	Debug             bool

--- a/pkg/core/energy.go
+++ b/pkg/core/energy.go
@@ -28,7 +28,7 @@ func (c *Core) QueueParticle(src string, num float64, ele attributes.Element, de
 }
 
 func (c *Core) SetupOnNormalHitEnergy() {
-	var current [MaxTeamSize][info.EndWeaponClass]float64
+	var current [info.MaxChars][info.EndWeaponClass]float64
 
 	// https://genshin-impact.fandom.com/wiki/Energy#Energy_Generated_by_Normal_Attacks
 	// Base Probability

--- a/pkg/core/info/character.go
+++ b/pkg/core/info/character.go
@@ -8,6 +8,8 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 )
 
+const MaxChars = 4
+
 type CharacterProfile struct {
 	Base           CharacterBase               `json:"base"`
 	Weapon         WeaponProfile               `json:"weapon"`

--- a/pkg/core/info/reaction.go
+++ b/pkg/core/info/reaction.go
@@ -44,7 +44,7 @@ type Reactable interface {
 
 	React(a *AttackEvent)
 	AttachOrRefill(a *AttackEvent) bool
-	SetAuraDurability(mod ReactionModKey, dur Durability)
+	SetAuraDurability(mod ReactionModKey, dur Durability, src int)
 	SetAuraDecayRate(mod ReactionModKey, decay Durability)
 	GetAuraDurability(mod ReactionModKey) Durability
 	GetAuraDecayRate(mod ReactionModKey) Durability

--- a/pkg/core/player/infusion/infusion.go
+++ b/pkg/core/player/infusion/infusion.go
@@ -6,6 +6,7 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/glog"
+	"github.com/genshinsim/gcsim/pkg/core/info"
 )
 
 type WeaponInfusion struct {
@@ -16,13 +17,11 @@ type WeaponInfusion struct {
 	CanBeOverridden bool
 }
 
-const MaxTeamSize = 4
-
 type Handler struct {
 	f        *int
 	log      glog.Logger
 	debug    bool
-	infusion [MaxTeamSize]WeaponInfusion
+	infusion [info.MaxChars]WeaponInfusion
 }
 
 func New(f *int, log glog.Logger, debug bool) Handler {

--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -61,7 +61,7 @@ func (r *Reactable) tryQuickenBloom(a *info.AttackEvent) {
 	}
 	avail := r.GetAuraDurability(info.ReactionModKeyQuicken)
 	consumed := r.reduce(attributes.Hydro, avail, 2)
-	r.Durability[info.ReactionModKeyQuicken] -= consumed
+	r.reduceMod(info.ReactionModKeyQuicken, consumed)
 
 	r.addBloomGadget(a)
 	r.core.Events.Emit(event.OnBloom, r.self, a)

--- a/pkg/reactable/bloom.go
+++ b/pkg/reactable/bloom.go
@@ -19,9 +19,9 @@ func (r *Reactable) TryBloom(a *info.AttackEvent) bool {
 		// this part is annoying. bloom will happen if any of the dendro like aura is present
 		// so we gotta check for all 3...
 		switch {
-		case r.Durability[info.ReactionModKeyDendro] > info.ZeroDur:
-		case r.Durability[info.ReactionModKeyQuicken] > info.ZeroDur:
-		case r.Durability[info.ReactionModKeyBurningFuel] > info.ZeroDur:
+		case r.GetAuraDurability(info.ReactionModKeyDendro) > info.ZeroDur:
+		case r.GetAuraDurability(info.ReactionModKeyQuicken) > info.ZeroDur:
+		case r.GetAuraDurability(info.ReactionModKeyBurningFuel) > info.ZeroDur:
 		default:
 			return false
 		}
@@ -32,7 +32,7 @@ func (r *Reactable) TryBloom(a *info.AttackEvent) bool {
 			consumed = f
 		}
 	case attributes.Dendro:
-		if r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Hydro, a.Info.Durability, 2)
@@ -51,15 +51,15 @@ func (r *Reactable) TryBloom(a *info.AttackEvent) bool {
 // this function should only be called after a catalyze reaction (queued to the end of current frame)
 // this reaction will check if any hydro exists and if so trigger a bloom reaction
 func (r *Reactable) tryQuickenBloom(a *info.AttackEvent) {
-	if r.Durability[info.ReactionModKeyQuicken] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyQuicken) < info.ZeroDur {
 		// this should be a sanity check; should not happen realistically unless something wipes off
 		// the quicken immediately (same frame) after catalyze
 		return
 	}
-	if r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 		return
 	}
-	avail := r.Durability[info.ReactionModKeyQuicken]
+	avail := r.GetAuraDurability(info.ReactionModKeyQuicken)
 	consumed := r.reduce(attributes.Hydro, avail, 2)
 	r.Durability[info.ReactionModKeyQuicken] -= consumed
 

--- a/pkg/reactable/burning.go
+++ b/pkg/reactable/burning.go
@@ -13,20 +13,20 @@ func (r *Reactable) TryBurning(a *info.AttackEvent) bool {
 		return false
 	}
 
-	dendroDur := r.Durability[info.ReactionModKeyDendro]
+	dendroDur := r.GetAuraDurability(info.ReactionModKeyDendro)
 
 	// adding pyro or dendro just adds to durability
 	switch a.Info.Element {
 	case attributes.Pyro:
 		// if there's no existing pyro/burning or dendro/quicken then do nothing
-		if r.Durability[info.ReactionModKeyDendro] < info.ZeroDur && r.Durability[info.ReactionModKeyQuicken] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyDendro) < info.ZeroDur && r.GetAuraDurability(info.ReactionModKeyQuicken) < info.ZeroDur {
 			return false
 		}
 		// add to pyro durability
 		// r.attachOrRefillNormalEle(ModifierPyro, a.Info.Durability)
 	case attributes.Dendro:
 		// if there's no existing pyro/burning or dendro/quicken then do nothing
-		if r.Durability[info.ReactionModKeyPyro] < info.ZeroDur && r.Durability[info.ReactionModKeyBurning] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyPyro) < info.ZeroDur && r.GetAuraDurability(info.ReactionModKeyBurning) < info.ZeroDur {
 			return false
 		}
 		dendroDur = max(dendroDur, a.Info.Durability*0.8)
@@ -37,8 +37,8 @@ func (r *Reactable) TryBurning(a *info.AttackEvent) bool {
 	}
 	// a.Reacted = true
 
-	if r.Durability[info.ReactionModKeyBurningFuel] < info.ZeroDur {
-		r.attachBurningFuel(max(dendroDur, r.Durability[info.ReactionModKeyQuicken]), 1)
+	if r.GetAuraDurability(info.ReactionModKeyBurningFuel) < info.ZeroDur {
+		r.attachBurningFuel(max(dendroDur, r.GetAuraDurability(info.ReactionModKeyQuicken)), 1)
 		r.attachBurning()
 
 		r.core.Events.Emit(event.OnBurning, r.self, a)
@@ -101,7 +101,7 @@ func (r *Reactable) nextBurningTick(src, counter int, t Enemy) func() {
 		}
 		// burning SHOULD be active still, since if not we would have
 		// called cleanup and set source to -1
-		if r.Durability[info.ReactionModKeyBurningFuel] < info.ZeroDur || r.Durability[info.ReactionModKeyBurning] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyBurningFuel) < info.ZeroDur || r.GetAuraDurability(info.ReactionModKeyBurning) < info.ZeroDur {
 			return
 		}
 		// so burning is active, which means both auras must still have value > 0, so we can do dmg
@@ -135,7 +135,7 @@ func (r *Reactable) nextBurningTick(src, counter int, t Enemy) func() {
 
 // burningCheck purges modifiers if burning no longer active
 func (r *Reactable) burningCheck() {
-	if r.Durability[info.ReactionModKeyBurning] < info.ZeroDur && r.Durability[info.ReactionModKeyBurningFuel] > info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyBurning) < info.ZeroDur && r.GetAuraDurability(info.ReactionModKeyBurningFuel) > info.ZeroDur {
 		// no more burning ticks
 		r.burningTickSrc = -1
 		// remove burning fuel

--- a/pkg/reactable/burning.go
+++ b/pkg/reactable/burning.go
@@ -38,8 +38,8 @@ func (r *Reactable) TryBurning(a *info.AttackEvent) bool {
 	// a.Reacted = true
 
 	if r.GetAuraDurability(info.ReactionModKeyBurningFuel) < info.ZeroDur {
-		r.attachBurningFuel(max(dendroDur, r.GetAuraDurability(info.ReactionModKeyQuicken)), 1, 0)
-		r.attachBurning(0)
+		r.attachBurningFuel(max(dendroDur, r.GetAuraDurability(info.ReactionModKeyQuicken)), 1, a.Info.ActorIndex)
+		r.attachBurning(a.Info.ActorIndex)
 
 		r.core.Events.Emit(event.OnBurning, r.self, a)
 		r.calcBurningDmg(a)
@@ -55,7 +55,7 @@ func (r *Reactable) TryBurning(a *info.AttackEvent) bool {
 	}
 	// overwrite burning fuel and recalc burning dmg
 	if a.Info.Element == attributes.Dendro {
-		r.attachBurningFuel(a.Info.Durability, 0.8, 0)
+		r.attachBurningFuel(a.Info.Durability, 0.8, a.Info.ActorIndex)
 	}
 	r.calcBurningDmg(a)
 
@@ -64,6 +64,7 @@ func (r *Reactable) TryBurning(a *info.AttackEvent) bool {
 
 func (r *Reactable) attachBurningFuel(dur, mult info.Durability, src int) {
 	// burning fuel always overwrites
+	r.removeMod(info.ReactionModKeyBurningFuel)
 	r.SetAuraDurability(info.ReactionModKeyBurningFuel, mult*dur, src)
 	decayRate := mult * dur / (6*dur + 420)
 	if decayRate < 10.0/60.0 {

--- a/pkg/reactable/burning.go
+++ b/pkg/reactable/burning.go
@@ -64,7 +64,7 @@ func (r *Reactable) TryBurning(a *info.AttackEvent) bool {
 
 func (r *Reactable) attachBurningFuel(dur, mult info.Durability) {
 	// burning fuel always overwrites
-	r.Durability[info.ReactionModKeyBurningFuel] = mult * dur
+	r.SetAuraDurability(info.ReactionModKeyBurningFuel, mult*dur)
 	decayRate := mult * dur / (6*dur + 420)
 	if decayRate < 10.0/60.0 {
 		decayRate = 10.0 / 60.0
@@ -139,7 +139,6 @@ func (r *Reactable) burningCheck() {
 		// no more burning ticks
 		r.burningTickSrc = -1
 		// remove burning fuel
-		r.Durability[info.ReactionModKeyBurningFuel] = 0
-		r.DecayRate[info.ReactionModKeyBurningFuel] = 0
+		r.removeMod(info.ReactionModKeyBurningFuel)
 	}
 }

--- a/pkg/reactable/burning.go
+++ b/pkg/reactable/burning.go
@@ -38,8 +38,8 @@ func (r *Reactable) TryBurning(a *info.AttackEvent) bool {
 	// a.Reacted = true
 
 	if r.GetAuraDurability(info.ReactionModKeyBurningFuel) < info.ZeroDur {
-		r.attachBurningFuel(max(dendroDur, r.GetAuraDurability(info.ReactionModKeyQuicken)), 1)
-		r.attachBurning()
+		r.attachBurningFuel(max(dendroDur, r.GetAuraDurability(info.ReactionModKeyQuicken)), 1, 0)
+		r.attachBurning(0)
 
 		r.core.Events.Emit(event.OnBurning, r.self, a)
 		r.calcBurningDmg(a)
@@ -55,16 +55,16 @@ func (r *Reactable) TryBurning(a *info.AttackEvent) bool {
 	}
 	// overwrite burning fuel and recalc burning dmg
 	if a.Info.Element == attributes.Dendro {
-		r.attachBurningFuel(a.Info.Durability, 0.8)
+		r.attachBurningFuel(a.Info.Durability, 0.8, 0)
 	}
 	r.calcBurningDmg(a)
 
 	return false
 }
 
-func (r *Reactable) attachBurningFuel(dur, mult info.Durability) {
+func (r *Reactable) attachBurningFuel(dur, mult info.Durability, src int) {
 	// burning fuel always overwrites
-	r.SetAuraDurability(info.ReactionModKeyBurningFuel, mult*dur)
+	r.SetAuraDurability(info.ReactionModKeyBurningFuel, mult*dur, src)
 	decayRate := mult * dur / (6*dur + 420)
 	if decayRate < 10.0/60.0 {
 		decayRate = 10.0 / 60.0

--- a/pkg/reactable/burning_test.go
+++ b/pkg/reactable/burning_test.go
@@ -27,8 +27,8 @@ func TestBurning(t *testing.T) {
 		},
 	})
 	// dendro electro gone; 20 quicken
-	if !durApproxEqual(20, trg.Durability[info.ReactionModKeyQuicken], 0.00001) {
-		t.Errorf("expecting 20 cryo attached, got %v", trg.Durability[info.ReactionModKeyQuicken])
+	if !durApproxEqual(20, trg.GetAuraDurability(info.ReactionModKeyQuicken), 0.00001) {
+		t.Errorf("expecting 20 cryo attached, got %v", trg.GetAuraDurability(info.ReactionModKeyQuicken))
 	}
 	if trg.AuraContains(attributes.Dendro, attributes.Electro) {
 		t.Error("expecting target to not contain any remaining dendro or electro aura")

--- a/pkg/reactable/catalyze.go
+++ b/pkg/reactable/catalyze.go
@@ -70,7 +70,7 @@ func (r *Reactable) TryQuicken(a *info.AttackEvent) bool {
 	r.core.Events.Emit(event.OnQuicken, r.self, a)
 
 	// attach quicken aura; special amount
-	r.attachQuicken(consumed)
+	r.attachQuicken(consumed, 0)
 
 	if r.GetAuraDurability(info.ReactionModKeyHydro) >= info.ZeroDur {
 		r.core.Tasks.Add(func() {
@@ -81,6 +81,6 @@ func (r *Reactable) TryQuicken(a *info.AttackEvent) bool {
 	return true
 }
 
-func (r *Reactable) attachQuicken(dur info.Durability) {
-	r.attachOverlapRefreshDuration(info.ReactionModKeyQuicken, dur, 12*dur+360)
+func (r *Reactable) attachQuicken(dur info.Durability, src int) {
+	r.attachOverlapRefreshDuration(info.ReactionModKeyQuicken, dur, 12*dur+360, src)
 }

--- a/pkg/reactable/catalyze.go
+++ b/pkg/reactable/catalyze.go
@@ -11,7 +11,7 @@ func (r *Reactable) TryAggravate(a *info.AttackEvent) bool {
 		return false
 	}
 
-	if r.Durability[info.ReactionModKeyQuicken] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyQuicken) < info.ZeroDur {
 		return false
 	}
 
@@ -30,7 +30,7 @@ func (r *Reactable) TrySpread(a *info.AttackEvent) bool {
 		return false
 	}
 
-	if r.Durability[info.ReactionModKeyQuicken] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyQuicken) < info.ZeroDur {
 		return false
 	}
 
@@ -52,12 +52,12 @@ func (r *Reactable) TryQuicken(a *info.AttackEvent) bool {
 	var consumed info.Durability
 	switch a.Info.Element {
 	case attributes.Dendro:
-		if r.Durability[info.ReactionModKeyElectro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyElectro) < info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Electro, a.Info.Durability, 1)
 	case attributes.Electro:
-		if r.Durability[info.ReactionModKeyDendro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyDendro) < info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Dendro, a.Info.Durability, 1)
@@ -72,7 +72,7 @@ func (r *Reactable) TryQuicken(a *info.AttackEvent) bool {
 	// attach quicken aura; special amount
 	r.attachQuicken(consumed)
 
-	if r.Durability[info.ReactionModKeyHydro] >= info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyHydro) >= info.ZeroDur {
 		r.core.Tasks.Add(func() {
 			r.tryQuickenBloom(a)
 		}, 0)

--- a/pkg/reactable/catalyze.go
+++ b/pkg/reactable/catalyze.go
@@ -70,7 +70,7 @@ func (r *Reactable) TryQuicken(a *info.AttackEvent) bool {
 	r.core.Events.Emit(event.OnQuicken, r.self, a)
 
 	// attach quicken aura; special amount
-	r.attachQuicken(consumed, 0)
+	r.attachQuicken(consumed, a.Info.ActorIndex)
 
 	if r.GetAuraDurability(info.ReactionModKeyHydro) >= info.ZeroDur {
 		r.core.Tasks.Add(func() {

--- a/pkg/reactable/crystallize.go
+++ b/pkg/reactable/crystallize.go
@@ -11,28 +11,28 @@ import (
 )
 
 func (r *Reactable) TryCrystallizeElectro(a *info.AttackEvent) bool {
-	if r.Durability[info.ReactionModKeyElectro] > info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyElectro) > info.ZeroDur {
 		return r.tryCrystallizeWithEle(a, attributes.Electro, info.ReactionTypeCrystallizeElectro, event.OnCrystallizeElectro)
 	}
 	return false
 }
 
 func (r *Reactable) TryCrystallizeHydro(a *info.AttackEvent) bool {
-	if r.Durability[info.ReactionModKeyHydro] > info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyHydro) > info.ZeroDur {
 		return r.tryCrystallizeWithEle(a, attributes.Hydro, info.ReactionTypeCrystallizeHydro, event.OnCrystallizeHydro)
 	}
 	return false
 }
 
 func (r *Reactable) TryCrystallizeCryo(a *info.AttackEvent) bool {
-	if r.Durability[info.ReactionModKeyCryo] > info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyCryo) > info.ZeroDur {
 		return r.tryCrystallizeWithEle(a, attributes.Cryo, info.ReactionTypeCrystallizeCryo, event.OnCrystallizeCryo)
 	}
 	return false
 }
 
 func (r *Reactable) TryCrystallizePyro(a *info.AttackEvent) bool {
-	if r.Durability[info.ReactionModKeyPyro] > info.ZeroDur || r.Durability[info.ReactionModKeyBurning] > info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyPyro) > info.ZeroDur || r.GetAuraDurability(info.ReactionModKeyBurning) > info.ZeroDur {
 		reacted := r.tryCrystallizeWithEle(a, attributes.Pyro, info.ReactionTypeCrystallizePyro, event.OnCrystallizePyro)
 		r.burningCheck()
 		return reacted
@@ -41,7 +41,7 @@ func (r *Reactable) TryCrystallizePyro(a *info.AttackEvent) bool {
 }
 
 func (r *Reactable) TryCrystallizeFrozen(a *info.AttackEvent) bool {
-	if r.Durability[info.ReactionModKeyFrozen] > info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyFrozen) > info.ZeroDur {
 		return r.tryCrystallizeWithEle(a, attributes.Frozen, info.ReactionTypeCrystallizeCryo, event.OnCrystallizeCryo)
 	}
 	return false
@@ -66,7 +66,7 @@ func (r *Reactable) tryCrystallizeWithEle(a *info.AttackEvent, ele attributes.El
 	r.core.Events.Emit(evt, r.self, a)
 	// check freeze + ec
 	switch {
-	case ele == attributes.Electro && r.Durability[info.ReactionModKeyHydro] > info.ZeroDur:
+	case ele == attributes.Electro && r.GetAuraDurability(info.ReactionModKeyHydro) > info.ZeroDur:
 		r.checkEC()
 	case ele == attributes.Frozen:
 		r.checkFreeze()

--- a/pkg/reactable/crystallize_test.go
+++ b/pkg/reactable/crystallize_test.go
@@ -77,7 +77,7 @@ func TestCrystallizePyro(t *testing.T) {
 		},
 	})
 	// force on burning
-	trg.Durability[info.ReactionModKeyBurning] = 50
+	trg.SetAuraDurability(info.ReactionModKeyBurning, 50)
 
 	trg.React(&info.AttackEvent{
 		Info: info.AttackInfo{

--- a/pkg/reactable/crystallize_test.go
+++ b/pkg/reactable/crystallize_test.go
@@ -34,6 +34,11 @@ func TestCrystallizeCryo(t *testing.T) {
 			Durability: 25,
 		},
 	})
+
+	if !durApproxEqual(7.5, trg.GetAuraDurability(info.ReactionModKeyCryo), 0.0001) {
+		t.Errorf("expecting 7.5 cryo left, got %v", trg.GetAuraDurability(info.ReactionModKeyCryo))
+	}
+
 	advanceCoreFrameMultiple(c, 53)
 	count := pickUpCrystallize(c, attributes.Cryo)
 	if count > 0 {
@@ -51,10 +56,6 @@ func TestCrystallizeCryo(t *testing.T) {
 	}
 	if trg.core.Player.Shields.Count() == 0 {
 		t.Errorf("expecting player to be shielded")
-	}
-
-	if !durApproxEqual(7.5-0.03508771929824561*54, trg.GetAuraDurability(info.ReactionModKeyCryo), 0.0001) {
-		t.Errorf("expecting 7.5 cryo left, got %v", trg.GetAuraDurability(info.ReactionModKeyCryo))
 	}
 }
 
@@ -86,6 +87,13 @@ func TestCrystallizePyro(t *testing.T) {
 		},
 	})
 
+	if !durApproxEqual(7.5, trg.GetAuraDurability(info.ReactionModKeyPyro), 0.0001) {
+		t.Errorf("expecting 7.5 pyro left, got %v", trg.GetAuraDurability(info.ReactionModKeyPyro))
+	}
+	if !durApproxEqual(37.5, trg.GetAuraDurability(info.ReactionModKeyBurning), 0.0001) {
+		t.Errorf("expecting 37.5 burning left, got %v", trg.GetAuraDurability(info.ReactionModKeyBurning))
+	}
+
 	advanceCoreFrameMultiple(c, 53)
 	count := pickUpCrystallize(c, attributes.Pyro)
 	if count > 0 {
@@ -103,12 +111,6 @@ func TestCrystallizePyro(t *testing.T) {
 	}
 	if trg.core.Player.Shields.Count() == 0 {
 		t.Errorf("expecting player to be shielded")
-	}
-	if !durApproxEqual(7.5-0.03508771929824561*54, trg.GetAuraDurability(info.ReactionModKeyPyro), 0.0001) {
-		t.Errorf("expecting 5.605263157894737 pyro left, got %v", trg.GetAuraDurability(info.ReactionModKeyPyro))
-	}
-	if !durApproxEqual(37.5, trg.GetAuraDurability(info.ReactionModKeyBurning), 0.0001) {
-		t.Errorf("expecting 37.5 burning left, got %v", trg.GetAuraDurability(info.ReactionModKeyBurning))
 	}
 }
 

--- a/pkg/reactable/crystallize_test.go
+++ b/pkg/reactable/crystallize_test.go
@@ -3,6 +3,8 @@ package reactable
 import (
 	"testing"
 
+	"github.com/genshinsim/gcsim/internal/template/crystallize"
+	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/event"
 	"github.com/genshinsim/gcsim/pkg/core/info"
@@ -32,7 +34,16 @@ func TestCrystallizeCryo(t *testing.T) {
 			Durability: 25,
 		},
 	})
-
+	advanceCoreFrameMultiple(c, 53)
+	count := pickUpCrystallize(c, attributes.Cryo)
+	if count > 0 {
+		t.Errorf("crystallize shard pickup too early (before 54)")
+	}
+	advanceCoreFrame(c)
+	count = pickUpCrystallize(c, attributes.Cryo)
+	if count == 0 {
+		t.Errorf("Did not pick up crystallize shard (at 54)")
+	}
 	// check shield
 	if !ok {
 		t.Errorf("expecting crystallize to have occured")
@@ -42,8 +53,8 @@ func TestCrystallizeCryo(t *testing.T) {
 		t.Errorf("expecting player to be shielded")
 	}
 
-	if !durApproxEqual(7.5, trg.GetAuraDurability(info.ReactionModKeyCryo), 0.0001) {
-		t.Errorf("expecting 7.5 pyro left, got %v", trg.GetAuraDurability(info.ReactionModKeyCryo))
+	if !durApproxEqual(7.5-0.03508771929824561*54, trg.GetAuraDurability(info.ReactionModKeyCryo), 0.0001) {
+		t.Errorf("expecting 7.5 cryo left, got %v", trg.GetAuraDurability(info.ReactionModKeyCryo))
 	}
 }
 
@@ -75,6 +86,16 @@ func TestCrystallizePyro(t *testing.T) {
 		},
 	})
 
+	advanceCoreFrameMultiple(c, 53)
+	count := pickUpCrystallize(c, attributes.Pyro)
+	if count > 0 {
+		t.Errorf("crystallize shard pickup too early (before 54)")
+	}
+	advanceCoreFrame(c)
+	count = pickUpCrystallize(c, attributes.Pyro)
+	if count == 0 {
+		t.Errorf("Did not pick up crystallize shard (at 54)")
+	}
 	// check shield
 	if !ok {
 		t.Errorf("expecting crystallize to have occured")
@@ -83,10 +104,31 @@ func TestCrystallizePyro(t *testing.T) {
 	if trg.core.Player.Shields.Count() == 0 {
 		t.Errorf("expecting player to be shielded")
 	}
-	if !durApproxEqual(7.5, trg.GetAuraDurability(info.ReactionModKeyPyro), 0.0001) {
-		t.Errorf("expecting 7.5 pyro left, got %v", trg.GetAuraDurability(info.ReactionModKeyPyro))
+	if !durApproxEqual(7.5-0.03508771929824561*54, trg.GetAuraDurability(info.ReactionModKeyPyro), 0.0001) {
+		t.Errorf("expecting 5.605263157894737 pyro left, got %v", trg.GetAuraDurability(info.ReactionModKeyPyro))
 	}
 	if !durApproxEqual(37.5, trg.GetAuraDurability(info.ReactionModKeyBurning), 0.0001) {
 		t.Errorf("expecting 37.5 burning left, got %v", trg.GetAuraDurability(info.ReactionModKeyBurning))
 	}
+}
+
+func pickUpCrystallize(c *core.Core, pickupEle attributes.Element) int {
+	var count int
+	for _, g := range c.Combat.Gadgets() {
+		shard, ok := g.(*crystallize.Shard)
+		// skip if no shard
+		if !ok {
+			continue
+		}
+		// skip if shard not specified element
+		if pickupEle != attributes.UnknownElement && shard.Shield.Ele != pickupEle {
+			continue
+		}
+		// try to pick up shard and stop if succeeded
+		if shard.AddShieldKillShard() {
+			count = 1
+			break
+		}
+	}
+	return count
 }

--- a/pkg/reactable/crystallize_test.go
+++ b/pkg/reactable/crystallize_test.go
@@ -42,8 +42,8 @@ func TestCrystallizeCryo(t *testing.T) {
 		t.Errorf("expecting player to be shielded")
 	}
 
-	if !durApproxEqual(7.5, trg.Durability[info.ReactionModKeyCryo], 0.0001) {
-		t.Errorf("expecting 7.5 pyro left, got %v", trg.Durability[info.ReactionModKeyCryo])
+	if !durApproxEqual(7.5, trg.GetAuraDurability(info.ReactionModKeyCryo), 0.0001) {
+		t.Errorf("expecting 7.5 pyro left, got %v", trg.GetAuraDurability(info.ReactionModKeyCryo))
 	}
 }
 
@@ -83,10 +83,10 @@ func TestCrystallizePyro(t *testing.T) {
 	if trg.core.Player.Shields.Count() == 0 {
 		t.Errorf("expecting player to be shielded")
 	}
-	if !durApproxEqual(7.5, trg.Durability[info.ReactionModKeyPyro], 0.0001) {
-		t.Errorf("expecting 7.5 pyro left, got %v", trg.Durability[info.ReactionModKeyPyro])
+	if !durApproxEqual(7.5, trg.GetAuraDurability(info.ReactionModKeyPyro), 0.0001) {
+		t.Errorf("expecting 7.5 pyro left, got %v", trg.GetAuraDurability(info.ReactionModKeyPyro))
 	}
-	if !durApproxEqual(37.5, trg.Durability[info.ReactionModKeyBurning], 0.0001) {
-		t.Errorf("expecting 37.5 burning left, got %v", trg.Durability[info.ReactionModKeyBurning])
+	if !durApproxEqual(37.5, trg.GetAuraDurability(info.ReactionModKeyBurning), 0.0001) {
+		t.Errorf("expecting 37.5 burning left, got %v", trg.GetAuraDurability(info.ReactionModKeyBurning))
 	}
 }

--- a/pkg/reactable/crystallize_test.go
+++ b/pkg/reactable/crystallize_test.go
@@ -77,7 +77,7 @@ func TestCrystallizePyro(t *testing.T) {
 		},
 	})
 	// force on burning
-	trg.SetAuraDurability(info.ReactionModKeyBurning, 50)
+	trg.SetAuraDurability(info.ReactionModKeyBurning, 50, 0)
 
 	trg.React(&info.AttackEvent{
 		Info: info.AttackInfo{

--- a/pkg/reactable/electrocharged.go
+++ b/pkg/reactable/electrocharged.go
@@ -17,7 +17,7 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 	}
 	// if there's still frozen left don't try to ec
 	// game actively rejects ec reaction if frozen is present
-	if r.Durability[info.ReactionModKeyFrozen] > info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyFrozen) > info.ZeroDur {
 		return false
 	}
 
@@ -25,7 +25,7 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 	switch a.Info.Element {
 	case attributes.Hydro:
 		// if there's no existing hydro or electro then do nothing
-		if r.Durability[info.ReactionModKeyElectro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyElectro) < info.ZeroDur {
 			return false
 		}
 		// add to hydro durability (can't add if the atk already reacted)
@@ -35,7 +35,7 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 		}
 	case attributes.Electro:
 		// if there's no existing hydro or electro then do nothing
-		if r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 			return false
 		}
 		// add to electro durability (can't add if the atk already reacted)
@@ -100,7 +100,8 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 				return false
 			}
 			// ignore if we no longer have both electro and hydro
-			if r.Durability[info.ReactionModKeyElectro] < info.ZeroDur || r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+			if r.GetAuraDurability(info.ReactionModKeyElectro) < info.ZeroDur ||
+				r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 				return true
 			}
 
@@ -119,24 +120,24 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 
 func (r *Reactable) waneEC() {
 	r.Durability[info.ReactionModKeyElectro] -= 10
-	r.Durability[info.ReactionModKeyElectro] = max(0, r.Durability[info.ReactionModKeyElectro])
+	r.Durability[info.ReactionModKeyElectro] = max(0, r.GetAuraDurability(info.ReactionModKeyElectro))
 	r.Durability[info.ReactionModKeyHydro] -= 10
-	r.Durability[info.ReactionModKeyHydro] = max(0, r.Durability[info.ReactionModKeyHydro])
+	r.Durability[info.ReactionModKeyHydro] = max(0, r.GetAuraDurability(info.ReactionModKeyHydro))
 	r.core.Log.NewEvent("ec wane",
 		glog.LogElementEvent,
 		-1,
 	).
 		Write("aura", "ec").
 		Write("target", r.self.Key()).
-		Write("hydro", r.Durability[info.ReactionModKeyHydro]).
-		Write("electro", r.Durability[info.ReactionModKeyElectro])
+		Write("hydro", r.GetAuraDurability(info.ReactionModKeyHydro)).
+		Write("electro", r.GetAuraDurability(info.ReactionModKeyElectro))
 
 	// ec is gone
 	r.checkEC()
 }
 
 func (r *Reactable) checkEC() {
-	if r.Durability[info.ReactionModKeyElectro] < info.ZeroDur || r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyElectro) < info.ZeroDur || r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 		r.ecTickSrc = -1
 		r.core.Events.Unsubscribe(event.OnEnemyDamage, fmt.Sprintf("ec-%v", r.self.Key()))
 		r.core.Log.NewEvent("ec expired",
@@ -145,8 +146,8 @@ func (r *Reactable) checkEC() {
 		).
 			Write("aura", "ec").
 			Write("target", r.self.Key()).
-			Write("hydro", r.Durability[info.ReactionModKeyHydro]).
-			Write("electro", r.Durability[info.ReactionModKeyElectro])
+			Write("hydro", r.GetAuraDurability(info.ReactionModKeyHydro)).
+			Write("electro", r.GetAuraDurability(info.ReactionModKeyElectro))
 	}
 }
 
@@ -158,7 +159,7 @@ func (r *Reactable) nextTick(src int) func() {
 		}
 		// ec SHOULD be active still, since if not we would have
 		// called cleanup and set source to -1
-		if r.Durability[info.ReactionModKeyElectro] < info.ZeroDur || r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyElectro) < info.ZeroDur || r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 			return
 		}
 

--- a/pkg/reactable/electrocharged.go
+++ b/pkg/reactable/electrocharged.go
@@ -31,7 +31,7 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 		// add to hydro durability (can't add if the atk already reacted)
 		// TODO: this shouldn't happen here
 		if !a.Reacted {
-			r.attachOrRefillNormalEle(info.ReactionModKeyHydro, a.Info.Durability)
+			r.attachOrRefillNormalEle(info.ReactionModKeyHydro, a.Info.Durability, 0)
 		}
 	case attributes.Electro:
 		// if there's no existing hydro or electro then do nothing
@@ -40,7 +40,7 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 		}
 		// add to electro durability (can't add if the atk already reacted)
 		if !a.Reacted {
-			r.attachOrRefillNormalEle(info.ReactionModKeyElectro, a.Info.Durability)
+			r.attachOrRefillNormalEle(info.ReactionModKeyElectro, a.Info.Durability, 0)
 		}
 	default:
 		return false

--- a/pkg/reactable/electrocharged.go
+++ b/pkg/reactable/electrocharged.go
@@ -31,7 +31,7 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 		// add to hydro durability (can't add if the atk already reacted)
 		// TODO: this shouldn't happen here
 		if !a.Reacted {
-			r.attachOrRefillNormalEle(info.ReactionModKeyHydro, a.Info.Durability, 0)
+			r.attachOrRefillNormalEle(info.ReactionModKeyHydro, a.Info.Durability, a.Info.ActorIndex)
 		}
 	case attributes.Electro:
 		// if there's no existing hydro or electro then do nothing
@@ -40,7 +40,7 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 		}
 		// add to electro durability (can't add if the atk already reacted)
 		if !a.Reacted {
-			r.attachOrRefillNormalEle(info.ReactionModKeyElectro, a.Info.Durability, 0)
+			r.attachOrRefillNormalEle(info.ReactionModKeyElectro, a.Info.Durability, a.Info.ActorIndex)
 		}
 	default:
 		return false

--- a/pkg/reactable/electrocharged.go
+++ b/pkg/reactable/electrocharged.go
@@ -119,10 +119,8 @@ func (r *Reactable) TryAddEC(a *info.AttackEvent) bool {
 }
 
 func (r *Reactable) waneEC() {
-	r.Durability[info.ReactionModKeyElectro] -= 10
-	r.Durability[info.ReactionModKeyElectro] = max(0, r.GetAuraDurability(info.ReactionModKeyElectro))
-	r.Durability[info.ReactionModKeyHydro] -= 10
-	r.Durability[info.ReactionModKeyHydro] = max(0, r.GetAuraDurability(info.ReactionModKeyHydro))
+	r.reduceMod(info.ReactionModKeyElectro, 10)
+	r.reduceMod(info.ReactionModKeyHydro, 10)
 	r.core.Log.NewEvent("ec wane",
 		glog.LogElementEvent,
 		-1,

--- a/pkg/reactable/freeze.go
+++ b/pkg/reactable/freeze.go
@@ -22,14 +22,14 @@ func (r *Reactable) TryFreeze(a *info.AttackEvent) bool {
 		if r.GetAuraDurability(info.ReactionModKeyCryo) < info.ZeroDur {
 			return false
 		}
-		consumed = r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyCryo), a.Info.Durability)
+		consumed = r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyCryo), a.Info.Durability, 0)
 		r.reduceMod(info.ReactionModKeyCryo, consumed)
 
 	case attributes.Cryo:
 		if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 			return false
 		}
-		consumed := r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyHydro), a.Info.Durability)
+		consumed := r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyHydro), a.Info.Durability, 0)
 		r.reduceMod(info.ReactionModKeyHydro, consumed)
 	default:
 		// should be here
@@ -100,13 +100,13 @@ func (r *Reactable) ShatterCheck(a *info.AttackEvent) bool {
 }
 
 // add to freeze durability and return amount of durability consumed
-func (r *Reactable) triggerFreeze(a, b info.Durability) info.Durability {
+func (r *Reactable) triggerFreeze(a, b info.Durability, src int) info.Durability {
 	d := min(a, b)
 	if r.FreezeResist >= 1 {
 		return d
 	}
 	// trigger freeze should only addDurability and should not touch decay rate
-	r.attachOverlap(info.ReactionModKeyFrozen, 2*d, info.ZeroDur)
+	r.attachOverlap(info.ReactionModKeyFrozen, 2*d, info.ZeroDur, src)
 	return d
 }
 

--- a/pkg/reactable/freeze.go
+++ b/pkg/reactable/freeze.go
@@ -23,15 +23,14 @@ func (r *Reactable) TryFreeze(a *info.AttackEvent) bool {
 			return false
 		}
 		consumed = r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyCryo), a.Info.Durability)
-		r.Durability[info.ReactionModKeyCryo] -= consumed
-		r.Durability[info.ReactionModKeyCryo] = max(r.GetAuraDurability(info.ReactionModKeyCryo), 0)
+		r.reduceMod(info.ReactionModKeyCryo, consumed)
+
 	case attributes.Cryo:
 		if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 			return false
 		}
 		consumed := r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyHydro), a.Info.Durability)
-		r.Durability[info.ReactionModKeyHydro] -= consumed
-		r.Durability[info.ReactionModKeyHydro] = max(r.GetAuraDurability(info.ReactionModKeyHydro), 0)
+		r.reduceMod(info.ReactionModKeyHydro, consumed)
 	default:
 		// should be here
 		return false
@@ -51,7 +50,7 @@ func (r *Reactable) PoiseDMGCheck(a *info.AttackEvent) bool {
 		return false
 	}
 	// remove frozen durability according to poise dmg
-	r.Durability[info.ReactionModKeyFrozen] -= info.Durability(0.15 * a.Info.PoiseDMG)
+	r.reduceMod(info.ReactionModKeyFrozen, info.Durability(0.15*a.Info.PoiseDMG))
 	r.checkFreeze()
 	return true
 }
@@ -64,7 +63,7 @@ func (r *Reactable) ShatterCheck(a *info.AttackEvent) bool {
 		return false
 	}
 	// remove 200 freeze gauge if available
-	r.Durability[info.ReactionModKeyFrozen] -= 200
+	r.reduceMod(info.ReactionModKeyFrozen, 200)
 	r.checkFreeze()
 
 	r.core.Events.Emit(event.OnShatter, r.self, a)

--- a/pkg/reactable/freeze.go
+++ b/pkg/reactable/freeze.go
@@ -22,14 +22,14 @@ func (r *Reactable) TryFreeze(a *info.AttackEvent) bool {
 		if r.GetAuraDurability(info.ReactionModKeyCryo) < info.ZeroDur {
 			return false
 		}
-		consumed = r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyCryo), a.Info.Durability, 0)
+		consumed = r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyCryo), a.Info.Durability, a.Info.ActorIndex)
 		r.reduceMod(info.ReactionModKeyCryo, consumed)
 
 	case attributes.Cryo:
 		if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 			return false
 		}
-		consumed := r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyHydro), a.Info.Durability, 0)
+		consumed := r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyHydro), a.Info.Durability, a.Info.ActorIndex)
 		r.reduceMod(info.ReactionModKeyHydro, consumed)
 	default:
 		// should be here

--- a/pkg/reactable/freeze.go
+++ b/pkg/reactable/freeze.go
@@ -112,7 +112,6 @@ func (r *Reactable) triggerFreeze(a, b info.Durability) info.Durability {
 
 func (r *Reactable) checkFreeze() {
 	if r.GetAuraDurability(info.ReactionModKeyFrozen) <= info.ZeroDur {
-		r.Durability[info.ReactionModKeyFrozen] = 0
 		r.core.Events.Emit(event.OnAuraDurabilityDepleted, r.self, attributes.Frozen)
 		// trigger another attack here, purely for the purpose of breaking bubbles >.>
 		ai := info.AttackInfo{

--- a/pkg/reactable/freeze.go
+++ b/pkg/reactable/freeze.go
@@ -19,19 +19,19 @@ func (r *Reactable) TryFreeze(a *info.AttackEvent) bool {
 	switch a.Info.Element {
 	case attributes.Hydro:
 		// if cryo exists we'll trigger freeze regardless if frozen already coexists
-		if r.Durability[info.ReactionModKeyCryo] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyCryo) < info.ZeroDur {
 			return false
 		}
-		consumed = r.triggerFreeze(r.Durability[info.ReactionModKeyCryo], a.Info.Durability)
+		consumed = r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyCryo), a.Info.Durability)
 		r.Durability[info.ReactionModKeyCryo] -= consumed
-		r.Durability[info.ReactionModKeyCryo] = max(r.Durability[info.ReactionModKeyCryo], 0)
+		r.Durability[info.ReactionModKeyCryo] = max(r.GetAuraDurability(info.ReactionModKeyCryo), 0)
 	case attributes.Cryo:
-		if r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 			return false
 		}
-		consumed := r.triggerFreeze(r.Durability[info.ReactionModKeyHydro], a.Info.Durability)
+		consumed := r.triggerFreeze(r.GetAuraDurability(info.ReactionModKeyHydro), a.Info.Durability)
 		r.Durability[info.ReactionModKeyHydro] -= consumed
-		r.Durability[info.ReactionModKeyHydro] = max(r.Durability[info.ReactionModKeyHydro], 0)
+		r.Durability[info.ReactionModKeyHydro] = max(r.GetAuraDurability(info.ReactionModKeyHydro), 0)
 	default:
 		// should be here
 		return false
@@ -44,7 +44,7 @@ func (r *Reactable) TryFreeze(a *info.AttackEvent) bool {
 }
 
 func (r *Reactable) PoiseDMGCheck(a *info.AttackEvent) bool {
-	if r.Durability[info.ReactionModKeyFrozen] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyFrozen) < info.ZeroDur {
 		return false
 	}
 	if a.Info.StrikeType != attacks.StrikeTypeBlunt {
@@ -57,7 +57,7 @@ func (r *Reactable) PoiseDMGCheck(a *info.AttackEvent) bool {
 }
 
 func (r *Reactable) ShatterCheck(a *info.AttackEvent) bool {
-	if r.Durability[info.ReactionModKeyFrozen] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyFrozen) < info.ZeroDur {
 		return false
 	}
 	if a.Info.StrikeType != attacks.StrikeTypeBlunt && a.Info.Element != attributes.Geo {
@@ -112,7 +112,7 @@ func (r *Reactable) triggerFreeze(a, b info.Durability) info.Durability {
 }
 
 func (r *Reactable) checkFreeze() {
-	if r.Durability[info.ReactionModKeyFrozen] <= info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyFrozen) <= info.ZeroDur {
 		r.Durability[info.ReactionModKeyFrozen] = 0
 		r.core.Events.Emit(event.OnAuraDurabilityDepleted, r.self, attributes.Frozen)
 		// trigger another attack here, purely for the purpose of breaking bubbles >.>

--- a/pkg/reactable/freeze_test.go
+++ b/pkg/reactable/freeze_test.go
@@ -25,8 +25,8 @@ func TestFreezePlusCryoHydro(t *testing.T) {
 		},
 	})
 	// without ticking, we should have 50 frozen here
-	if !durApproxEqual(40, trg.Durability[info.ReactionModKeyFrozen], 0.00001) {
-		t.Errorf("frozen expected to be 40, got %v", trg.Durability[info.ReactionModKeyFrozen])
+	if !durApproxEqual(40, trg.GetAuraDurability(info.ReactionModKeyFrozen), 0.00001) {
+		t.Errorf("frozen expected to be 40, got %v", trg.GetAuraDurability(info.ReactionModKeyFrozen))
 		t.FailNow()
 	}
 
@@ -38,8 +38,8 @@ func TestFreezePlusCryoHydro(t *testing.T) {
 	})
 
 	// should have frozen + cryo here
-	if !durApproxEqual(20, trg.Durability[info.ReactionModKeyCryo], 0.00001) {
-		t.Errorf("expecting 20 cryo attached, got %v", trg.Durability[info.ReactionModKeyCryo])
+	if !durApproxEqual(20, trg.GetAuraDurability(info.ReactionModKeyCryo), 0.00001) {
+		t.Errorf("expecting 20 cryo attached, got %v", trg.GetAuraDurability(info.ReactionModKeyCryo))
 	}
 }
 
@@ -61,8 +61,8 @@ func TestFreezePlusAddFreeze(t *testing.T) {
 		},
 	})
 	// without ticking, we should have 50 frozen here
-	if !durApproxEqual(40, trg.Durability[info.ReactionModKeyFrozen], 0.00001) {
-		t.Errorf("frozen expected to be 40, got %v", trg.Durability[info.ReactionModKeyFrozen])
+	if !durApproxEqual(40, trg.GetAuraDurability(info.ReactionModKeyFrozen), 0.00001) {
+		t.Errorf("frozen expected to be 40, got %v", trg.GetAuraDurability(info.ReactionModKeyFrozen))
 		t.FailNow()
 	}
 
@@ -80,7 +80,7 @@ func TestFreezePlusAddFreeze(t *testing.T) {
 	})
 
 	// should have frozen + cryo here
-	if !durApproxEqual(80, trg.Durability[info.ReactionModKeyFrozen], 0.00001) {
-		t.Errorf("expecting 80 frozen attached, got %v", trg.Durability[info.ReactionModKeyFrozen])
+	if !durApproxEqual(80, trg.GetAuraDurability(info.ReactionModKeyFrozen), 0.00001) {
+		t.Errorf("expecting 80 frozen attached, got %v", trg.GetAuraDurability(info.ReactionModKeyFrozen))
 	}
 }

--- a/pkg/reactable/melt.go
+++ b/pkg/reactable/melt.go
@@ -13,7 +13,7 @@ func (r *Reactable) TryMelt(a *info.AttackEvent) bool {
 	var consumed info.Durability
 	switch a.Info.Element {
 	case attributes.Pyro:
-		if r.Durability[info.ReactionModKeyCryo] < info.ZeroDur && r.Durability[info.ReactionModKeyFrozen] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyCryo) < info.ZeroDur && r.GetAuraDurability(info.ReactionModKeyFrozen) < info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Cryo, a.Info.Durability, 2)
@@ -23,7 +23,7 @@ func (r *Reactable) TryMelt(a *info.AttackEvent) bool {
 		}
 		a.Info.AmpMult = 2.0
 	case attributes.Cryo:
-		if r.Durability[info.ReactionModKeyPyro] < info.ZeroDur && r.Durability[info.ReactionModKeyBurning] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyPyro) < info.ZeroDur && r.GetAuraDurability(info.ReactionModKeyBurning) < info.ZeroDur {
 			return false
 		}
 		r.reduce(attributes.Pyro, a.Info.Durability, 0.5)

--- a/pkg/reactable/overload.go
+++ b/pkg/reactable/overload.go
@@ -16,7 +16,7 @@ func (r *Reactable) TryOverload(a *info.AttackEvent) bool {
 	switch a.Info.Element {
 	case attributes.Electro:
 		// must have pyro; pyro cant coexist (for now) so ok to ignore count?
-		if r.Durability[info.ReactionModKeyPyro] < info.ZeroDur && r.Durability[info.ReactionModKeyBurning] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyPyro) < info.ZeroDur && r.GetAuraDurability(info.ReactionModKeyBurning) < info.ZeroDur {
 			return false
 		}
 		// reduce; either gone or left; don't care how much actually reacted
@@ -24,7 +24,7 @@ func (r *Reactable) TryOverload(a *info.AttackEvent) bool {
 		r.burningCheck()
 	case attributes.Pyro:
 		// must have electro; gotta be careful with ec?
-		if r.Durability[info.ReactionModKeyElectro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyElectro) < info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Electro, a.Info.Durability, 1)

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -264,6 +264,10 @@ func (r *Reactable) IsBurning() bool {
 	return false
 }
 
+func (r *Reactable) reduceMod(mod info.ReactionModKey, amt info.Durability) {
+	r.Durability[mod] -= min(amt, r.Durability[mod])
+}
+
 // reduce the requested element by dur * factor, return the amount of dur consumed
 // if multiple modifier with same element are present, all of them are reduced
 // the max on reduced is used for consumption purpose
@@ -284,7 +288,7 @@ func (r *Reactable) reduce(e attributes.Element, dur, factor info.Durability) in
 
 		red := min(m, r.GetAuraDurability(i))
 
-		r.Durability[i] -= red
+		r.reduceMod(i, red)
 
 		if red > reduced {
 			reduced = red
@@ -318,7 +322,7 @@ func (r *Reactable) Tick() {
 			continue
 		}
 		if r.GetAuraDurability(i) > info.ZeroDur {
-			r.Durability[i] -= r.DecayRate[i]
+			r.reduceMod(i, r.DecayRate[i])
 			r.deplete(i)
 		}
 	}
@@ -350,7 +354,7 @@ func (r *Reactable) Tick() {
 				rate = max(rate, r.DecayRate[i]*2)
 			}
 		}
-		r.Durability[i] -= rate
+		r.reduceMod(i, rate)
 		r.deplete(i)
 	}
 
@@ -359,7 +363,7 @@ func (r *Reactable) Tick() {
 	if r.GetAuraDurability(info.ReactionModKeyFrozen) > info.ZeroDur {
 		// ramp up decay rate first
 		r.DecayRate[info.ReactionModKeyFrozen] += frzDelta
-		r.Durability[info.ReactionModKeyFrozen] -= r.DecayRate[info.ReactionModKeyFrozen] / info.Durability(1.0-r.FreezeResist)
+		r.reduceMod(info.ReactionModKeyFrozen, r.DecayRate[info.ReactionModKeyFrozen]/info.Durability(1.0-r.FreezeResist))
 
 		r.checkFreeze()
 	} else if r.DecayRate[info.ReactionModKeyFrozen] > frzDecayCap { // otherwise ramp down decay rate

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -14,7 +14,7 @@ import (
 const maxChars = 4
 
 type Reactable struct {
-	Durability [info.ReactionModKeyEnd][4]info.Durability
+	Durability [info.ReactionModKeyEnd][maxChars]info.Durability
 	DecayRate  [info.ReactionModKeyEnd]info.Durability
 	// Source     []int //source frame of the aura
 	self info.Target

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -75,7 +75,7 @@ func (r *Reactable) ActiveAuraString() []string {
 	for i := range info.ReactionModKeyEnd {
 		v := r.GetAuraDurability(i)
 		if v > info.ZeroDur {
-			result = append(result, info.ReactionModKey(i).String()+": "+strconv.FormatFloat(float64(v), 'f', 3, 64))
+			result = append(result, i.String()+": "+strconv.FormatFloat(float64(v), 'f', 3, 64))
 		}
 	}
 	return result

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -14,7 +14,7 @@ import (
 const maxChars = 4
 
 type Reactable struct {
-	durability [info.ReactionModKeyEnd][4]info.Durability
+	Durability [info.ReactionModKeyEnd][4]info.Durability
 	DecayRate  [info.ReactionModKeyEnd]info.Durability
 	// Source     []int //source frame of the aura
 	self info.Target
@@ -174,7 +174,7 @@ func (r *Reactable) AttachOrRefill(a *info.AttackEvent) bool {
 }
 
 func (r *Reactable) GetAuraDurability(mod info.ReactionModKey) info.Durability {
-	return slices.Max(r.durability[mod][:])
+	return slices.Max(r.Durability[mod][:])
 }
 
 func (r *Reactable) GetDurability() []info.Durability {
@@ -190,7 +190,7 @@ func (r *Reactable) GetAuraDecayRate(mod info.ReactionModKey) info.Durability {
 }
 
 func (r *Reactable) SetAuraDurability(mod info.ReactionModKey, dur info.Durability, src int) {
-	r.durability[mod][src] = dur
+	r.Durability[mod][src] = dur
 }
 
 func (r *Reactable) SetAuraDecayRate(mod info.ReactionModKey, decay info.Durability) {
@@ -214,7 +214,7 @@ func (r *Reactable) attachOrRefillNormalEle(mod info.ReactionModKey, dur info.Du
 
 func (r *Reactable) attachOverlap(mod info.ReactionModKey, amt, length info.Durability, src int) {
 	if r.GetAuraDurability(mod) > info.ZeroDur {
-		add := max(amt-r.durability[mod][src], 0)
+		add := max(amt-r.Durability[mod][src], 0)
 		if add > 0 {
 			r.addDurability(mod, add, src)
 		}
@@ -245,7 +245,7 @@ func (r *Reactable) attachBurning(src int) {
 }
 
 func (r *Reactable) addDurability(mod info.ReactionModKey, amt info.Durability, src int) {
-	r.durability[mod][src] += amt
+	r.Durability[mod][src] += amt
 	r.core.Events.Emit(event.OnAuraDurabilityAdded, r.self, mod, amt)
 }
 
@@ -273,14 +273,14 @@ func (r *Reactable) IsBurning() bool {
 }
 
 func (r *Reactable) reduceMod(mod info.ReactionModKey, amt info.Durability) {
-	for i := range r.durability[mod] {
-		r.durability[mod][i] -= min(amt, r.durability[mod][i])
+	for i := range r.Durability[mod] {
+		r.Durability[mod][i] -= min(amt, r.Durability[mod][i])
 	}
 }
 
 func (r *Reactable) removeMod(mod info.ReactionModKey) {
-	for i := range r.durability[mod] {
-		r.durability[mod][i] = 0
+	for i := range r.Durability[mod] {
+		r.Durability[mod][i] = 0
 	}
 	r.DecayRate[mod] = 0
 }

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -76,7 +76,6 @@ func (r *Reactable) ActiveAuraString() []string {
 		v := r.GetAuraDurability(i)
 		if v > info.ZeroDur {
 			result = append(result, info.ReactionModKey(i).String()+": "+strconv.FormatFloat(float64(v), 'f', 3, 64))
-			break
 		}
 	}
 	return result

--- a/pkg/reactable/reactable.go
+++ b/pkg/reactable/reactable.go
@@ -11,10 +11,8 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/info"
 )
 
-const maxChars = 4
-
 type Reactable struct {
-	Durability [info.ReactionModKeyEnd][maxChars]info.Durability
+	Durability [info.ReactionModKeyEnd][info.MaxChars]info.Durability
 	DecayRate  [info.ReactionModKeyEnd]info.Durability
 	// Source     []int //source frame of the aura
 	self info.Target

--- a/pkg/reactable/reactable_test.go
+++ b/pkg/reactable/reactable_test.go
@@ -151,7 +151,7 @@ func TestReduce(t *testing.T) {
 	r.Durability[info.ReactionModKeyElectro] = 20
 	r.reduce(attributes.Electro, 20, 1)
 	if r.Durability[info.ReactionModKeyElectro] != 0 {
-		t.Errorf("expecting nil electro balance, got %v", r.Durability[info.ReactionModKeyElectro])
+		t.Errorf("expecting nil electro balance, got %v", r.GetAuraDurability(info.ReactionModKeyElectro))
 	}
 
 	// straight up consumption
@@ -197,7 +197,7 @@ func TestTick(t *testing.T) {
 	})
 
 	if trg.Durability[info.ReactionModKeyElectro] != 0.8*25 {
-		t.Errorf("expecting 20 electro, got %v", trg.Durability[info.ReactionModKeyElectro])
+		t.Errorf("expecting 20 electro, got %v", trg.GetAuraDurability(info.ReactionModKeyElectro))
 	}
 	if trg.DecayRate[info.ReactionModKeyElectro] != 20.0/(6*25+420) {
 		t.Errorf("expecting %v decay rate, got %v", 1.0/(6*25+420), trg.DecayRate[info.ReactionModKeyElectro])
@@ -275,8 +275,8 @@ func TestTick(t *testing.T) {
 		trg.Tick()
 	}
 	// make sure > 0
-	if trg.Durability[info.ReactionModKeyElectro] < 0 {
-		t.Errorf("expecting electro not to be 0 yet, got %v", trg.Durability[info.ReactionModKeyElectro])
+	if trg.GetAuraDurability(info.ReactionModKeyElectro) < 0 {
+		t.Errorf("expecting electro not to be 0 yet, got %v", trg.GetAuraDurability(info.ReactionModKeyElectro))
 	}
 	// 1 more tick and should be gone
 	trg.Tick()
@@ -295,13 +295,13 @@ func TestTick(t *testing.T) {
 		// log.Println("------------------------")
 	}
 	// should be > 0 still
-	if trg.Durability[info.ReactionModKeyFrozen] < 0 {
-		t.Errorf("expecting frozen not to be 0 yet, got %v", trg.Durability[info.ReactionModKeyFrozen])
+	if trg.GetAuraDurability(info.ReactionModKeyFrozen) < 0 {
+		t.Errorf("expecting frozen not to be 0 yet, got %v", trg.GetAuraDurability(info.ReactionModKeyFrozen))
 	}
 	// 1 more tick and should be gone
 	trg.Tick()
-	if trg.Durability[info.ReactionModKeyFrozen] > 0 {
-		t.Errorf("expecting frozen to be gone, got %v", trg.Durability[info.ReactionModKeyFrozen])
+	if trg.GetAuraDurability(info.ReactionModKeyFrozen) > 0 {
+		t.Errorf("expecting frozen to be gone, got %v", trg.GetAuraDurability(info.ReactionModKeyFrozen))
 	}
 	// 105 more frames to full recover
 	for range 104 {
@@ -312,12 +312,12 @@ func TestTick(t *testing.T) {
 	}
 	// decay should be > 0 still
 	if trg.DecayRate[info.ReactionModKeyFrozen] < frzDecayCap {
-		t.Errorf("expecting frozen decay to > cap, got %v", trg.Durability[info.ReactionModKeyFrozen])
+		t.Errorf("expecting frozen decay to > cap, got %v", trg.GetAuraDurability(info.ReactionModKeyFrozen))
 	}
 	// 1 more tick to reset decay
 	trg.Tick()
 	if trg.DecayRate[info.ReactionModKeyFrozen] > frzDecayCap {
-		t.Errorf("expecting frozen decay to reset, got %v", trg.Durability[info.ReactionModKeyFrozen])
+		t.Errorf("expecting frozen decay to reset, got %v", trg.GetAuraDurability(info.ReactionModKeyFrozen))
 	}
 }
 

--- a/pkg/reactable/reactable_test.go
+++ b/pkg/reactable/reactable_test.go
@@ -158,36 +158,39 @@ func TestMain(m *testing.M) {
 
 func TestReduce(t *testing.T) {
 	r := &Reactable{}
-	r.SetAuraDurability(info.ReactionModKeyElectro, 20)
+	// for i := range r.Durability {
+	// 	r.Durability[i] = make([]info.Durability, 1)
+	// }
+	r.SetAuraDurability(info.ReactionModKeyElectro, 20, 0)
 	r.reduce(attributes.Electro, 20, 1)
-	if r.Durability[info.ReactionModKeyElectro] != 0 {
+	if r.GetAuraDurability(info.ReactionModKeyElectro) != 0 {
 		t.Errorf("expecting nil electro balance, got %v", r.GetAuraDurability(info.ReactionModKeyElectro))
 	}
 
 	// straight up consumption
-	r.SetAuraDurability(info.ReactionModKeyPyro, 20)
-	r.SetAuraDurability(info.ReactionModKeyBurning, 50)
+	r.SetAuraDurability(info.ReactionModKeyPyro, 20, 0)
+	r.SetAuraDurability(info.ReactionModKeyBurning, 50, 0)
 	consumed := r.reduce(attributes.Pyro, 30, 1)
 	if consumed != 30 {
 		t.Errorf("expecting consumed to be 30, got %v", consumed)
 	}
 
 	// 2x multiplier, i.e. 1 incoming reduces 2
-	r.SetAuraDurability(info.ReactionModKeyPyro, 50)
+	r.SetAuraDurability(info.ReactionModKeyPyro, 50, 0)
 	consumed = r.reduce(attributes.Pyro, 20, 2)
 	if consumed != 20 {
 		t.Errorf("expecting consumed to be 20, got %v", consumed)
 	}
-	if r.Durability[info.ReactionModKeyPyro] != 10 {
+	if r.GetAuraDurability(info.ReactionModKeyPyro) != 10 {
 		t.Errorf("expecting 10 remaining ModifierPyro, got %v", 10)
 	}
 
-	r.SetAuraDurability(info.ReactionModKeyPyro, 50)
+	r.SetAuraDurability(info.ReactionModKeyPyro, 50, 0)
 	consumed = r.reduce(attributes.Pyro, 50, 0.5)
 	if consumed != 50 {
 		t.Errorf("expecting consumed to be 50, got %v", consumed)
 	}
-	if r.Durability[info.ReactionModKeyPyro] != 25 {
+	if r.GetAuraDurability(info.ReactionModKeyPyro) != 25 {
 		t.Errorf("expecting 25 remaining ModifierPyro, got %v", 25)
 	}
 }
@@ -296,7 +299,7 @@ func TestTick(t *testing.T) {
 
 	// test frozen
 	// 50 frozen should last just over 208 frames (i.e. 0 by 209)
-	trg.SetAuraDurability(info.ReactionModKeyFrozen, 50)
+	trg.SetAuraDurability(info.ReactionModKeyFrozen, 50, 0)
 	for range 208 {
 		trg.Tick()
 		// log.Println(trg.Durability)
@@ -332,7 +335,7 @@ func TestTick(t *testing.T) {
 
 func (target *testTarget) allNil(t *testing.T) bool {
 	ok := true
-	for i, v := range target.Durability {
+	for i, v := range target.GetDurability() {
 		ele := info.ReactionModKey(i).Element()
 		if !durApproxEqual(0, v, 0.00001) {
 			t.Errorf("ele %v expected 0 durability got %v", ele, v)

--- a/pkg/reactable/reactable_test.go
+++ b/pkg/reactable/reactable_test.go
@@ -161,22 +161,22 @@ func TestReduce(t *testing.T) {
 	// for i := range r.Durability {
 	// 	r.Durability[i] = make([]info.Durability, 1)
 	// }
-	r.SetAuraDurability(info.ReactionModKeyElectro, 20, 0)
+	r.SetAuraDurability(info.ReactionModKeyElectro, 20, 2)
 	r.reduce(attributes.Electro, 20, 1)
 	if r.GetAuraDurability(info.ReactionModKeyElectro) != 0 {
 		t.Errorf("expecting nil electro balance, got %v", r.GetAuraDurability(info.ReactionModKeyElectro))
 	}
 
 	// straight up consumption
-	r.SetAuraDurability(info.ReactionModKeyPyro, 20, 0)
-	r.SetAuraDurability(info.ReactionModKeyBurning, 50, 0)
+	r.SetAuraDurability(info.ReactionModKeyPyro, 20, 1)
+	r.SetAuraDurability(info.ReactionModKeyBurning, 50, 3)
 	consumed := r.reduce(attributes.Pyro, 30, 1)
 	if consumed != 30 {
 		t.Errorf("expecting consumed to be 30, got %v", consumed)
 	}
 
 	// 2x multiplier, i.e. 1 incoming reduces 2
-	r.SetAuraDurability(info.ReactionModKeyPyro, 50, 0)
+	r.SetAuraDurability(info.ReactionModKeyPyro, 50, 2)
 	consumed = r.reduce(attributes.Pyro, 20, 2)
 	if consumed != 20 {
 		t.Errorf("expecting consumed to be 20, got %v", consumed)

--- a/pkg/reactable/reactable_test.go
+++ b/pkg/reactable/reactable_test.go
@@ -74,6 +74,7 @@ func testCoreWithTrgs(count int) (*core.Core, []*testTarget) {
 func makeAOEAttack(ele attributes.Element, dur info.Durability) *info.AttackEvent {
 	return &info.AttackEvent{
 		Info: info.AttackInfo{
+			Abil:       "Test AoE Attack",
 			Element:    ele,
 			Durability: dur,
 		},
@@ -84,10 +85,12 @@ func makeAOEAttack(ele attributes.Element, dur info.Durability) *info.AttackEven
 func makeSTAttack(ele attributes.Element, dur info.Durability, trg info.TargetKey) *info.AttackEvent {
 	return &info.AttackEvent{
 		Info: info.AttackInfo{
+			Abil:       "Test ST Attack",
 			Element:    ele,
 			Durability: dur,
 		},
-		Pattern: combat.NewSingleTargetHit(trg),
+		// add one to account for the player being target 0
+		Pattern: combat.NewSingleTargetHit(trg + 1),
 	}
 }
 
@@ -117,6 +120,7 @@ func (target *testTarget) Attack(atk *info.AttackEvent, evt glog.Event) (float64
 	target.ShatterCheck(atk)
 	if atk.Info.Durability > 0 {
 		// don't care about icd
+
 		target.React(atk)
 	}
 	return 0, false
@@ -140,6 +144,12 @@ func addTargetToCore(c *core.Core) *testTarget {
 func advanceCoreFrame(c *core.Core) {
 	c.F++
 	c.Tick()
+}
+
+func advanceCoreFrameMultiple(c *core.Core, count int) {
+	for range count {
+		advanceCoreFrame(c)
+	}
 }
 
 func TestMain(m *testing.M) {
@@ -196,7 +206,7 @@ func TestTick(t *testing.T) {
 		},
 	})
 
-	if trg.Durability[info.ReactionModKeyElectro] != 0.8*25 {
+	if trg.GetAuraDurability(info.ReactionModKeyElectro) != 0.8*25 {
 		t.Errorf("expecting 20 electro, got %v", trg.GetAuraDurability(info.ReactionModKeyElectro))
 	}
 	if trg.DecayRate[info.ReactionModKeyElectro] != 20.0/(6*25+420) {

--- a/pkg/reactable/reactable_test.go
+++ b/pkg/reactable/reactable_test.go
@@ -158,22 +158,22 @@ func TestMain(m *testing.M) {
 
 func TestReduce(t *testing.T) {
 	r := &Reactable{}
-	r.Durability[info.ReactionModKeyElectro] = 20
+	r.SetAuraDurability(info.ReactionModKeyElectro, 20)
 	r.reduce(attributes.Electro, 20, 1)
 	if r.Durability[info.ReactionModKeyElectro] != 0 {
 		t.Errorf("expecting nil electro balance, got %v", r.GetAuraDurability(info.ReactionModKeyElectro))
 	}
 
 	// straight up consumption
-	r.Durability[info.ReactionModKeyPyro] = 20
-	r.Durability[info.ReactionModKeyBurning] = 50
+	r.SetAuraDurability(info.ReactionModKeyPyro, 20)
+	r.SetAuraDurability(info.ReactionModKeyBurning, 50)
 	consumed := r.reduce(attributes.Pyro, 30, 1)
 	if consumed != 30 {
 		t.Errorf("expecting consumed to be 30, got %v", consumed)
 	}
 
 	// 2x multiplier, i.e. 1 incoming reduces 2
-	r.Durability[info.ReactionModKeyPyro] = 50
+	r.SetAuraDurability(info.ReactionModKeyPyro, 50)
 	consumed = r.reduce(attributes.Pyro, 20, 2)
 	if consumed != 20 {
 		t.Errorf("expecting consumed to be 20, got %v", consumed)
@@ -182,7 +182,7 @@ func TestReduce(t *testing.T) {
 		t.Errorf("expecting 10 remaining ModifierPyro, got %v", 10)
 	}
 
-	r.Durability[info.ReactionModKeyPyro] = 50
+	r.SetAuraDurability(info.ReactionModKeyPyro, 50)
 	consumed = r.reduce(attributes.Pyro, 50, 0.5)
 	if consumed != 50 {
 		t.Errorf("expecting consumed to be 50, got %v", consumed)
@@ -225,8 +225,7 @@ func TestTick(t *testing.T) {
 	}
 
 	// test multiple aura
-	trg.Durability[info.ReactionModKeyElectro] = 0 // reset from previous test
-	trg.DecayRate[info.ReactionModKeyElectro] = 0
+	trg.removeMod(info.ReactionModKeyElectro) // reset from previous test
 	trg.AttachOrRefill(&info.AttackEvent{
 		Info: info.AttackInfo{
 			Element:    attributes.Electro,
@@ -297,7 +296,7 @@ func TestTick(t *testing.T) {
 
 	// test frozen
 	// 50 frozen should last just over 208 frames (i.e. 0 by 209)
-	trg.Durability[info.ReactionModKeyFrozen] = 50
+	trg.SetAuraDurability(info.ReactionModKeyFrozen, 50)
 	for range 208 {
 		trg.Tick()
 		// log.Println(trg.Durability)

--- a/pkg/reactable/superconduct.go
+++ b/pkg/reactable/superconduct.go
@@ -13,19 +13,19 @@ func (r *Reactable) TrySuperconduct(a *info.AttackEvent) bool {
 		return false
 	}
 	// this is for non frozen one
-	if r.Durability[info.ReactionModKeyFrozen] >= info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyFrozen) >= info.ZeroDur {
 		return false
 	}
 	var consumed info.Durability
 	switch a.Info.Element {
 	case attributes.Electro:
-		if r.Durability[info.ReactionModKeyCryo] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyCryo) < info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Cryo, a.Info.Durability, 1)
 	case attributes.Cryo:
 		// could be ec potentially
-		if r.Durability[info.ReactionModKeyElectro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyElectro) < info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Electro, a.Info.Durability, 1)
@@ -45,7 +45,7 @@ func (r *Reactable) TryFrozenSuperconduct(a *info.AttackEvent) bool {
 		return false
 	}
 	// this is for frozen
-	if r.Durability[info.ReactionModKeyFrozen] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyFrozen) < info.ZeroDur {
 		return false
 	}
 	switch a.Info.Element {

--- a/pkg/reactable/swirl.go
+++ b/pkg/reactable/swirl.go
@@ -60,7 +60,7 @@ func (r *Reactable) TrySwirlElectro(a *info.AttackEvent) bool {
 	if a.Info.Durability < info.ZeroDur {
 		return false
 	}
-	if r.Durability[info.ReactionModKeyElectro] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyElectro) < info.ZeroDur {
 		return false
 	}
 	rd := r.reduce(attributes.Electro, a.Info.Durability, 0.5)
@@ -85,7 +85,7 @@ func (r *Reactable) TrySwirlElectro(a *info.AttackEvent) bool {
 
 	// at this point if any durability left, we need to check for prescence of
 	// hydro in case of EC
-	if a.Info.Durability > info.ZeroDur && r.Durability[info.ReactionModKeyHydro] > info.ZeroDur {
+	if a.Info.Durability > info.ZeroDur && r.GetAuraDurability(info.ReactionModKeyHydro) > info.ZeroDur {
 		// trigger swirl hydro
 		r.TrySwirlHydro(a)
 		// check EC clean up
@@ -98,7 +98,7 @@ func (r *Reactable) TrySwirlHydro(a *info.AttackEvent) bool {
 	if a.Info.Durability < info.ZeroDur {
 		return false
 	}
-	if r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 		return false
 	}
 	rd := r.reduce(attributes.Hydro, a.Info.Durability, 0.5)
@@ -128,7 +128,7 @@ func (r *Reactable) TrySwirlCryo(a *info.AttackEvent) bool {
 	if a.Info.Durability < info.ZeroDur {
 		return false
 	}
-	if r.Durability[info.ReactionModKeyCryo] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyCryo) < info.ZeroDur {
 		return false
 	}
 	rd := r.reduce(attributes.Cryo, a.Info.Durability, 0.5)
@@ -158,7 +158,7 @@ func (r *Reactable) TrySwirlPyro(a *info.AttackEvent) bool {
 	if a.Info.Durability < info.ZeroDur {
 		return false
 	}
-	if r.Durability[info.ReactionModKeyPyro] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyPyro) < info.ZeroDur {
 		return false
 	}
 	rd := r.reduce(attributes.Pyro, a.Info.Durability, 0.5)
@@ -189,7 +189,7 @@ func (r *Reactable) TrySwirlFrozen(a *info.AttackEvent) bool {
 	if a.Info.Durability < info.ZeroDur {
 		return false
 	}
-	if r.Durability[info.ReactionModKeyFrozen] < info.ZeroDur {
+	if r.GetAuraDurability(info.ReactionModKeyFrozen) < info.ZeroDur {
 		return false
 	}
 	rd := r.reduce(attributes.Frozen, a.Info.Durability, 0.5)

--- a/pkg/reactable/swirl_test.go
+++ b/pkg/reactable/swirl_test.go
@@ -185,28 +185,28 @@ func TestSwirl50to10(t *testing.T) {
 	}
 
 	// apply 25 pyro first
-	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 25, 0), 0)
+	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 25, 1), 0)
 	// tick 286
 	for range 286 {
 		advanceCoreFrame(c)
 	}
 	// check durability after 286 tick
-	dur := trg[0].GetAuraDurability(info.ReactionModKeyPyro)
+	dur := trg[1].GetAuraDurability(info.ReactionModKeyPyro)
 	if math.Abs(float64(dur)-10.0) > 1e-3 {
 		t.Errorf("expecting 10 dur pyro, got %v", dur)
 	}
-	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 25, 0), 0)
+	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 25, 1), 0)
 	// dmg should trigger next tick
 	// i'm expecting an aoe swirl with durability = dur * 1.25 + 23.75
 	expected := dur*1.25 + 23.75
 
 	advanceCoreFrameMultiple(c, 5)
 
-	if trg[1].last.Info.Abil != swirlAbil {
-		t.Errorf("expecting swirl, got %v", trg[1].last.Info.Abil)
+	if trg[0].last.Info.Abil != swirlAbil {
+		t.Errorf("expecting swirl, got %v", trg[0].last.Info.Abil)
 	}
 	// no durability
-	if math.Abs(float64(trg[1].last.Info.Durability-expected)) > float64(info.ZeroDur) {
-		t.Errorf("expected durability to be %v, got %v", expected, trg[1].last.Info.Durability)
+	if math.Abs(float64(trg[0].last.Info.Durability-expected)) > float64(info.ZeroDur) {
+		t.Errorf("expected durability to be %v, got %v", expected, trg[0].last.Info.Durability)
 	}
 }

--- a/pkg/reactable/swirl_test.go
+++ b/pkg/reactable/swirl_test.go
@@ -1,7 +1,6 @@
 package reactable
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -12,7 +11,6 @@ import (
 const swirlAbil = "swirl-pyro (aoe)"
 
 func TestSwirl50to25(t *testing.T) {
-	fmt.Println("------------------------------\ntesting swirl 50 applied to ~20")
 	c, trg := testCoreWithTrgs(2)
 	err := c.Init()
 	if err != nil {
@@ -21,17 +19,21 @@ func TestSwirl50to25(t *testing.T) {
 	}
 
 	// apply 25 pyro first
-	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 25, 1), 0)
+	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 25, 0), 0)
 	// 1 tick
 	advanceCoreFrame(c)
 	// check durability after 1 tick
-	dur := trg[0].Durability[info.ReactionModKeyPyro]
-	fmt.Printf("pyro left: %v\n", dur)
-	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 50, 1), 0)
+	dur := trg[0].GetAuraDurability(info.ReactionModKeyPyro)
+	if dur != 20 {
+		t.Errorf("expecting 20 dur pyro, got %v", dur)
+	}
+	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 50, 0), 0)
 	// dmg should trigger next tick
 	// i'm expecting an aoe swirl with durability = dur * 1.25 + 23.75
 	expected := dur*1.25 + 23.75
-	advanceCoreFrame(c)
+
+	advanceCoreFrameMultiple(c, 5)
+
 	if trg[1].last.Info.Abil != swirlAbil {
 		t.Errorf("expecting swirl, got %v", trg[1].last.Info.Abil)
 		t.FailNow()
@@ -43,7 +45,6 @@ func TestSwirl50to25(t *testing.T) {
 }
 
 func TestSwirl25to25(t *testing.T) {
-	fmt.Println("------------------------------\ntesting swirl 25 applied to ~20")
 	c, trg := testCoreWithTrgs(2)
 
 	err := c.Init()
@@ -56,13 +57,17 @@ func TestSwirl25to25(t *testing.T) {
 	// 1 tick
 	advanceCoreFrame(c)
 	// check durability after 1 tick
-	dur := trg[0].Durability[info.ReactionModKeyPyro]
-	fmt.Printf("pyro left: %v\n", dur)
+	dur := trg[0].GetAuraDurability(info.ReactionModKeyPyro)
+	if dur != 20 {
+		t.Errorf("expecting 20 dur pyro, got %v", dur)
+	}
 	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 25, 0), 0)
 	// dmg should trigger next tick
 	// i'm expecting an aoe swirl with durability = dur * 1.25 + 23.75
 	expected := info.Durability(25)*1.25 + 23.75
-	advanceCoreFrame(c)
+
+	advanceCoreFrameMultiple(c, 5)
+
 	if trg[1].last.Info.Abil != swirlAbil {
 		t.Errorf("expecting swirl, got %v", trg[1].last.Info.Abil)
 	}
@@ -73,7 +78,6 @@ func TestSwirl25to25(t *testing.T) {
 }
 
 func TestSwirl25to50(t *testing.T) {
-	fmt.Println("------------------------------\ntesting swirl 25 applied to ~40")
 	c, trg := testCoreWithTrgs(2)
 
 	err := c.Init()
@@ -86,13 +90,17 @@ func TestSwirl25to50(t *testing.T) {
 	// 1 tick
 	advanceCoreFrame(c)
 	// check durability after 1 tick
-	dur := trg[0].Durability[info.ReactionModKeyPyro]
-	fmt.Printf("pyro left: %v\n", dur)
+	dur := trg[0].GetAuraDurability(info.ReactionModKeyPyro)
+	if dur != 40 {
+		t.Errorf("expecting 40 dur pyro, got %v", dur)
+	}
 	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 25, 0), 0)
 	// dmg should trigger next tick
 	// i'm expecting an aoe swirl with durability = dur * 1.25 + 23.75
 	expected := info.Durability(25)*1.25 + 23.75
-	advanceCoreFrame(c)
+
+	advanceCoreFrameMultiple(c, 5)
+
 	if trg[1].last.Info.Abil != swirlAbil {
 		t.Errorf("expecting swirl, got %v", trg[1].last.Info.Abil)
 	}
@@ -103,7 +111,6 @@ func TestSwirl25to50(t *testing.T) {
 }
 
 func TestSwirl50to50(t *testing.T) {
-	fmt.Println("------------------------------\ntesting swirl 50 applied to ~40")
 	c, trg := testCoreWithTrgs(2)
 
 	err := c.Init()
@@ -112,19 +119,22 @@ func TestSwirl50to50(t *testing.T) {
 		t.FailNow()
 	}
 
-	// apply 25 pyro first
+	// apply 50 pyro first
 	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 50, 0), 0)
 	// 1 tick
 	advanceCoreFrame(c)
 	// check durability after 1 tick
-	dur := trg[0].Durability[info.ReactionModKeyPyro]
-	fmt.Printf("pyro left: %v\n", dur)
+	dur := trg[0].GetAuraDurability(info.ReactionModKeyPyro)
+	if dur != 40 {
+		t.Errorf("expecting 40 dur pyro, got %v", dur)
+	}
 	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 50, 0), 0)
 	// dmg should trigger next tick
 	// i'm expecting an aoe swirl with durability = dur * 1.25 + 23.75
 	expected := info.Durability(50)*1.25 + 23.75
 
-	advanceCoreFrame(c)
+	advanceCoreFrameMultiple(c, 5)
+
 	if trg[1].last.Info.Abil != swirlAbil {
 		t.Errorf("expecting swirl, got %v", trg[1].last.Info.Abil)
 	}
@@ -135,24 +145,28 @@ func TestSwirl50to50(t *testing.T) {
 }
 
 func TestSwirl25to10(t *testing.T) {
-	fmt.Println("------------------------------\ntesting swirl 25 applied to ~10")
 	c, trg := testCoreWithTrgs(2)
 	c.Init()
 
 	// apply 25 pyro first
-	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 25, 1), 0)
-	// tick 285
-	for range 285 {
+	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 25, 0), 0)
+	// tick 286
+	for range 286 {
 		advanceCoreFrame(c)
 	}
-	// check durability after 1 tick
-	dur := trg[0].Durability[info.ReactionModKeyPyro]
-	fmt.Printf("pyro left: %v\n", dur)
-	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 25, 1), 0)
+	// check durability after 286 tick
+	dur := trg[0].GetAuraDurability(info.ReactionModKeyPyro)
+	if math.Abs(float64(dur)-10.0) > 1e-3 {
+		t.Errorf("expecting 10 dur pyro, got %v", dur)
+	}
+
+	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 25, 0), 0)
 	// dmg should trigger next tick
 	// i'm expecting an aoe swirl with durability = dur * 1.25 + 23.75
 	expected := dur*1.25 + 23.75
-	advanceCoreFrame(c)
+
+	advanceCoreFrameMultiple(c, 5)
+
 	if trg[1].last.Info.Abil != swirlAbil {
 		t.Errorf("expecting swirl, got %v", trg[1].last.Info.Abil)
 	}
@@ -163,8 +177,6 @@ func TestSwirl25to10(t *testing.T) {
 }
 
 func TestSwirl50to10(t *testing.T) {
-	fmt.Println("------------------------------\ntesting swirl 50 applied to ~10")
-
 	c, trg := testCoreWithTrgs(2)
 	err := c.Init()
 	if err != nil {
@@ -173,19 +185,23 @@ func TestSwirl50to10(t *testing.T) {
 	}
 
 	// apply 25 pyro first
-	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 25, 1), 0)
-	// tick 285
-	for range 285 {
+	c.QueueAttackEvent(makeSTAttack(attributes.Pyro, 25, 0), 0)
+	// tick 286
+	for range 286 {
 		advanceCoreFrame(c)
 	}
-	// check durability after 1 tick
-	dur := trg[0].Durability[info.ReactionModKeyPyro]
-	fmt.Printf("pyro left: %v\n", dur)
-	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 25, 1), 0)
+	// check durability after 286 tick
+	dur := trg[0].GetAuraDurability(info.ReactionModKeyPyro)
+	if math.Abs(float64(dur)-10.0) > 1e-3 {
+		t.Errorf("expecting 10 dur pyro, got %v", dur)
+	}
+	c.QueueAttackEvent(makeSTAttack(attributes.Anemo, 25, 0), 0)
 	// dmg should trigger next tick
 	// i'm expecting an aoe swirl with durability = dur * 1.25 + 23.75
 	expected := dur*1.25 + 23.75
-	advanceCoreFrame(c)
+
+	advanceCoreFrameMultiple(c, 5)
+
 	if trg[1].last.Info.Abil != swirlAbil {
 		t.Errorf("expecting swirl, got %v", trg[1].last.Info.Abil)
 	}

--- a/pkg/reactable/vaporize.go
+++ b/pkg/reactable/vaporize.go
@@ -14,19 +14,19 @@ func (r *Reactable) TryVaporize(a *info.AttackEvent) bool {
 	switch a.Info.Element {
 	case attributes.Pyro:
 		// make sure there's hydro
-		if r.Durability[info.ReactionModKeyHydro] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyHydro) < info.ZeroDur {
 			return false
 		}
 		// if there's still frozen left don't try to vape
 		// game actively rejects vaporize reaction if frozen is present
-		if r.Durability[info.ReactionModKeyFrozen] > info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyFrozen) > info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Hydro, a.Info.Durability, .5)
 		a.Info.AmpMult = 1.5
 	case attributes.Hydro:
 		// make sure there's pyro to vape; no coexistance with pyro (yet)
-		if r.Durability[info.ReactionModKeyPyro] < info.ZeroDur && r.Durability[info.ReactionModKeyBurning] < info.ZeroDur {
+		if r.GetAuraDurability(info.ReactionModKeyPyro) < info.ZeroDur && r.GetAuraDurability(info.ReactionModKeyBurning) < info.ZeroDur {
 			return false
 		}
 		consumed = r.reduce(attributes.Pyro, a.Info.Durability, 2)

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -59,8 +59,8 @@ func SetupTargetsInCore(core *core.Core, p info.Point, r float64, targets []info
 }
 
 func SetupCharactersInCore(core *core.Core, chars []info.CharacterProfile, initial keys.Char) error {
-	if len(chars) > 4 {
-		return errors.New("cannot have more than 4 characters per team")
+	if len(chars) > info.MaxChars {
+		return fmt.Errorf("cannot have more than %v characters per team", info.MaxChars)
 	}
 	dup := make(map[keys.Char]bool)
 

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -9,8 +9,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core/info"
 )
 
-const MaxTeamSize = 4
-
 type Target struct {
 	Core            *core.Core
 	key             info.TargetKey
@@ -22,10 +20,10 @@ type Target struct {
 	Alive bool
 
 	// icd related
-	icdTagOnTimer       [MaxTeamSize][attacks.ICDTagLength]bool
-	icdTagCounter       [MaxTeamSize][attacks.ICDTagLength]int
-	icdDamageTagOnTimer [MaxTeamSize][attacks.ICDTagLength]bool
-	icdDamageTagCounter [MaxTeamSize][attacks.ICDTagLength]int
+	icdTagOnTimer       [info.MaxChars][attacks.ICDTagLength]bool
+	icdTagCounter       [info.MaxChars][attacks.ICDTagLength]int
+	icdDamageTagOnTimer [info.MaxChars][attacks.ICDTagLength]bool
+	icdDamageTagCounter [info.MaxChars][attacks.ICDTagLength]int
 
 	direction info.Point
 }

--- a/scripts/dbsnapshot/main.go
+++ b/scripts/dbsnapshot/main.go
@@ -104,7 +104,6 @@ func compareFromSnapshot(from, saveTo string, earlyExit bool) error {
 					}
 					return current.save(saveTo)
 				}
-
 			}
 		}
 	}

--- a/scripts/dbsnapshot/main.go
+++ b/scripts/dbsnapshot/main.go
@@ -20,6 +20,7 @@ type opts struct {
 	iters       int
 	saveTo      string
 	compareFrom string
+	earlyExit   bool
 }
 
 var workers = 5
@@ -30,6 +31,7 @@ func main() {
 	flag.IntVar(&opt.iters, "iters", 10, "number of iterations to run per config")
 	flag.StringVar(&opt.saveTo, "save", "", "file to save snapshot to; if blank will use time stamp")
 	flag.StringVar(&opt.compareFrom, "compare", "", "file to compare snapshot from")
+	flag.BoolVar(&opt.earlyExit, "early_exit", false, "exit immediately when a difference is found")
 	flag.Parse()
 
 	if opt.saveTo == "" {
@@ -47,19 +49,20 @@ func main() {
 	}
 
 	log.Printf("comparing from %v", opt.compareFrom)
-	err := compareFromSnapshot(opt.compareFrom, opt.saveTo)
+	err := compareFromSnapshot(opt.compareFrom, opt.saveTo, opt.earlyExit)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func compareFromSnapshot(from, saveTo string) error {
+func compareFromSnapshot(from, saveTo string, earlyExit bool) error {
 	prev, err := load(from)
 	if err != nil {
 		return err
 	}
 	current := &snapshot{}
 	var warnings []string
+	start := time.Now()
 	bar := progressbar.Default(int64(len(prev.results)), "running sims")
 	for i, v := range prev.results {
 		id := prev.ids[i]
@@ -95,6 +98,13 @@ func compareFromSnapshot(from, saveTo string) error {
 			diff := v.Dps - orig
 			if diff > 0.01 || diff < -0.01 {
 				warnings = append(warnings, fmt.Sprintf("id %v seed %v has different dps: original %v, new %v, diff %v", id, v.Seed, orig, v.Dps, diff))
+				if earlyExit {
+					for _, v := range warnings {
+						log.Println(v)
+					}
+					return current.save(saveTo)
+				}
+
 			}
 		}
 	}
@@ -105,6 +115,7 @@ func compareFromSnapshot(from, saveTo string) error {
 			log.Println(v)
 		}
 	}
+	log.Printf("finished in %v\n", time.Since(start))
 	return current.save(saveTo)
 }
 


### PR DESCRIPTION
This PR refactors Reactable to prepare for Lunar Charged implementation, which needs to know which characters currently have aura on the enemy.