### PR TITLE
Added invalid weapon error to simulator

### DIFF
--- a/pkg/gcs/parser/parseCharacter.go
+++ b/pkg/gcs/parser/parseCharacter.go
@@ -197,7 +197,7 @@ func parseCharAddWeapon(p *Parser) (parseFn, error) {
 	}
 	label, ok := shortcut.WeaponNameToKey[s]
 	if !ok {
-		return nil, fmt.Errorf("invalid set %v", s)
+		return nil, fmt.Errorf("invalid weapon %v", s)
 	}
 	c.Weapon.Key = label
 	c.Weapon.Name = c.Weapon.Key.String()

--- a/pkg/gcs/parser/parseCharacter.go
+++ b/pkg/gcs/parser/parseCharacter.go
@@ -195,7 +195,11 @@ func parseCharAddWeapon(p *Parser) (parseFn, error) {
 	if len(s) > 0 && s[len(s)-1] == '"' {
 		s = s[:len(s)-1]
 	}
-	c.Weapon.Key = shortcut.WeaponNameToKey[s]
+	label, ok := shortcut.WeaponNameToKey[s]
+	if !ok {
+		return nil, fmt.Errorf("invalid set %v", s)
+	}
+	c.Weapon.Key = label
 	c.Weapon.Name = c.Weapon.Key.String()
 
 	lvlOk := false


### PR DESCRIPTION
Provides same QOL for weapon names as for artifact names by giving error when weapon name doesn't match any name from the list of valid weapon names.