### PR TITLE
Fix mona skill explosion hitmark

### DIFF
--- a/internal/characters/mona/skill.go
+++ b/internal/characters/mona/skill.go
@@ -58,7 +58,7 @@ func (c *char) Skill(p map[string]int) (action.Info, error) {
 	ap := combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 5)
 
 	// tick every 1s
-	for i := skillHitmarks[hold]; i < 300; i += 60 {
+	for i := skillHitmarks[hold]; i < 300; i += 59 {
 		c.Core.QueueAttackWithSnap(ai, snap, ap, i)
 	}
 

--- a/ui/packages/docs/src/components/Frames/character_data.json
+++ b/ui/packages/docs/src/components/Frames/character_data.json
@@ -1101,7 +1101,7 @@
     {
       "vid_credit": "soloxcx",
       "count_credit": "soloxcx",
-      "vid": "https://youtu.be/vYiKg0Hg7gs",
+      "vid": "https://youtu.be/V7LU2AGTfvU",
       "count": "https://docs.google.com/spreadsheets/d/182Mq2Eimpolj_DyUKUDPnwutFeTaPxOLXBNSeSF0lRQ/edit?usp=sharing"
     }
   ],


### PR DESCRIPTION
Not sure where the original count came from, but re-recorded and counted the hitmark from the first tick

https://youtu.be/V7LU2AGTfvU
https://docs.google.com/spreadsheets/d/182Mq2Eimpolj_DyUKUDPnwutFeTaPxOLXBNSeSF0lRQ/edit?usp=sharing

Closes #2526 