### PR TITLE
Add Mav Buffered CA Through Dash

### DIFF
--- a/internal/characters/mavuika/dash.go
+++ b/internal/characters/mavuika/dash.go
@@ -45,9 +45,16 @@ func (c *char) Dash(p map[string]int) (action.Info, error) {
 		)
 		c.Core.QueueAttack(ai, ap, 6, 6)
 		c.reduceNightsoulPoints(10)
-		// If dashing from NA while in bike, do not reset NA string
-		if c.Core.Player.CurrentState() == action.NormalAttackState {
+		x := c.Core.Player.CurrentState()
+		c.isDashFromCA = false
+		switch x {
+		case action.NormalAttackState:
+			// If dashing from NA while in bike, do not reset NA string
 			c.savedNormalCounter = c.NormalCounter
+		case action.ChargeAttackState:
+			// Used for n0 proc logic in charge.go
+			c.isDashFromCA = true
+		default:
 		}
 
 		// Execute dash CD logic

--- a/internal/characters/mavuika/mavuika.go
+++ b/internal/characters/mavuika/mavuika.go
@@ -35,6 +35,7 @@ type char struct {
 	savedNormalCounter int
 	caState            ChargeState
 	canBikePlunge      bool
+	isDashFromCA       bool
 }
 
 func init() {


### PR DESCRIPTION
Extends Mavuika charge.go's 'buffered' parameter to allow shorter CA startups from a dash.

Syntax differs from in-game inputs: while in bike mode, use `mav dash, charge[buffered=28];` for maximum buffering. 15f is the normal buffering assumed from dashes, this allows for 13f additional frames.

n0 procs can occur if buffered dash CA is done from idle, but the timing is currently slightly inaccurate. This combo isn't very compatible with n0 procs in the first place, so it shouldn't be an issue.