### PR TITLE
Changed PMC nightsoul drain rate to 7 per second

### DIFF
--- a/internal/characters/traveler/common/pyro/skill.go
+++ b/internal/characters/traveler/common/pyro/skill.go
@@ -26,7 +26,8 @@ const (
 	tapCdStart                     = 19
 	holdCdStart                    = 48
 	enterNightsoulDelay            = 19
-	nightsoulReduceDelay           = 8 // From wiki: consumption is 7.5 points per second -> 1 per 8f
+	nightsoulReduceVal             = 0.7
+	nightsoulReduceDelay           = 6 // consumption is 7 points per second -> 0.7 per 6f
 	scorchingThresholdICD          = 180
 	particleICDKey                 = "travelerpyro-particle-icd"
 	scoringThresholdKey            = "travelerpyro-e"
@@ -148,8 +149,7 @@ func (c *Traveler) nightsoulPointReduceFunc(src int) func() {
 		if !c.nightsoulState.HasBlessing() {
 			return
 		}
-		val := 1.
-		c.reduceNightsoulPoints(val)
+		c.reduceNightsoulPoints(nightsoulReduceVal)
 		c.QueueCharTask(c.nightsoulPointReduceFunc(src), nightsoulReduceDelay)
 	}
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/6bc0b50a-9bc8-4741-922a-61bbe5ca911e

Nightsoul lasts from 84f to 441f which is 357f, which is 5.95s. This means that the nightsoul drain rate should be 7ns/s and not 7.5ns/s.