### PR TITLE
Added grace period to SS drain per void rift absorbed

### DIFF
--- a/internal/characters/skirk/asc.go
+++ b/internal/characters/skirk/asc.go
@@ -10,14 +10,12 @@ import (
 )
 
 const (
-	a1Dur                = 1054
-	a1Key                = "skirk-a1"
-	a1IcdKey             = "skirk-a1-icd"
-	a1SSPauseKey         = "skirk-a1-ss-pause"
-	a1SSPauseDurPerStack = 0.3 * 60
-	a1SSPauseMaxDur      = a1SSPauseDurPerStack * 3
-	a4Key                = "deaths-crossing"
-	a4Dur                = 20 * 60
+	a1Dur        = 1054
+	a1Key        = "skirk-a1"
+	a1IcdKey     = "skirk-a1-icd"
+	a1SSPauseKey = "skirk-a1-ss-pause"
+	a4Key        = "deaths-crossing"
+	a4Dur        = 20 * 60
 )
 
 var (
@@ -75,16 +73,20 @@ func (c *char) onVoidAbsorb(count int) {
 }
 
 func (c *char) addA1SSPauseDur(count int) {
-	existingPauseDur := c.StatusDuration(a1SSPauseKey)
-	newDur := existingPauseDur
-	for range count {
-		if newDur <= 0.75*60 { // < 0.75*60 means there are 5 or less stacks. When at 6 stacks (duration from (0.75, 0.9]) we don't add stacks
-			newDur = min(existingPauseDur+count*a1SSPauseDurPerStack, a1SSPauseMaxDur)
-		} else {
-			break
-		}
+	c.AddStatus(a1SSPauseKey, -1, false)
+	if c.a1PauseSSStacks == 0 {
+		c.QueueCharTask(c.a1SSPauseTicker, 0.15*60)
 	}
-	c.AddStatus(a1SSPauseKey, newDur, false)
+	c.a1PauseSSStacks = min(c.a1PauseSSStacks+count*2, 6)
+}
+
+func (c *char) a1SSPauseTicker() {
+	c.a1PauseSSStacks -= 1
+	if c.a1PauseSSStacks == 0 {
+		c.DeleteStatus(a1SSPauseKey)
+		return
+	}
+	c.QueueCharTask(c.a1SSPauseTicker, 0.15*60)
 }
 
 func (c *char) createVoidRift() {

--- a/internal/characters/skirk/asc.go
+++ b/internal/characters/skirk/asc.go
@@ -75,7 +75,7 @@ func (c *char) onVoidAbsorb(count int) {
 func (c *char) addA1SSPauseDur(count int) {
 	c.AddStatus(a1SSPauseKey, -1, false)
 	if c.a1PauseSSStacks == 0 {
-		c.QueueCharTask(c.a1SSPauseTicker, 0.15*60)
+		c.Core.Tasks.Add(c.a1SSPauseTicker, 0.15*60)
 	}
 	c.a1PauseSSStacks = min(c.a1PauseSSStacks+count*2, 6)
 }
@@ -86,7 +86,7 @@ func (c *char) a1SSPauseTicker() {
 		c.DeleteStatus(a1SSPauseKey)
 		return
 	}
-	c.QueueCharTask(c.a1SSPauseTicker, 0.15*60)
+	c.Core.Tasks.Add(c.a1SSPauseTicker, 0.15*60)
 }
 
 func (c *char) createVoidRift() {

--- a/internal/characters/skirk/asc.go
+++ b/internal/characters/skirk/asc.go
@@ -10,11 +10,14 @@ import (
 )
 
 const (
-	a1Dur    = 1054
-	a1Key    = "skirk-a1"
-	a1IcdKey = "skirk-a1-icd"
-	a4Key    = "deaths-crossing"
-	a4Dur    = 20 * 60
+	a1Dur                = 1054
+	a1Key                = "skirk-a1"
+	a1IcdKey             = "skirk-a1-icd"
+	a1SSPauseKey         = "skirk-a1-ss-pause"
+	a1SSPauseDurPerStack = 0.3 * 60
+	a1SSPauseMaxDur      = a1SSPauseDurPerStack * 3
+	a4Key                = "deaths-crossing"
+	a4Dur                = 20 * 60
 )
 
 var (
@@ -65,6 +68,9 @@ func (c *char) onVoidAbsorb(count int) {
 
 	c.AddSerpentsSubtlety("a1-void-rifts", float64(count)*8.0)
 
+	existingPauseDur := c.StatusDuration(a1SSPauseKey)
+	newPauseDur := min(existingPauseDur+count*a1SSPauseDurPerStack, a1SSPauseMaxDur)
+	c.AddStatus(a1SSPauseKey, newPauseDur, false)
 	for range count {
 		c.c1()
 		c.c6OnVoidAbsorb()

--- a/internal/characters/skirk/asc.go
+++ b/internal/characters/skirk/asc.go
@@ -67,7 +67,7 @@ func (c *char) onVoidAbsorb(count int) {
 	}
 
 	c.AddSerpentsSubtlety("a1-void-rifts", float64(count)*8.0)
-
+	c.addA1SSPauseDur(count)
 	existingPauseDur := c.StatusDuration(a1SSPauseKey)
 	// if the existing pause duration is more than 0.75s, we do not refill to the full 0.9s
 	if existingPauseDur <= 0.75*60 {
@@ -78,6 +78,19 @@ func (c *char) onVoidAbsorb(count int) {
 		c.c1()
 		c.c6OnVoidAbsorb()
 	}
+}
+
+func (c *char) addA1SSPauseDur(count int) {
+	existingPauseDur := c.StatusDuration(a1SSPauseKey)
+	newDur := existingPauseDur
+	for range count {
+		if newDur <= 0.75*60 { // < 0.75*60 means there are 5 or less stacks. When at 6 stacks (duration from (0.75, 0.9]) we don't add stacks
+			newDur = min(existingPauseDur+count*a1SSPauseDurPerStack, a1SSPauseMaxDur)
+		} else {
+			break
+		}
+	}
+	c.AddStatus(a1SSPauseKey, newDur, false)
 }
 
 func (c *char) createVoidRift() {

--- a/internal/characters/skirk/asc.go
+++ b/internal/characters/skirk/asc.go
@@ -69,8 +69,11 @@ func (c *char) onVoidAbsorb(count int) {
 	c.AddSerpentsSubtlety("a1-void-rifts", float64(count)*8.0)
 
 	existingPauseDur := c.StatusDuration(a1SSPauseKey)
-	newPauseDur := min(existingPauseDur+count*a1SSPauseDurPerStack, a1SSPauseMaxDur)
-	c.AddStatus(a1SSPauseKey, newPauseDur, false)
+	// if the existing pause duration is more than 0.75s, we do not refill to the full 0.9s
+	if existingPauseDur <= 0.75*60 {
+		newPauseDur := min(existingPauseDur+count*a1SSPauseDurPerStack, a1SSPauseMaxDur)
+		c.AddStatus(a1SSPauseKey, newPauseDur, false)
+	}
 	for range count {
 		c.c1()
 		c.c6OnVoidAbsorb()

--- a/internal/characters/skirk/asc.go
+++ b/internal/characters/skirk/asc.go
@@ -68,12 +68,6 @@ func (c *char) onVoidAbsorb(count int) {
 
 	c.AddSerpentsSubtlety("a1-void-rifts", float64(count)*8.0)
 	c.addA1SSPauseDur(count)
-	existingPauseDur := c.StatusDuration(a1SSPauseKey)
-	// if the existing pause duration is more than 0.75s, we do not refill to the full 0.9s
-	if existingPauseDur <= 0.75*60 {
-		newPauseDur := min(existingPauseDur+count*a1SSPauseDurPerStack, a1SSPauseMaxDur)
-		c.AddStatus(a1SSPauseKey, newPauseDur, false)
-	}
 	for range count {
 		c.c1()
 		c.c6OnVoidAbsorb()

--- a/internal/characters/skirk/skill.go
+++ b/internal/characters/skirk/skill.go
@@ -96,11 +96,13 @@ func (c *char) serpentsReduceTask(src int) {
 		}
 		// reduce 1.4 point every 12f, which is 7 per second
 		// for 0.3s per absorbed void rift, SS consumption is frozen
-		if !c.StatusIsActive(a1SSPauseKey) {
+		if c.a1PauseSSStacks == 0 {
 			c.ReduceSerpentsSubtlety(c.Base.Key.String()+"skill", 1.4)
 			if c.serpentsSubtlety == 0 && c.StatusIsActive(skillKey) {
 				c.exitSkillState(src)
 			}
+		} else {
+			c.Core.Log.NewEventBuildMsg(glog.LogCharacterEvent, c.Index(), "skip SS drain due to "+a1SSPauseKey)
 		}
 
 		c.serpentsReduceTask(src)

--- a/internal/characters/skirk/skill.go
+++ b/internal/characters/skirk/skill.go
@@ -95,10 +95,14 @@ func (c *char) serpentsReduceTask(src int) {
 			return
 		}
 		// reduce 1.4 point every 12f, which is 7 per second
-		c.ReduceSerpentsSubtlety(c.Base.Key.String()+"skill", 1.4)
-		if c.serpentsSubtlety == 0 && c.StatusIsActive(skillKey) {
-			c.exitSkillState(src)
+		// for 0.3s per absorbed void rift, SS consumption is frozen
+		if !c.StatusIsActive(a1SSPauseKey) {
+			c.ReduceSerpentsSubtlety(c.Base.Key.String()+"skill", 1.4)
+			if c.serpentsSubtlety == 0 && c.StatusIsActive(skillKey) {
+				c.exitSkillState(src)
+			}
 		}
+
 		c.serpentsReduceTask(src)
 	}, 60*tickInterval)
 }

--- a/internal/characters/skirk/skirk.go
+++ b/internal/characters/skirk/skirk.go
@@ -27,6 +27,7 @@ type char struct {
 	burstCount       int
 	burstVoids       int
 	voidRifts        RingQueue[int]
+	a1PauseSSStacks  int
 	c2Atk            []float64
 	c6Stacks         RingQueue[int]
 }


### PR DESCRIPTION
Implementing mechanic for Skirk:

After absorbing Void Rifts, for 0.3s per absorbed void rift, Skirk's SS consumption is paused.

The cap is 6 stacks, and stacks go down every 0.15s. this means that when duration is between 0.9s and 0.75s, the buff is not extended, otherwise each stack will extend buff by 0.15s.

Each void rifts gives 2 stacks.