### PR TITLE
fix targeted shields being deleted when unshielded unit takes damage

### DIFF
--- a/pkg/core/player/shield/handler.go
+++ b/pkg/core/player/shield/handler.go
@@ -93,10 +93,12 @@ func (h *Handler) OnDamage(char, active int, dmg float64, ele attributes.Element
 	for _, v := range h.shields {
 		target := v.ShieldTarget()
 		if target == -1 && char != active {
+			h.shields[n] = v
 			n++
 			continue
 		}
 		if target != -1 && char != target {
+			h.shields[n] = v
 			n++
 			continue
 		}


### PR DESCRIPTION
from https://discord.com/channels/845087716541595668/1458064279507832923

The shield re-slicing (`h.shields = h.shields[:n]`) was deleting active shields because `n` was not incremented when a shield is found but skipped taking damage based on target. 