### PR TITLE
Fix Gest of the Mighty Wolf not applying hex passive on 2 Hex chars in team

### DIFF
--- a/internal/weapons/claymore/gestofthemightywolf/gestofthemightywolf.go
+++ b/internal/weapons/claymore/gestofthemightywolf/gestofthemightywolf.go
@@ -17,11 +17,13 @@ func init() {
 }
 
 type Weapon struct {
-	Index  int
-	char   *character.CharWrapper
-	refine int
-	stacks int
-	mod    []float64
+	Index               int
+	char                *character.CharWrapper
+	core                *core.Core
+	refine              int
+	stacks              int
+	mod                 []float64
+	isHexereiSecretRite bool
 }
 
 const (
@@ -30,11 +32,16 @@ const (
 )
 
 func (w *Weapon) SetIndex(idx int) { w.Index = idx }
-func (w *Weapon) Init() error      { return nil }
+
+func (w *Weapon) Init() error {
+	w.isHexereiSecretRite = w.core.Player.GetHexereiCount() >= 2
+	return nil
+}
 
 func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) (info.Weapon, error) {
 	w := &Weapon{
 		char:   char,
+		core:   c,
 		refine: p.Refine,
 		mod:    make([]float64, attributes.EndStatType),
 	}
@@ -74,7 +81,7 @@ func (w *Weapon) addStacks(amt int) {
 		Amount: func() []float64 {
 			w.mod[attributes.DmgP] = (0.055 + 0.02*float64(w.refine)) * float64(w.stacks)
 
-			if !w.char.IsHexerei {
+			if !w.isHexereiSecretRite {
 				return w.mod
 			}
 

--- a/internal/weapons/claymore/gestofthemightywolf/gestofthemightywolf.go
+++ b/internal/weapons/claymore/gestofthemightywolf/gestofthemightywolf.go
@@ -63,6 +63,9 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 		if atk.Info.ActorIndex != char.Index() {
 			return
 		}
+		if w.core.Player.Active() != char.Index() {
+			return
+		}
 		if atk.Info.AttackTag != attacks.AttackTagNormal {
 			return
 		}

--- a/internal/weapons/claymore/gestofthemightywolf/gestofthemightywolf.go
+++ b/internal/weapons/claymore/gestofthemightywolf/gestofthemightywolf.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	"github.com/genshinsim/gcsim/pkg/core"
+	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/event"
+	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/info"
 	"github.com/genshinsim/gcsim/pkg/core/keys"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
@@ -57,15 +59,28 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 	})
 
 	c.Events.Subscribe(event.OnEnemyDamage, func(args ...any) {
+		atk := args[1].(*info.AttackEvent)
+		if atk.Info.ActorIndex != char.Index() {
+			return
+		}
+		if atk.Info.AttackTag != attacks.AttackTagNormal {
+			return
+		}
 		w.addStacks(1)
+		c.Log.NewEvent("gest adding stack- normal on hit", glog.LogWeaponEvent, char.Index()).
+			Write("stacks", w.stacks)
 	}, fmt.Sprintf("gest-of-the-mighty-wolf-on-normal-attack-%v", char.Base.Key.String()))
 
 	c.Events.Subscribe(event.OnChargeAttack, func(args ...any) {
 		w.addStacks(2)
+		c.Log.NewEvent("gest adding stack- charge on start", glog.LogWeaponEvent, char.Index()).
+			Write("stacks", w.stacks)
 	}, fmt.Sprintf("gest-of-the-mighty-wolf-on-charge-%v", char.Base.Key.String()))
 
 	c.Events.Subscribe(event.OnSkill, func(args ...any) {
 		w.addStacks(2)
+		c.Log.NewEvent("gest adding stack- skill on cast", glog.LogWeaponEvent, char.Index()).
+			Write("stacks", w.stacks)
 	}, fmt.Sprintf("gest-of-the-mighty-wolf-on-skill-%v", char.Base.Key.String()))
 
 	return w, nil

--- a/internal/weapons/claymore/gestofthemightywolf/gestofthemightywolf.go
+++ b/internal/weapons/claymore/gestofthemightywolf/gestofthemightywolf.go
@@ -75,12 +75,18 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 	}, fmt.Sprintf("gest-of-the-mighty-wolf-on-normal-attack-%v", char.Base.Key.String()))
 
 	c.Events.Subscribe(event.OnChargeAttack, func(args ...any) {
+		if w.core.Player.Active() != char.Index() {
+			return
+		}
 		w.addStacks(2)
 		c.Log.NewEvent("gest adding stack- charge on start", glog.LogWeaponEvent, char.Index()).
 			Write("stacks", w.stacks)
 	}, fmt.Sprintf("gest-of-the-mighty-wolf-on-charge-%v", char.Base.Key.String()))
 
 	c.Events.Subscribe(event.OnSkill, func(args ...any) {
+		if w.core.Player.Active() != char.Index() {
+			return
+		}
 		w.addStacks(2)
 		c.Log.NewEvent("gest adding stack- skill on cast", glog.LogWeaponEvent, char.Index()).
 			Write("stacks", w.stacks)


### PR DESCRIPTION
Description: Additionally, when the team has the "[Hexerei: Secret Rite](https://genshin-impact.fandom.com/wiki/Hexerei:_Secret_Rite)" effect, each stack of Four Winds' Hymn will increase the [CRIT DMG](https://genshin-impact.fandom.com/wiki/CRIT_DMG) of the equipping character by 7.5%.

No requirement for the equipping char to be hex