### PR TITLE
Build Server on PR

### DIFF
--- a/.github/workflows/pullrequest-server.yaml
+++ b/.github/workflows/pullrequest-server.yaml
@@ -31,9 +31,9 @@ jobs:
       # 1. Upload file safely as an artifact without creating tags
       - name: Upload Binary Artifact
         id: upload-step
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: server_windows_amd64-${{ github.event.pull_request.number }}.exe
+          name: server_windows_amd64-pr${{ github.event.pull_request.number }}.exe
           path: server_windows_amd64.exe
           archive: false
           retention-days: 7
@@ -48,6 +48,6 @@ jobs:
             **PR Test Binary Built Successfully!**
 
             You can download the compiled server directly from the GitHub artifact portal:
-            [Download server_windows_amd64-${{ github.event.pull_request.number }}.exe](${{ steps.upload-step.outputs.artifact-url }})
+            [Download server_windows_amd64-pr${{ github.event.pull_request.number }}.exe](${{ steps.upload-step.outputs.artifact-url }})
 
             _Note: You must be logged into GitHub to access this link._

--- a/.github/workflows/pullrequest-server.yaml
+++ b/.github/workflows/pullrequest-server.yaml
@@ -1,4 +1,4 @@
-name: Build and Comment PR Binary
+name: build server
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build-and-comment:
-    name: Build and Link Binary
+    name: Build Binary
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pullrequest-server.yaml
+++ b/.github/workflows/pullrequest-server.yaml
@@ -1,0 +1,53 @@
+name: Build and Comment PR Binary
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# Permissions required to upload releases and write comments
+permissions:
+  pull-requests: write
+
+jobs:
+  build-and-comment:
+    name: Build and Link Binary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # Example: Setting up Go (Change this to your specific language setup)
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "^1.21"
+
+      - name: Build Binary
+        run: |
+          GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=`git tag --sort=-version:refname | head -n 1`" -o server_windows_amd64.exe ./cmd/server
+
+      # 1. Upload file safely as an artifact without creating tags
+      - name: Upload Binary Artifact
+        id: upload-step
+        uses: actions/upload-artifact@v4
+        with:
+          name: server_windows_amd64-${{ github.event.pull_request.number }}.exe
+          path: server_windows_amd64.exe
+          archive: false
+          retention-days: 7
+
+      # 2. Post or Update a comment containing the download instructions
+      - name: Comment PR Link
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          comment-tag: pr_binary_download
+          mode: replace
+          message: |
+            **PR Test Binary Built Successfully!**
+
+            You can download the compiled server directly from the GitHub artifact portal:
+            [Download server_windows_amd64-${{ github.event.pull_request.number }}.exe](${{ steps.upload-step.outputs.artifact-url }})
+
+            _Note: You must be logged into GitHub to access this link._

--- a/.github/workflows/pullrequest-server.yaml
+++ b/.github/workflows/pullrequest-server.yaml
@@ -26,15 +26,15 @@ jobs:
 
       - name: Build Binary
         run: |
-          GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=`git tag --sort=-version:refname | head -n 1`" -o server_windows_amd64.exe ./cmd/server
+          GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=`git tag --sort=-version:refname | head -n 1`" -o server-pr${{ github.event.pull_request.number }}.exe ./cmd/server
 
       # 1. Upload file safely as an artifact without creating tags
       - name: Upload Binary Artifact
         id: upload-step
         uses: actions/upload-artifact@v7
         with:
-          name: server_windows_amd64-pr${{ github.event.pull_request.number }}.exe
-          path: server_windows_amd64.exe
+          name: server-pr${{ github.event.pull_request.number }}.exe
+          path: server-pr${{ github.event.pull_request.number }}.exe
           archive: false
           retention-days: 7
 
@@ -47,6 +47,6 @@ jobs:
             **PR Test Binary Built Successfully!**
 
             You can download the compiled server directly from the GitHub artifact portal:
-            [Download server_windows_amd64-pr${{ github.event.pull_request.number }}.exe](${{ steps.upload-step.outputs.artifact-url }})
+            Download [server-pr${{ github.event.pull_request.number }}.exe](${{ steps.upload-step.outputs.artifact-url }})
 
             _Note: You must be logged into GitHub to access this link._

--- a/.github/workflows/pullrequest-server.yaml
+++ b/.github/workflows/pullrequest-server.yaml
@@ -1,7 +1,7 @@
 name: build server
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
@@ -11,12 +11,15 @@ permissions:
 
 jobs:
   build-and-comment:
-    name: Build Binary
+    name: build binary
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       # Example: Setting up Go (Change this to your specific language setup)
       - name: Set up Go
@@ -49,6 +52,6 @@ jobs:
             You can download the server directly from the GitHub artifact portal:
             Download [server-pr${{ github.event.pull_request.number }}.exe](${{ steps.upload-step.outputs.artifact-url }})
 
-            Note: Download will expire 7 days after the uploading
+            Note: Download will expire 7 days after the last update
 
             _Note: You must be logged into GitHub to access this link._

--- a/.github/workflows/pullrequest-server.yaml
+++ b/.github/workflows/pullrequest-server.yaml
@@ -43,7 +43,6 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: pr_binary_download
-          mode: replace
           message: |
             **PR Test Binary Built Successfully!**
 

--- a/.github/workflows/pullrequest-server.yaml
+++ b/.github/workflows/pullrequest-server.yaml
@@ -44,9 +44,11 @@ jobs:
         with:
           comment-tag: pr_binary_download
           message: |
-            **PR Test Binary Built Successfully!**
+            **PR Test Server Built Successfully!**
 
-            You can download the compiled server directly from the GitHub artifact portal:
+            You can download the server directly from the GitHub artifact portal:
             Download [server-pr${{ github.event.pull_request.number }}.exe](${{ steps.upload-step.outputs.artifact-url }})
+
+            Note: Download will expire 7 days after the uploading
 
             _Note: You must be logged into GitHub to access this link._


### PR DESCRIPTION
Adds a GitHub Actions to automatically build a server.exe binary when a PR to the main branch is made or updated. The server.exe binary will be uploaded and a comment posted on the PR with a link to download it.

Due to requiring write permissions to post a comment, it won't actually work until the PR is merged. To see an example of it working, please see https://github.com/Charlie-Zheng/gcsim/pull/13