### PR TITLE
Updated geo resonance behavior to match 6.3 changes from datamine

### DIFF
--- a/pkg/core/player/shield/handler.go
+++ b/pkg/core/player/shield/handler.go
@@ -139,17 +139,23 @@ func (h *Handler) OnDamage(char, active int, dmg float64, ele attributes.Element
 
 func (h *Handler) Tick() {
 	n := 0
+	broken := make([]Shield, 0)
 	for _, v := range h.shields {
 		if v.Expiry() == *h.f {
 			v.OnExpire()
 			h.log.NewEvent("shield expired", glog.LogShieldEvent, -1).
 				Write("name", v.Desc()).
 				Write("hp", v.CurrentHP())
-			h.events.Emit(event.OnShieldBreak, v)
+			broken = append(broken, v)
 		} else {
 			h.shields[n] = v
 			n++
 		}
 	}
 	h.shields = h.shields[:n]
+	if len(broken) > 0 {
+		for _, v := range broken {
+			h.events.Emit(event.OnShieldBreak, v)
+		}
+	}
 }

--- a/pkg/core/player/shield/handler.go
+++ b/pkg/core/player/shield/handler.go
@@ -90,6 +90,7 @@ func (h *Handler) OnDamage(char, active int, dmg float64, ele attributes.Element
 	bonus := h.ShieldBonus()
 	mintaken := dmg // min of damage taken
 	n := 0
+	broken := make([]Shield, 0)
 	for _, v := range h.shields {
 		target := v.ShieldTarget()
 		if target == -1 && char != active {
@@ -130,10 +131,15 @@ func (h *Handler) OnDamage(char, active int, dmg float64, ele attributes.Element
 			).Write("name", v.Desc()).
 				Write("ele", v.Element()).
 				Write("expiry", v.Expiry())
-			h.events.Emit(event.OnShieldBreak, v)
+			broken = append(broken, v)
 		}
 	}
 	h.shields = h.shields[:n]
+	if len(broken) > 0 {
+		for _, v := range broken {
+			h.events.Emit(event.OnShieldBreak, v)
+		}
+	}
 	return mintaken
 }
 

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -254,6 +254,18 @@ func SetupResonance(s *core.Core) {
 				updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)()
 			}, "geo-res-on-swap")
 
