### PR TITLE
Add timeout to damage mode sims to prevent common infinite loops

### DIFF
--- a/pkg/core/info/actionlist.go
+++ b/pkg/core/info/actionlist.go
@@ -42,6 +42,7 @@ type HurtSettings struct {
 
 type SimulatorSettings struct {
 	Duration          float64 `json:"-"`
+	TimeoutFrames     int     `json:"timeout_frames"`
 	DamageMode        bool    `json:"damage_mode"`
 	EnableHitlag      bool    `json:"enable_hitlag"`
 	DefHalt           bool    `json:"def_halt"` // for hitlag

--- a/pkg/core/info/actionlist.go
+++ b/pkg/core/info/actionlist.go
@@ -41,12 +41,12 @@ type HurtSettings struct {
 }
 
 type SimulatorSettings struct {
-	Duration          float64 `json:"-"`
-	TimeoutFrames     int     `json:"timeout_frames"`
-	DamageMode        bool    `json:"damage_mode"`
-	EnableHitlag      bool    `json:"enable_hitlag"`
-	DefHalt           bool    `json:"def_halt"` // for hitlag
-	IgnoreBurstEnergy bool    `json:"ignore_burst_energy"`
+	Duration           float64 `json:"-"`
+	DamageModeDuration float64 `json:"timeout_frames"`
+	DamageMode         bool    `json:"damage_mode"`
+	EnableHitlag       bool    `json:"enable_hitlag"`
+	DefHalt            bool    `json:"def_halt"` // for hitlag
+	IgnoreBurstEnergy  bool    `json:"ignore_burst_energy"`
 	// other stuff
 	NumberOfWorkers int    `json:"-"`          // how many workers to run the simulation
 	Iterations      int    `json:"iterations"` // how many iterations to run

--- a/pkg/core/info/actionlist.go
+++ b/pkg/core/info/actionlist.go
@@ -42,7 +42,7 @@ type HurtSettings struct {
 
 type SimulatorSettings struct {
 	Duration           float64 `json:"-"`
-	DamageModeDuration float64 `json:"timeout_frames"`
+	DamageModeDuration float64 `json:"damage_mode_duration"`
 	DamageMode         bool    `json:"damage_mode"`
 	EnableHitlag       bool    `json:"enable_hitlag"`
 	DefHalt            bool    `json:"def_halt"` // for hitlag

--- a/pkg/gcs/parser/parseOptions.go
+++ b/pkg/gcs/parser/parseOptions.go
@@ -36,10 +36,10 @@ func parseOptions(p *Parser) (parseFn, error) {
 				if err == nil {
 					p.res.Settings.Duration, err = itemNumberToFloat64(n)
 				}
-			case "timeout_frames":
+			case "damage_mode_duration":
 				n, err = p.acceptSeqReturnLast(ast.ItemAssign, ast.ItemNumber)
 				if err == nil {
-					p.res.Settings.TimeoutFrames, err = itemNumberToInt(n)
+					p.res.Settings.DamageModeDuration, err = itemNumberToFloat64(n)
 				}
 			case "workers":
 				n, err = p.acceptSeqReturnLast(ast.ItemAssign, ast.ItemNumber)

--- a/pkg/gcs/parser/parseOptions.go
+++ b/pkg/gcs/parser/parseOptions.go
@@ -36,6 +36,11 @@ func parseOptions(p *Parser) (parseFn, error) {
 				if err == nil {
 					p.res.Settings.Duration, err = itemNumberToFloat64(n)
 				}
+			case "timeout_frames":
+				n, err = p.acceptSeqReturnLast(ast.ItemAssign, ast.ItemNumber)
+				if err == nil {
+					p.res.Settings.TimeoutFrames, err = itemNumberToInt(n)
+				}
 			case "workers":
 				n, err = p.acceptSeqReturnLast(ast.ItemAssign, ast.ItemNumber)
 				if err == nil {

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -109,12 +109,17 @@ func (s *Simulation) popQueue() int {
 
 func initialize(s *Simulation) (stateFn, error) {
 	go s.eval.Start()
+
+	s.C.Flags.DamageMode = s.cfg.Settings.DamageMode
+	// Run sim for 10 minutes if in damage mode
 	// run sim for 90s if no duration set
+	if s.C.Flags.DamageMode {
+		s.cfg.Settings.Duration = 10 * 60
+	}
 	if s.cfg.Settings.Duration == 0 {
 		// fmt.Println("no duration set, running for 90s")
 		s.cfg.Settings.Duration = 90
 	}
-	s.C.Flags.DamageMode = s.cfg.Settings.DamageMode
 
 	return s.advanceFrames(1, queuePhase)
 }
@@ -296,22 +301,25 @@ func (s *Simulation) nextFrame() (bool, error) {
 }
 
 func (s *Simulation) stopCheck() bool {
-	if s.C.Combat.DamageMode {
-		// stop if no more actions
-		if s.noMoreActions {
-			return true
-		}
-		// stop if all targets are reporting dead
-		allDead := true
-		for _, t := range s.C.Combat.Enemies() {
-			if t.IsAlive() {
-				allDead = false
-				break
-			}
-		}
-		return allDead
+	// Exit after specified duration, or timeout duration if in damage mode
+	if s.C.F == int(s.cfg.Settings.Duration*60) {
+		return true
 	}
-	return s.C.F == int(s.cfg.Settings.Duration*60)
+
+	// stop if no more actions
+	if s.noMoreActions {
+		return true
+	}
+
+	// stop if all targets are reporting dead
+	allDead := true
+	for _, t := range s.C.Combat.Enemies() {
+		if t.IsAlive() {
+			allDead = false
+			break
+		}
+	}
+	return allDead
 }
 
 // TODO: remove defer in favour of every function actually returning error

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -113,12 +113,13 @@ func initialize(s *Simulation) (stateFn, error) {
 	s.C.Flags.DamageMode = s.cfg.Settings.DamageMode
 	// Run sim for 10 minutes if in damage mode
 	// run sim for 90s if no duration set
-	if s.C.Flags.DamageMode {
-		s.cfg.Settings.Duration = 10 * 60
-	}
 	if s.cfg.Settings.Duration == 0 {
-		// fmt.Println("no duration set, running for 90s")
-		s.cfg.Settings.Duration = 90
+		if s.C.Flags.DamageMode {
+			s.cfg.Settings.Duration = 10 * 60
+		} else {
+			// fmt.Println("no duration set, running for 90s")
+			s.cfg.Settings.Duration = 90
+		}
 	}
 
 	return s.advanceFrames(1, queuePhase)

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -111,15 +111,16 @@ func initialize(s *Simulation) (stateFn, error) {
 	go s.eval.Start()
 
 	s.C.Flags.DamageMode = s.cfg.Settings.DamageMode
-	// Run sim for 10 minutes if in damage mode
+
 	// run sim for 90s if no duration set
 	if s.cfg.Settings.Duration == 0 {
-		if s.C.Flags.DamageMode {
-			s.cfg.Settings.Duration = 10 * 60
-		} else {
-			// fmt.Println("no duration set, running for 90s")
-			s.cfg.Settings.Duration = 90
-		}
+		// fmt.Println("no duration set, running for 90s")
+		s.cfg.Settings.Duration = 90
+	}
+
+	// Timeout frames are currently only used in damage mode
+	if s.cfg.Settings.TimeoutFrames == 0 {
+		s.cfg.Settings.TimeoutFrames = 10 * 60 * 60
 	}
 
 	return s.advanceFrames(1, queuePhase)
@@ -302,25 +303,28 @@ func (s *Simulation) nextFrame() (bool, error) {
 }
 
 func (s *Simulation) stopCheck() bool {
-	// Exit after specified duration, or timeout duration if in damage mode
-	if s.C.F == int(s.cfg.Settings.Duration*60) {
-		return true
-	}
-
-	// stop if no more actions
-	if s.noMoreActions {
-		return true
-	}
-
-	// stop if all targets are reporting dead
-	allDead := true
-	for _, t := range s.C.Combat.Enemies() {
-		if t.IsAlive() {
-			allDead = false
-			break
+	if s.C.Combat.DamageMode {
+		// stop if no more actions
+		if s.noMoreActions {
+			return true
 		}
+
+		// stop if frames threshold passed
+		if s.C.F == s.cfg.Settings.TimeoutFrames {
+			return true
+		}
+
+		// stop if all targets are reporting dead
+		allDead := true
+		for _, t := range s.C.Combat.Enemies() {
+			if t.IsAlive() {
+				allDead = false
+				break
+			}
+		}
+		return allDead
 	}
-	return allDead
+	return s.C.F == int(s.cfg.Settings.Duration*60)
 }
 
 // TODO: remove defer in favour of every function actually returning error

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -119,8 +119,8 @@ func initialize(s *Simulation) (stateFn, error) {
 	}
 
 	// Timeout frames are currently only used in damage mode
-	if s.cfg.Settings.TimeoutFrames == 0 {
-		s.cfg.Settings.TimeoutFrames = 10 * 60 * 60
+	if s.cfg.Settings.DamageModeDuration == 0 {
+		s.cfg.Settings.DamageModeDuration = 10 * 60
 	}
 
 	return s.advanceFrames(1, queuePhase)
@@ -310,7 +310,7 @@ func (s *Simulation) stopCheck() bool {
 		}
 
 		// stop if frames threshold passed
-		if s.C.F == s.cfg.Settings.TimeoutFrames {
+		if s.C.F == int(s.cfg.Settings.DamageModeDuration*60) {
 			return true
 		}
 

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -118,7 +118,8 @@ func initialize(s *Simulation) (stateFn, error) {
 		s.cfg.Settings.Duration = 90
 	}
 
-	// Timeout frames are currently only used in damage mode
+	// Damage Mode Duration is currently only used in damage mode
+	// Cap sim at 10 min (600s) if no duration set
 	if s.cfg.Settings.DamageModeDuration == 0 {
 		s.cfg.Settings.DamageModeDuration = 10 * 60
 	}

--- a/ui/packages/docs/docs/reference/config.md
+++ b/ui/packages/docs/docs/reference/config.md
@@ -17,8 +17,8 @@ options iteration=1000 duration=90 swap_delay=14;
 
 | name | description | default |
 | --- | --- | --- |
-| `iteration`| Number of iterations to run gcsim for. | 1000 |
-| `duration` | Duration to run gcsim for (in seconds). Fractional duration is allowed, for example: 11.5. In this case, gcsim will run until the duration has passed or there are no more actions to perform. This option is ignored if any `target` has `hp` specified. In that case, gcsim will run until all enemies are dead. | 90 |
+| `iteration` | Number of iterations to run gcsim for. | 1000 |
+| `duration` | Duration to run gcsim for (in seconds). Fractional duration is allowed, for example: 11.5. In this case, gcsim will run until the duration has passed. This option is ignored if any `target` has `hp` specified. In that case, gcsim will run until all enemies are dead or there are no more actions to perform. | 90 |
 | `swap_delay` | Number of frames it takes to swap characters. | 1 |
 | `workers` | Number of workers to use. Only valid when using cli, ignored in web. | 20 |
 | `hitlag` | Whether hitlag should be enabled. See the [hitlag page](/mechanics/hitlag) for more details. | true |
@@ -27,49 +27,47 @@ options iteration=1000 duration=90 swap_delay=14;
 
 ### Set energy generation
 
-Example: 
+Example:
+
 ```
 energy every interval=480,720 amount=1;
 ```
+
 This means that gcsim will generate 1 clear elemental particle every 480 to 720 frames randomly.
 
-:::note
-If multiple `energy every` lines are added, then the values specified by the final one will be used.
-:::
+:::note If multiple `energy every` lines are added, then the values specified by the final one will be used. :::
 
-:::info
-Generating energy only at a specific frame for one time can also be specified. 
-Multiple `energy once` lines can be added to spawn particles at different points in time.
+:::info Generating energy only at a specific frame for one time can also be specified. Multiple `energy once` lines can be added to spawn particles at different points in time.
 
 Example:
+
 ```
 energy once interval=300 amount=1;
 ```
-This drops 1 clear elemental particle once at frame 300.
-:::
 
-### Set hurt generation 
+This drops 1 clear elemental particle once at frame 300. :::
 
-Example: 
+### Set hurt generation
+
+Example:
+
 ```
 hurt every interval=480,720 amount=1,300 element=physical;
 ```
+
 This means that gcsim will deal between 1 and 300 physical damage to the active character every 480 to 720 frames randomly.
 
-:::note
-If multiple `hurt every` lines are added, then the values specified by the final one will be used.
-:::
+:::note If multiple `hurt every` lines are added, then the values specified by the final one will be used. :::
 
-:::info
-Generating hurt only at a specific frame for one time can also be specified. 
-Multiple `hurt once` lines can be added to deal damage at different points in time.
+:::info Generating hurt only at a specific frame for one time can also be specified. Multiple `hurt once` lines can be added to deal damage at different points in time.
 
 Example:
+
 ```
 hurt once interval=300 amount=1,300 element=physical;
 ```
-This will deal between 1 and 300 physical damage to the active character once at frame 300.
-:::
+
+This will deal between 1 and 300 physical damage to the active character once at frame 300. :::
 
 ### Perform character, weapon, artifact setup
 
@@ -77,7 +75,7 @@ Character data can be roughly broken into 4 parts:
 
 - `<name> char` data such as level, cons and talents
 - `<name> add weapon=<weapon name>` data such as refine and level
-- `<name> add set=<set name>` data such as count 
+- `<name> add set=<set name>` data such as count
 - `<name> add stats` for any character stats
 
 For example:
@@ -90,13 +88,9 @@ bennett add stats hp=4780 atk=311 er=0.518 pyro%=0.466 cr=0.311; # main
 bennett add stats hp=717 hp%=0.058 atk=121 atk%=0.635 def=102 em=42 er=0.156 cr=0.128 cd=0.265; # subs
 ```
 
-:::danger
-With the exception of the stats (i.e. `hp`, `atk`, etc...), all other fields not starting with a `+` are mandatory.
-:::danger
+:::danger With the exception of the stats (i.e. `hp`, `atk`, etc...), all other fields not starting with a `+` are mandatory. :::danger
 
-:::info
-An optional param flag may be added to the character/weapon/artifact set via the `+params` flag. This optional param is defined by each character/weapon/artifact set.
-:::
+:::info An optional param flag may be added to the character/weapon/artifact set via the `+params` flag. This optional param is defined by each character/weapon/artifact set. :::
 
 #### Optional global character params
 
@@ -106,34 +100,32 @@ An optional param flag may be added to the character/weapon/artifact set via the
 | `start_hp%` | Set the character's starting hp ratio. | -1 (Character's max hp). Values should be 1 <= `start_hp%` <= 100. |
 | `start_energy` | Set the character's starting energy. | Character's max energy. |
 
-:::info
-Some details about `start_hp` and `start_hp%`:
+:::info Some details about `start_hp` and `start_hp%`:
+
 - a value <= 0 for both (manually supplied or by omission) will mean that the character's hp is set to max
 - `start_hp%` can only be set as a percentage without decimal places, so 50 or 49 but not 49.5.
 - the two params work additively so supplying both with a value > 0 will add them together
 
 Example:
+
 - `start_hp` is 10
 - `start_hp%` is 49
-- the sim will set the character's starting hp to be 49% of max hp + 10 flat hp
-:::
+- the sim will set the character's starting hp to be 49% of max hp + 10 flat hp :::
 
-:::info
-Example: 
+:::info Example:
+
 ```
 bennett char lvl=70/80 cons=2 talent=6,8,8 +params=[start_hp=10,start_hp%=49,start_energy=20];
 ```
-This will set Bennett's starting hp to 49% + 10 and starting energy to 20.
-:::
 
-:::caution
-There is no sanity check on these params. 
-If you set this to a negative number or a really large number, behaviour is undefined. 
-:::
+This will set Bennett's starting hp to 49% + 10 and starting energy to 20. :::
+
+:::caution There is no sanity check on these params. If you set this to a negative number or a really large number, behaviour is undefined. :::
 
 ### Add enemies
 
 Example:
+
 ```
 target lvl=88 resist=0.1 pos=0,0 radius=2 freeze_resist=0.8 hp=9999 particle_threshold=200 particle_drop_count=2;
 ```
@@ -146,52 +138,44 @@ target lvl=88 resist=0.1 pos=0,0 radius=2 freeze_resist=0.8 hp=9999 particle_thr
 | `pos` | Position of the enemy as x,y. | 0,0 |
 | `radius` | The radius of the enemy's circle [hurtbox](https://en.wiktionary.org/wiki/hurtbox) in meters. | 1 |
 | `freeze_resist` | How much freeze resistance the enemy has. `0` means no freeze resistance, `1` means immune to being frozen. The reaction still happens though. | 0 |
-| `hp` | HP of the enemy. If this is set, duration in the sim options will be ignored and the sim will run until all enemies have died. If `hp` is set for at least one enemy, then it has to be set for all enemies. | - |
+| `hp` | HP of the enemy. If this is set, duration in the sim options will be ignored and the sim will run until all enemies have died, there are no more actions to be performed, or the duration safeguard has been met. If `hp` is set for at least one enemy, then it has to be set for all enemies. | - |
+| `damage_mode_duration` | Duration safeguard for damage mode (when hp is set). In case a damage mode sim does not stop normally - via the depletion of all enemie's hp or the completion of all available actions- this option will stop the sim after the specified number of seconds have passed. | 600 |
 | `particle_threshold` | Only available if the `hp` is set. Determines after how much damage the enemy drops elemental particles. Example: If the enemy has 500 HP and this is set to 200, then the enemy will drop particles at 300 and 100 HP. | - |
 | `particle_drop_count` | Only available if the `hp` is set. Number of elemental particles to drop at `particle_threshold`. | - |
 | `particle_element` | Only available if the `hp` is set. Element of the particle at `particle_threshold`. Defaults to clear if not set. | - |
 | `type` | Sets the stats of the target to the one specified in this parameter by name. This overwrites HP, resistances, particle threshold and particle drop count. The `dummy` parameter sets a huge amount of HP to the target with 10% resistance to all types of elemental damage and no particle generation. | - |
 
-:::danger
-All configs must have at least one enemy specified. Otherwise you will get an error. 
-:::
+:::danger All configs must have at least one enemy specified. Otherwise you will get an error. :::
 
-:::info
-To use custom HP or resistances with `type`, include them after `type`.
-Example:
+:::info To use custom HP or resistances with `type`, include them after `type`. Example:
+
 ```
 target lvl=100 type=eremitegalehunter[hp_mult=1] radius=2 pos=0,2.4 hp=10000;
 ```
+
 :::
 
-:::info
-Optional params may be added to the target type via `[]` after the enemy name.
-:::
+:::info Optional params may be added to the target type via `[]` after the enemy name. :::
 
 #### Optional target type params
+
 | name | description | default |
 | --- | --- | --- |
 | `hp_mult` | HP multiplier for the enemy. The default multiplier is 2.5 (Spiral Abyss, Floor 12). | 2.5 |
 | `particles` | Use particle theresholds from the enemy. Use `0` if you want to use a custom threshold (`particle_threshold`). | 1 |
 
-:::info
-If you have multiple targets, make sure to set their starting position properly. 
-Otherwise you may get unintended behaviour such as otherwise single target abilities hitting multiple targets.
-:::
+:::info If you have multiple targets, make sure to set their starting position properly. Otherwise you may get unintended behaviour such as otherwise single target abilities hitting multiple targets. :::
 
-:::info
-To add multiple enemies, simply repeat the target line. 
-Each enemy does not have to have the same level/resistance/position.
+:::info To add multiple enemies, simply repeat the target line. Each enemy does not have to have the same level/resistance/position.
 
 For example:
+
 ```
 target lvl=100 resist=0.1;
 target lvl=88 resist=0.05;
 ```
 
-This would add two targets (making it a multi target simulation). 
-Each target has different level and resistance.
-:::
+This would add two targets (making it a multi target simulation). Each target has different level and resistance. :::
 
 ### Set the active character
 
@@ -201,9 +185,7 @@ Example:
 active xiangling;
 ```
 
-:::danger
-All configs must have an active character specified. Otherwise you will get an error. 
-:::
+:::danger All configs must have an active character specified. Otherwise you will get an error. :::
 
 ### Add comments
 
@@ -304,7 +286,7 @@ if <condition> {
 }
 ```
 
-- `<condition>` can be any expression that evalutes into a number. 
+- `<condition>` can be any expression that evalutes into a number.
 - `<condition>` is considered false if it evaluates to 0 and true otherwise.
 
 ### `switch` statement
@@ -325,8 +307,8 @@ switch <expr> {
 }
 ```
 
-- A case is executed if the switch expression equals the case expression. 
-- There is no `break;` at the end of each case. By default, once a case finishes evaluating, the switch statement will exit. 
+- A case is executed if the switch expression equals the case expression.
+- There is no `break;` at the end of each case. By default, once a case finishes evaluating, the switch statement will exit.
 - The exception to this is if a fallthrough is present. This will cause the case immediately below the current case to be executed as well.
 - The `default` case is executed if none of the cases equals the switch expression. If no `default` is present, the switch will simply exit.
 
@@ -340,7 +322,7 @@ while <condition> {
 }
 ```
 
-- `<condition>` can be any expression that evalutes into a number. 
+- `<condition>` can be any expression that evalutes into a number.
 - `<condition>` is considered false if it evaluates to 0 and true otherwise.
 - `while` will repeat the block for as long as `<condition>` evalutes true.
 
@@ -394,33 +376,33 @@ In this example the `xiangling attack;` can never be reached, causing the script
 `for` statement takes the following format:
 
 ```
-for <init>; <condition>; <post> { 
-    
+for <init>; <condition>; <post> {
+
 }
 ```
 
 - `<init>` must be a variable initialization.
-- `<condition>` can be any expression that evalutes into a number. 
+- `<condition>` can be any expression that evalutes into a number.
 - `<condition>` is considered false if it evaluates to 0 and true otherwise.
 - `<post>` must be a variable assignment without a `;`.
 - `for` will repeat the block for as long as `<condition>` evalutes true.
 
-:::info
-Example:
+:::info Example:
+
 ```
 for let i = 0; i < 5; i = i + 1 {
     xiangling attack;
 }
 ```
-This will execute `xiangling attack;` 5 times.
-:::
+
+This will execute `xiangling attack;` 5 times. :::
 
 ### `break` statement
 
-`break` immediately exits the innermost enclosing `while` loop, `for` loop or `switch` statement. 
+`break` immediately exits the innermost enclosing `while` loop, `for` loop or `switch` statement.
 
-:::info
-Example:
+:::info Example:
+
 ```
 let i = 0;
 while 1 {
@@ -431,15 +413,15 @@ while 1 {
     i = i + 1;
 }
 ```
-This will execute `xiangling attack;` one time, because in the second iteration it will execute the `break;` statement and thus exit the `while` loop.
-:::
+
+This will execute `xiangling attack;` one time, because in the second iteration it will execute the `break;` statement and thus exit the `while` loop. :::
 
 ### `continue` statement
 
 `continue` skips to the next iteration of a `while` or `for` loop.
 
-:::info
-Example:
+:::info Example:
+
 ```
 for let i = 0; i < 5; i = i + 1 {
     if i == 0 {
@@ -448,5 +430,5 @@ for let i = 0; i < 5; i = i + 1 {
     xiangling attack;
 }
 ```
-This will skip the very first iteration of the `for` loop and execute `xiangling attack;` 4 times.
-:::
+
+This will skip the very first iteration of the `for` loop and execute `xiangling attack;` 4 times. :::

--- a/ui/packages/docs/docs/reference/config.md
+++ b/ui/packages/docs/docs/reference/config.md
@@ -18,7 +18,7 @@ options iteration=1000 duration=90 swap_delay=14;
 | name | description | default |
 | --- | --- | --- |
 | `iteration`| Number of iterations to run gcsim for. | 1000 |
-| `duration` | Duration to run gcsim for (in seconds). Fractional duration is allowed, for example: 11.5. In this case, gcsim will run until the duration has passed or there are no more actions to perform. This option is ignored if any `target` has `hp` specified. In that case, gcsim will run until all enemies are dead. | 90 |
+| `duration` | Duration to run gcsim for (in seconds). Fractional duration is allowed, for example: 11.5. In this case, gcsim will run until the duration has passed. This option is ignored if any `target` has `hp` specified. In that case, gcsim will run until all enemies are dead or there are no more actions to perform. | 90 |
 | `swap_delay` | Number of frames it takes to swap characters. | 1 |
 | `workers` | Number of workers to use. Only valid when using cli, ignored in web. | 20 |
 | `hitlag` | Whether hitlag should be enabled. See the [hitlag page](/mechanics/hitlag) for more details. | true |
@@ -146,7 +146,8 @@ target lvl=88 resist=0.1 pos=0,0 radius=2 freeze_resist=0.8 hp=9999 particle_thr
 | `pos` | Position of the enemy as x,y. | 0,0 |
 | `radius` | The radius of the enemy's circle [hurtbox](https://en.wiktionary.org/wiki/hurtbox) in meters. | 1 |
 | `freeze_resist` | How much freeze resistance the enemy has. `0` means no freeze resistance, `1` means immune to being frozen. The reaction still happens though. | 0 |
-| `hp` | HP of the enemy. If this is set, duration in the sim options will be ignored and the sim will run until all enemies have died. If `hp` is set for at least one enemy, then it has to be set for all enemies. | - |
+| `hp` | HP of the enemy. If this is set, duration in the sim options will be ignored and the sim will run until all enemies have died, there are no more actions to be performed, or the duration safeguard has been met. If `hp` is set for at least one enemy, then it has to be set for all enemies. | - |
+| `damage_mode_duration` | Duration safeguard for damage mode (when hp is set). In case a damage mode sim does not stop normally - via the depletion of all enemie's hp or the completion of all available actions- this option will stop the sim after the specified number of seconds have passed. | 600 |
 | `particle_threshold` | Only available if the `hp` is set. Determines after how much damage the enemy drops elemental particles. Example: If the enemy has 500 HP and this is set to 200, then the enemy will drop particles at 300 and 100 HP. | - |
 | `particle_drop_count` | Only available if the `hp` is set. Number of elemental particles to drop at `particle_threshold`. | - |
 | `particle_element` | Only available if the `hp` is set. Element of the particle at `particle_threshold`. Defaults to clear if not set. | - |

--- a/ui/packages/docs/docs/reference/config.md
+++ b/ui/packages/docs/docs/reference/config.md
@@ -17,8 +17,8 @@ options iteration=1000 duration=90 swap_delay=14;
 
 | name | description | default |
 | --- | --- | --- |
-| `iteration` | Number of iterations to run gcsim for. | 1000 |
-| `duration` | Duration to run gcsim for (in seconds). Fractional duration is allowed, for example: 11.5. In this case, gcsim will run until the duration has passed. This option is ignored if any `target` has `hp` specified. In that case, gcsim will run until all enemies are dead or there are no more actions to perform. | 90 |
+| `iteration`| Number of iterations to run gcsim for. | 1000 |
+| `duration` | Duration to run gcsim for (in seconds). Fractional duration is allowed, for example: 11.5. In this case, gcsim will run until the duration has passed or there are no more actions to perform. This option is ignored if any `target` has `hp` specified. In that case, gcsim will run until all enemies are dead. | 90 |
 | `swap_delay` | Number of frames it takes to swap characters. | 1 |
 | `workers` | Number of workers to use. Only valid when using cli, ignored in web. | 20 |
 | `hitlag` | Whether hitlag should be enabled. See the [hitlag page](/mechanics/hitlag) for more details. | true |
@@ -27,47 +27,49 @@ options iteration=1000 duration=90 swap_delay=14;
 
 ### Set energy generation
 
-Example:
-
+Example: 
 ```
 energy every interval=480,720 amount=1;
 ```
-
 This means that gcsim will generate 1 clear elemental particle every 480 to 720 frames randomly.
 
-:::note If multiple `energy every` lines are added, then the values specified by the final one will be used. :::
+:::note
+If multiple `energy every` lines are added, then the values specified by the final one will be used.
+:::
 
-:::info Generating energy only at a specific frame for one time can also be specified. Multiple `energy once` lines can be added to spawn particles at different points in time.
+:::info
+Generating energy only at a specific frame for one time can also be specified. 
+Multiple `energy once` lines can be added to spawn particles at different points in time.
 
 Example:
-
 ```
 energy once interval=300 amount=1;
 ```
+This drops 1 clear elemental particle once at frame 300.
+:::
 
-This drops 1 clear elemental particle once at frame 300. :::
+### Set hurt generation 
 
-### Set hurt generation
-
-Example:
-
+Example: 
 ```
 hurt every interval=480,720 amount=1,300 element=physical;
 ```
-
 This means that gcsim will deal between 1 and 300 physical damage to the active character every 480 to 720 frames randomly.
 
-:::note If multiple `hurt every` lines are added, then the values specified by the final one will be used. :::
+:::note
+If multiple `hurt every` lines are added, then the values specified by the final one will be used.
+:::
 
-:::info Generating hurt only at a specific frame for one time can also be specified. Multiple `hurt once` lines can be added to deal damage at different points in time.
+:::info
+Generating hurt only at a specific frame for one time can also be specified. 
+Multiple `hurt once` lines can be added to deal damage at different points in time.
 
 Example:
-
 ```
 hurt once interval=300 amount=1,300 element=physical;
 ```
-
-This will deal between 1 and 300 physical damage to the active character once at frame 300. :::
+This will deal between 1 and 300 physical damage to the active character once at frame 300.
+:::
 
 ### Perform character, weapon, artifact setup
 
@@ -75,7 +77,7 @@ Character data can be roughly broken into 4 parts:
 
 - `<name> char` data such as level, cons and talents
 - `<name> add weapon=<weapon name>` data such as refine and level
-- `<name> add set=<set name>` data such as count
+- `<name> add set=<set name>` data such as count 
 - `<name> add stats` for any character stats
 
 For example:
@@ -88,9 +90,13 @@ bennett add stats hp=4780 atk=311 er=0.518 pyro%=0.466 cr=0.311; # main
 bennett add stats hp=717 hp%=0.058 atk=121 atk%=0.635 def=102 em=42 er=0.156 cr=0.128 cd=0.265; # subs
 ```
 
-:::danger With the exception of the stats (i.e. `hp`, `atk`, etc...), all other fields not starting with a `+` are mandatory. :::danger
+:::danger
+With the exception of the stats (i.e. `hp`, `atk`, etc...), all other fields not starting with a `+` are mandatory.
+:::danger
 
-:::info An optional param flag may be added to the character/weapon/artifact set via the `+params` flag. This optional param is defined by each character/weapon/artifact set. :::
+:::info
+An optional param flag may be added to the character/weapon/artifact set via the `+params` flag. This optional param is defined by each character/weapon/artifact set.
+:::
 
 #### Optional global character params
 
@@ -100,32 +106,34 @@ bennett add stats hp=717 hp%=0.058 atk=121 atk%=0.635 def=102 em=42 er=0.156 cr=
 | `start_hp%` | Set the character's starting hp ratio. | -1 (Character's max hp). Values should be 1 <= `start_hp%` <= 100. |
 | `start_energy` | Set the character's starting energy. | Character's max energy. |
 
-:::info Some details about `start_hp` and `start_hp%`:
-
+:::info
+Some details about `start_hp` and `start_hp%`:
 - a value <= 0 for both (manually supplied or by omission) will mean that the character's hp is set to max
 - `start_hp%` can only be set as a percentage without decimal places, so 50 or 49 but not 49.5.
 - the two params work additively so supplying both with a value > 0 will add them together
 
 Example:
-
 - `start_hp` is 10
 - `start_hp%` is 49
-- the sim will set the character's starting hp to be 49% of max hp + 10 flat hp :::
+- the sim will set the character's starting hp to be 49% of max hp + 10 flat hp
+:::
 
-:::info Example:
-
+:::info
+Example: 
 ```
 bennett char lvl=70/80 cons=2 talent=6,8,8 +params=[start_hp=10,start_hp%=49,start_energy=20];
 ```
+This will set Bennett's starting hp to 49% + 10 and starting energy to 20.
+:::
 
-This will set Bennett's starting hp to 49% + 10 and starting energy to 20. :::
-
-:::caution There is no sanity check on these params. If you set this to a negative number or a really large number, behaviour is undefined. :::
+:::caution
+There is no sanity check on these params. 
+If you set this to a negative number or a really large number, behaviour is undefined. 
+:::
 
 ### Add enemies
 
 Example:
-
 ```
 target lvl=88 resist=0.1 pos=0,0 radius=2 freeze_resist=0.8 hp=9999 particle_threshold=200 particle_drop_count=2;
 ```
@@ -138,44 +146,52 @@ target lvl=88 resist=0.1 pos=0,0 radius=2 freeze_resist=0.8 hp=9999 particle_thr
 | `pos` | Position of the enemy as x,y. | 0,0 |
 | `radius` | The radius of the enemy's circle [hurtbox](https://en.wiktionary.org/wiki/hurtbox) in meters. | 1 |
 | `freeze_resist` | How much freeze resistance the enemy has. `0` means no freeze resistance, `1` means immune to being frozen. The reaction still happens though. | 0 |
-| `hp` | HP of the enemy. If this is set, duration in the sim options will be ignored and the sim will run until all enemies have died, there are no more actions to be performed, or the duration safeguard has been met. If `hp` is set for at least one enemy, then it has to be set for all enemies. | - |
-| `damage_mode_duration` | Duration safeguard for damage mode (when hp is set). In case a damage mode sim does not stop normally - via the depletion of all enemie's hp or the completion of all available actions- this option will stop the sim after the specified number of seconds have passed. | 600 |
+| `hp` | HP of the enemy. If this is set, duration in the sim options will be ignored and the sim will run until all enemies have died. If `hp` is set for at least one enemy, then it has to be set for all enemies. | - |
 | `particle_threshold` | Only available if the `hp` is set. Determines after how much damage the enemy drops elemental particles. Example: If the enemy has 500 HP and this is set to 200, then the enemy will drop particles at 300 and 100 HP. | - |
 | `particle_drop_count` | Only available if the `hp` is set. Number of elemental particles to drop at `particle_threshold`. | - |
 | `particle_element` | Only available if the `hp` is set. Element of the particle at `particle_threshold`. Defaults to clear if not set. | - |
 | `type` | Sets the stats of the target to the one specified in this parameter by name. This overwrites HP, resistances, particle threshold and particle drop count. The `dummy` parameter sets a huge amount of HP to the target with 10% resistance to all types of elemental damage and no particle generation. | - |
 
-:::danger All configs must have at least one enemy specified. Otherwise you will get an error. :::
+:::danger
+All configs must have at least one enemy specified. Otherwise you will get an error. 
+:::
 
-:::info To use custom HP or resistances with `type`, include them after `type`. Example:
-
+:::info
+To use custom HP or resistances with `type`, include them after `type`.
+Example:
 ```
 target lvl=100 type=eremitegalehunter[hp_mult=1] radius=2 pos=0,2.4 hp=10000;
 ```
-
 :::
 
-:::info Optional params may be added to the target type via `[]` after the enemy name. :::
+:::info
+Optional params may be added to the target type via `[]` after the enemy name.
+:::
 
 #### Optional target type params
-
 | name | description | default |
 | --- | --- | --- |
 | `hp_mult` | HP multiplier for the enemy. The default multiplier is 2.5 (Spiral Abyss, Floor 12). | 2.5 |
 | `particles` | Use particle theresholds from the enemy. Use `0` if you want to use a custom threshold (`particle_threshold`). | 1 |
 
-:::info If you have multiple targets, make sure to set their starting position properly. Otherwise you may get unintended behaviour such as otherwise single target abilities hitting multiple targets. :::
+:::info
+If you have multiple targets, make sure to set their starting position properly. 
+Otherwise you may get unintended behaviour such as otherwise single target abilities hitting multiple targets.
+:::
 
-:::info To add multiple enemies, simply repeat the target line. Each enemy does not have to have the same level/resistance/position.
+:::info
+To add multiple enemies, simply repeat the target line. 
+Each enemy does not have to have the same level/resistance/position.
 
 For example:
-
 ```
 target lvl=100 resist=0.1;
 target lvl=88 resist=0.05;
 ```
 
-This would add two targets (making it a multi target simulation). Each target has different level and resistance. :::
+This would add two targets (making it a multi target simulation). 
+Each target has different level and resistance.
+:::
 
 ### Set the active character
 
@@ -185,7 +201,9 @@ Example:
 active xiangling;
 ```
 
-:::danger All configs must have an active character specified. Otherwise you will get an error. :::
+:::danger
+All configs must have an active character specified. Otherwise you will get an error. 
+:::
 
 ### Add comments
 
@@ -286,7 +304,7 @@ if <condition> {
 }
 ```
 
-- `<condition>` can be any expression that evalutes into a number.
+- `<condition>` can be any expression that evalutes into a number. 
 - `<condition>` is considered false if it evaluates to 0 and true otherwise.
 
 ### `switch` statement
@@ -307,8 +325,8 @@ switch <expr> {
 }
 ```
 
-- A case is executed if the switch expression equals the case expression.
-- There is no `break;` at the end of each case. By default, once a case finishes evaluating, the switch statement will exit.
+- A case is executed if the switch expression equals the case expression. 
+- There is no `break;` at the end of each case. By default, once a case finishes evaluating, the switch statement will exit. 
 - The exception to this is if a fallthrough is present. This will cause the case immediately below the current case to be executed as well.
 - The `default` case is executed if none of the cases equals the switch expression. If no `default` is present, the switch will simply exit.
 
@@ -322,7 +340,7 @@ while <condition> {
 }
 ```
 
-- `<condition>` can be any expression that evalutes into a number.
+- `<condition>` can be any expression that evalutes into a number. 
 - `<condition>` is considered false if it evaluates to 0 and true otherwise.
 - `while` will repeat the block for as long as `<condition>` evalutes true.
 
@@ -376,33 +394,33 @@ In this example the `xiangling attack;` can never be reached, causing the script
 `for` statement takes the following format:
 
 ```
-for <init>; <condition>; <post> {
-
+for <init>; <condition>; <post> { 
+    
 }
 ```
 
 - `<init>` must be a variable initialization.
-- `<condition>` can be any expression that evalutes into a number.
+- `<condition>` can be any expression that evalutes into a number. 
 - `<condition>` is considered false if it evaluates to 0 and true otherwise.
 - `<post>` must be a variable assignment without a `;`.
 - `for` will repeat the block for as long as `<condition>` evalutes true.
 
-:::info Example:
-
+:::info
+Example:
 ```
 for let i = 0; i < 5; i = i + 1 {
     xiangling attack;
 }
 ```
-
-This will execute `xiangling attack;` 5 times. :::
+This will execute `xiangling attack;` 5 times.
+:::
 
 ### `break` statement
 
-`break` immediately exits the innermost enclosing `while` loop, `for` loop or `switch` statement.
+`break` immediately exits the innermost enclosing `while` loop, `for` loop or `switch` statement. 
 
-:::info Example:
-
+:::info
+Example:
 ```
 let i = 0;
 while 1 {
@@ -413,15 +431,15 @@ while 1 {
     i = i + 1;
 }
 ```
-
-This will execute `xiangling attack;` one time, because in the second iteration it will execute the `break;` statement and thus exit the `while` loop. :::
+This will execute `xiangling attack;` one time, because in the second iteration it will execute the `break;` statement and thus exit the `while` loop.
+:::
 
 ### `continue` statement
 
 `continue` skips to the next iteration of a `while` or `for` loop.
 
-:::info Example:
-
+:::info
+Example:
 ```
 for let i = 0; i < 5; i = i + 1 {
     if i == 0 {
@@ -430,5 +448,5 @@ for let i = 0; i < 5; i = i + 1 {
     xiangling attack;
 }
 ```
-
-This will skip the very first iteration of the `for` loop and execute `xiangling attack;` 4 times. :::
+This will skip the very first iteration of the `for` loop and execute `xiangling attack;` 4 times.
+:::

--- a/ui/packages/docs/docs/reference/config.md
+++ b/ui/packages/docs/docs/reference/config.md
@@ -19,6 +19,7 @@ options iteration=1000 duration=90 swap_delay=14;
 | --- | --- | --- |
 | `iteration`| Number of iterations to run gcsim for. | 1000 |
 | `duration` | Duration to run gcsim for (in seconds). Fractional duration is allowed, for example: 11.5. In this case, gcsim will run until the duration has passed. This option is ignored if any `target` has `hp` specified. In that case, gcsim will run until all enemies are dead or there are no more actions to perform. | 90 |
+| `damage_mode_duration` | Duration safeguard for damage mode (when hp is set). In case a damage mode sim does not stop normally - via the depletion of all enemie's hp or the completion of all available actions- this option will stop the sim after the specified number of seconds have passed. | 600 |
 | `swap_delay` | Number of frames it takes to swap characters. | 1 |
 | `workers` | Number of workers to use. Only valid when using cli, ignored in web. | 20 |
 | `hitlag` | Whether hitlag should be enabled. See the [hitlag page](/mechanics/hitlag) for more details. | true |
@@ -147,7 +148,6 @@ target lvl=88 resist=0.1 pos=0,0 radius=2 freeze_resist=0.8 hp=9999 particle_thr
 | `radius` | The radius of the enemy's circle [hurtbox](https://en.wiktionary.org/wiki/hurtbox) in meters. | 1 |
 | `freeze_resist` | How much freeze resistance the enemy has. `0` means no freeze resistance, `1` means immune to being frozen. The reaction still happens though. | 0 |
 | `hp` | HP of the enemy. If this is set, duration in the sim options will be ignored and the sim will run until all enemies have died, there are no more actions to be performed, or the duration safeguard has been met. If `hp` is set for at least one enemy, then it has to be set for all enemies. | - |
-| `damage_mode_duration` | Duration safeguard for damage mode (when hp is set). In case a damage mode sim does not stop normally - via the depletion of all enemie's hp or the completion of all available actions- this option will stop the sim after the specified number of seconds have passed. | 600 |
 | `particle_threshold` | Only available if the `hp` is set. Determines after how much damage the enemy drops elemental particles. Example: If the enemy has 500 HP and this is set to 200, then the enemy will drop particles at 300 and 100 HP. | - |
 | `particle_drop_count` | Only available if the `hp` is set. Number of elemental particles to drop at `particle_threshold`. | - |
 | `particle_element` | Only available if the `hp` is set. Element of the particle at `particle_threshold`. Defaults to clear if not set. | - |


### PR DESCRIPTION
- Simulation config, duration field used as a timeout setting for damage mode, instead of being ignored.
- Sim currently sets timeout to 10 minutes with damage mode, no matter what user specifies.
- This can be changed to use whatever timer the user puts in their config, if desired.
- Default can be changed, if desired.
- A warning can be added to results when timeout occurs, if desired.

The purpose of this PR is to stop simulations early when infinite actions are provided to the gcsl parser. This PR does not attempt to stop other kinds of infinite loops, or act as a generic memory watchdog.