### PR TITLE
Removed nightsoul consume event from nightsoul clear points

### DIFF
--- a/internal/characters/citlali/skill.go
+++ b/internal/characters/citlali/skill.go
@@ -78,7 +78,7 @@ func (c *char) Skill(_ map[string]int) (action.Info, error) {
 
 	if c.Base.Cons >= 6 {
 		currentPoints := c.nightsoulState.Points()
-		c.nightsoulState.ClearPoints()
+		c.nightsoulState.ConsumePoints(currentPoints)
 		c.numC6Stacks = min(maxC6Stacks, currentPoints)
 	}
 

--- a/internal/characters/kinich/skill.go
+++ b/internal/characters/kinich/skill.go
@@ -141,7 +141,7 @@ func (c *char) ScalespikerCannon(p map[string]int) (action.Info, error) {
 	var snap info.Snapshot
 	c.QueueCharTask(func() {
 		// Nightsoul points are drained before snapshot
-		c.nightsoulState.ClearPoints()
+		c.nightsoulState.ConsumePoints(c.nightsoulState.Points())
 		snap = c.Snapshot(&ai)
 		c.Core.Tasks.Add(c.createBlindSpot, blindSpotDelay)
 		c.Core.Tasks.Add(func() {

--- a/internal/characters/mavuika/charge.go
+++ b/internal/characters/mavuika/charge.go
@@ -407,6 +407,7 @@ func (c *char) BikeChargeAttackFinal(caFrames, skippedWindupFrames int) (action.
 		}, adjustedBikeChargeFinalHitmark)
 
 		c.QueueCharTask(func() {
+			c.nightsoulState.ConsumePoints(c.nightsoulState.Points())
 			c.exitNightsoul()
 		}, nightSoulDuration)
 	}

--- a/internal/characters/varesa/plunge.go
+++ b/internal/characters/varesa/plunge.go
@@ -182,7 +182,9 @@ func (c *char) highPlungeCA(p map[string]int) action.Info {
 		c.exitNS = true
 		plungeFrames = fieryHighPlungeFrames
 
-		c.QueueCharTask(c.nightsoulState.ClearPoints, 2)
+		c.QueueCharTask(func() {
+			c.nightsoulState.ConsumePoints(c.nightsoulState.Points())
+		}, 2)
 	} else {
 		c.QueueCharTask(c.generatePlungeNightsoul, hitmark)
 	}
@@ -242,7 +244,9 @@ func (c *char) highPlungeXY(p map[string]int) action.Info {
 		c.exitNS = true
 		plungeFrames = frames.NewAbilFunc(xianyunFieryHighPlungeFrames)
 
-		c.QueueCharTask(c.nightsoulState.ClearPoints, 2)
+		c.QueueCharTask(func() {
+			c.nightsoulState.ConsumePoints(c.nightsoulState.Points())
+		}, 2)
 	} else {
 		c.QueueCharTask(c.generatePlungeNightsoul, hitmark)
 	}
@@ -302,7 +306,9 @@ func (c *char) lowPlungeXY(p map[string]int) action.Info {
 		c.exitNS = true
 		plungeFrames = frames.NewAbilFunc(xianyunFieryLowPlungeFrames)
 
-		c.QueueCharTask(c.nightsoulState.ClearPoints, 2)
+		c.QueueCharTask(func() {
+			c.nightsoulState.ConsumePoints(c.nightsoulState.Points())
+		}, 2)
 	} else {
 		c.QueueCharTask(c.generatePlungeNightsoul, hitmark)
 	}

--- a/internal/characters/xilonen/asc.go
+++ b/internal/characters/xilonen/asc.go
@@ -71,7 +71,7 @@ func (c *char) a1cb(cb info.AttackCB) {
 }
 
 func (c *char) a1MaxPoints() {
-	c.nightsoulState.ClearPoints()
+	c.nightsoulState.ConsumePoints(c.nightsoulState.Points())
 	c.AddStatus(activeSamplerKey, 15*60, false)
 	if c.Base.Cons >= 2 {
 		c.AddStatus(c2key, 15*60, true)

--- a/internal/characters/xilonen/skill.go
+++ b/internal/characters/xilonen/skill.go
@@ -76,7 +76,7 @@ func (c *char) exitNightsoul() {
 		return
 	}
 	c.nightsoulState.ExitBlessing()
-	// c.nightsoulState.ClearPoints() // TODO: add a method to clear points without a consume event
+	c.nightsoulState.ClearPoints()
 	c.nightsoulSrc = -1
 	c.exitStateSrc = -1
 	c.SetCD(action.ActionSkill, 7*60)

--- a/internal/template/nightsoul/nightsoul.go
+++ b/internal/template/nightsoul/nightsoul.go
@@ -153,7 +153,6 @@ func (s *State) ConsumePoints(amount float64) {
 func (s *State) ClearPoints() {
 	amt := s.nightsoulPoints
 	s.nightsoulPoints = 0
-	s.c.Events.Emit(event.OnNightsoulConsume, s.char.Index(), amt)
 	s.c.Log.NewEvent("clear nightsoul points", glog.LogCharacterEvent, s.char.Index()).
 		Write("previous points", amt)
 }


### PR DESCRIPTION
Removed s.c.Events.Emit(event.OnNightsoulConsume from ClearPoints() in nightsoul.go.

Abilities that consumed all nightsoul points were changed from ClearPoints() to ConsumePoints(c.nightsoulState.Points()).

Purpose of this PR is to stop Mavuika from getting fighting spirit when characters cancel their nightsoul state and don't spend the points.