### PR TITLE
adjusted dbsnapshot to not exit on error

### DIFF
--- a/scripts/dbsnapshot/main.go
+++ b/scripts/dbsnapshot/main.go
@@ -130,11 +130,12 @@ func createSnapshot(filename string, iters int) error {
 
 	bar := progressbar.Default(int64(len(entries)), "running sims")
 	for _, v := range entries {
+		bar.Add(1)
 		simResult, err := runSim(ctx, v.Config, iters)
 		if err != nil {
-			return err
+			log.Printf("Error occurred on %v: %v", v.Id, err)
+			continue
 		}
-		bar.Add(1)
 		s.results = append(s.results, simResult)
 		s.ids = append(s.ids, v.Id)
 	}


### PR DESCRIPTION
We still want to do the snapshot if there is an error. This is especially useful when a sim in the DB is triggering an error on main.