+			s.Events.Subscribe(event.OnShielded, func(args ...any) {
+				geoResTickerSrc = s.F
+
+				updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)
+			}, "geo-res-on-shielded")
+
+			s.Events.Subscribe(event.OnShieldBreak, func(args ...any) {
+				geoResTickerSrc = s.F
+
+				updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)
+			}, "geo-res-on-shield-break")
+
 		case attributes.Anemo:
 			s.Player.AddStamPercentMod("anemo-res-stam", -1, func(a action.Action) (float64, bool) {
 				return -0.15, false

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -20,8 +20,6 @@ import (
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
-var geoResTickerSrc int
-
 const (
 	nightsoulBurstICDStatus = "nightsoul-burst-icd"
 	geoResKey               = "geo-res"
@@ -214,7 +212,9 @@ func SetupResonance(s *core.Core) {
 			f := func() (float64, bool) { return 0.15, true }
 			s.Player.Shields.AddShieldBonusMod(geoResKey, -1, f)
 
-			updateGeoResonance(s, s.Player.Active(), geoResTickerSrc)
+			geoResTickerSrc := s.F
+
+			updateGeoResonance(s, s.Player.Active(), geoResTickerSrc, &geoResTickerSrc)
 
 			// shred geo res of target
 			s.Events.Subscribe(event.OnEnemyDamage, func(args ...any) {
@@ -240,7 +240,7 @@ func SetupResonance(s *core.Core) {
 				c.AddAttackMod(character.AttackMod{
 					Base: modifier.NewBase(geoResKey, -1),
 					Amount: func(ae *info.AttackEvent, t info.Target) []float64 {
-						if s.Flags.Custom[geoResKey] == 1 && s.Player.Active() == c.Index() {
+						if s.Status.Duration(geoResKey) != 0 && s.Player.Active() == c.Index() {
 							return m
 						}
 						return nil
@@ -253,9 +253,7 @@ func SetupResonance(s *core.Core) {
 
 				geoResTickerSrc = s.F
 
-				updateGeoResonance(s, next, geoResTickerSrc)
-
-				return
+				updateGeoResonance(s, next, geoResTickerSrc, &geoResTickerSrc)
 			}, "geo-res-on-swap")
 
 		case attributes.Anemo:
@@ -329,17 +327,13 @@ func SetupResonance(s *core.Core) {
 	}
 }
 
-func updateGeoResonance(s *core.Core, index, src int) func() {
+func updateGeoResonance(s *core.Core, index, src int, startFrame *int) func() {
 	return func() {
-		if geoResTickerSrc != src {
+		if *startFrame != src {
 			return
 		}
 
-		isGeoResActive := false
-
-		if s.Player.Shields.CharacterIsShielded(index, s.Player.Active()) {
-			isGeoResActive = true
-		}
+		isGeoResActive := s.Player.Shields.CharacterIsShielded(index, s.Player.Active())
 
 		moondrifts, _ := s.Constructs.ConstructsByType(construct.GeoConstructLunarCrystallize)
 		playerPos := s.Combat.Player().Pos()
@@ -350,12 +344,12 @@ func updateGeoResonance(s *core.Core, index, src int) func() {
 		}
 
 		if isGeoResActive {
-			s.Flags.Custom[geoResKey] = 1
+			s.Status.Add(geoResKey, -1)
 		} else {
-			s.Flags.Custom[geoResKey] = 0
+			s.Status.Delete(geoResKey)
 		}
 
-		s.Player.Chars()[index].QueueCharTask(updateGeoResonance(s, index, src), 1*60)
+		s.Player.Chars()[index].QueueCharTask(updateGeoResonance(s, index, src, startFrame), 1*60)
 	}
 }
 

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -20,7 +20,12 @@ import (
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
-const nightsoulBurstICDStatus = "nightsoul-burst-icd"
+var geoResTickerSrc int
+
+const (
+	nightsoulBurstICDStatus = "nightsoul-burst-icd"
+	geoResKey               = "geo-res"
+)
 
 // first is 0 because you can't proc it without the natlan character
 var nightsoulBurstICD = []int{0, 18 * 60, 12 * 60, 9 * 60, 9 * 60}
@@ -207,23 +212,9 @@ func SetupResonance(s *core.Core) {
 			//
 			// DMG dealt increased by 15%, dealing DMG to enemies will decrease their Geo RES by 20% for 15s.
 			f := func() (float64, bool) { return 0.15, true }
-			s.Player.Shields.AddShieldBonusMod("geo-res", -1, f)
+			s.Player.Shields.AddShieldBonusMod(geoResKey, -1, f)
 
-			isGeoResoActive := func(index int) bool {
-				if s.Player.Shields.CharacterIsShielded(index, s.Player.Active()) {
-					return true
-				}
-
-				moondrifts, _ := s.Constructs.ConstructsByType(construct.GeoConstructLunarCrystallize)
-				playerPos := s.Combat.Player().Pos()
-				for _, moondrift := range moondrifts {
-					// TODO: geo resonance distance for moondrifts
-					if playerPos.Distance(moondrift.Pos()) < 20 {
-						return true
-					}
-				}
-				return false
-			}
+			updateGeoResonance(s, s.Player.Active(), geoResTickerSrc)
 
 			// shred geo res of target
 			s.Events.Subscribe(event.OnEnemyDamage, func(args ...any) {
@@ -232,9 +223,11 @@ func SetupResonance(s *core.Core) {
 					return
 				}
 				atk := args[1].(*info.AttackEvent)
-				if isGeoResoActive(atk.Info.ActorIndex) {
+
+				charIndex := atk.Info.ActorIndex
+				if s.Flags.Custom[geoResKey] == 1 && s.Player.Active() == charIndex {
 					t.AddResistMod(info.ResistMod{
-						Base:  modifier.NewBaseWithHitlag("geo-res", 15*60),
+						Base:  modifier.NewBaseWithHitlag(geoResKey, 15*60),
 						Ele:   attributes.Geo,
 						Value: -0.2,
 					})
@@ -245,15 +238,25 @@ func SetupResonance(s *core.Core) {
 			m[attributes.DmgP] = .15
 			for _, c := range chars {
 				c.AddAttackMod(character.AttackMod{
-					Base: modifier.NewBase("geo-res", -1),
+					Base: modifier.NewBase(geoResKey, -1),
 					Amount: func(ae *info.AttackEvent, t info.Target) []float64 {
-						if isGeoResoActive(ae.Info.ActorIndex) {
+						if s.Flags.Custom[geoResKey] == 1 && s.Player.Active() == c.Index() {
 							return m
 						}
 						return nil
 					},
 				})
 			}
+
+			s.Events.Subscribe(event.OnCharacterSwap, func(args ...any) {
+				next := args[1].(int)
+
+				geoResTickerSrc = s.F
+
+				updateGeoResonance(s, next, geoResTickerSrc)
+
+				return
+			}, "geo-res-on-swap")
 
 		case attributes.Anemo:
 			s.Player.AddStamPercentMod("anemo-res-stam", -1, func(a action.Action) (float64, bool) {
@@ -323,6 +326,36 @@ func SetupResonance(s *core.Core) {
 			s.Events.Subscribe(event.OnHyperbloom, threeEl, "dendro-res")
 			s.Events.Subscribe(event.OnBurgeon, threeEl, "dendro-res")
 		}
+	}
+}
+
+func updateGeoResonance(s *core.Core, index, src int) func() {
+	return func() {
+		if geoResTickerSrc != src {
+			return
+		}
+
+		isGeoResActive := false
+
+		if s.Player.Shields.CharacterIsShielded(index, s.Player.Active()) {
+			isGeoResActive = true
+		}
+
+		moondrifts, _ := s.Constructs.ConstructsByType(construct.GeoConstructLunarCrystallize)
+		playerPos := s.Combat.Player().Pos()
+		for _, moondrift := range moondrifts {
+			if playerPos.Distance(moondrift.Pos()) < 16 {
+				isGeoResActive = true
+			}
+		}
+
+		if isGeoResActive {
+			s.Flags.Custom[geoResKey] = 1
+		} else {
+			s.Flags.Custom[geoResKey] = 0
+		}
+
+		s.Player.Chars()[index].QueueCharTask(updateGeoResonance(s, index, src), 1*60)
 	}
 }
 

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -257,13 +257,13 @@ func SetupResonance(s *core.Core) {
 			s.Events.Subscribe(event.OnShielded, func(args ...any) {
 				geoResTickerSrc = s.F
 
-				updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)
+				updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)()
 			}, "geo-res-on-shielded")
 
 			s.Events.Subscribe(event.OnShieldBreak, func(args ...any) {
 				geoResTickerSrc = s.F
 
-				updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)
+				updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)()
 			}, "geo-res-on-shield-break")
 
 		case attributes.Anemo:

--- a/pkg/simulation/setup.go
+++ b/pkg/simulation/setup.go
@@ -212,9 +212,9 @@ func SetupResonance(s *core.Core) {
 			f := func() (float64, bool) { return 0.15, true }
 			s.Player.Shields.AddShieldBonusMod(geoResKey, -1, f)
 
-			geoResTickerSrc := s.F
+			geoResTickerSrc := 0
 
-			updateGeoResonance(s, s.Player.Active(), geoResTickerSrc, &geoResTickerSrc)
+			updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)
 
 			// shred geo res of target
 			s.Events.Subscribe(event.OnEnemyDamage, func(args ...any) {
@@ -240,7 +240,7 @@ func SetupResonance(s *core.Core) {
 				c.AddAttackMod(character.AttackMod{
 					Base: modifier.NewBase(geoResKey, -1),
 					Amount: func(ae *info.AttackEvent, t info.Target) []float64 {
-						if s.Status.Duration(geoResKey) != 0 && s.Player.Active() == c.Index() {
+						if s.Flags.Custom[geoResKey] == 1 && s.Player.Active() == c.Index() {
 							return m
 						}
 						return nil
@@ -249,11 +249,9 @@ func SetupResonance(s *core.Core) {
 			}
 
 			s.Events.Subscribe(event.OnCharacterSwap, func(args ...any) {
-				next := args[1].(int)
-
 				geoResTickerSrc = s.F
 
-				updateGeoResonance(s, next, geoResTickerSrc, &geoResTickerSrc)
+				updateGeoResonance(s, geoResTickerSrc, &geoResTickerSrc)()
 			}, "geo-res-on-swap")
 
 		case attributes.Anemo:
@@ -327,13 +325,13 @@ func SetupResonance(s *core.Core) {
 	}
 }
 
-func updateGeoResonance(s *core.Core, index, src int, startFrame *int) func() {
+func updateGeoResonance(s *core.Core, src int, srcPtr *int) func() {
 	return func() {
-		if *startFrame != src {
+		if *srcPtr != src {
 			return
 		}
 
-		isGeoResActive := s.Player.Shields.CharacterIsShielded(index, s.Player.Active())
+		isGeoResActive := s.Player.Shields.CharacterIsShielded(s.Player.Active(), s.Player.Active())
 
 		moondrifts, _ := s.Constructs.ConstructsByType(construct.GeoConstructLunarCrystallize)
 		playerPos := s.Combat.Player().Pos()
@@ -343,13 +341,15 @@ func updateGeoResonance(s *core.Core, index, src int, startFrame *int) func() {
 			}
 		}
 
+		// core.Status doesn't support unlimited duration statues
+		// so we need to use the core.Flags.Custom
 		if isGeoResActive {
-			s.Status.Add(geoResKey, -1)
+			s.Flags.Custom[geoResKey] = 1
 		} else {
-			s.Status.Delete(geoResKey)
+			s.Flags.Custom[geoResKey] = 0
 		}
 
-		s.Player.Chars()[index].QueueCharTask(updateGeoResonance(s, index, src, startFrame), 1*60)
+		s.Player.ActiveChar().QueueCharTask(updateGeoResonance(s, src, srcPtr), 60)
 	}
 }
 


### PR DESCRIPTION
- Added 1s ticker hitlag extended by the active character
- Added onSwap event when the ticker should be forced to tick
- Updated moondrift distance

Currently conflicts with #2652 which adds moondrift checking but not the ticker