### PR TITLE
Add Columbina's baseDmgBonus on reaction Lunar attacks

### DIFF
--- a/internal/characters/columbina/asc.go
+++ b/internal/characters/columbina/asc.go
@@ -38,6 +38,16 @@ func (c *char) moonsignInit() {
 
 		atk.Info.BaseDmgBonus += bonus
 	}, lunarBonusKey)
+
+	c.Core.Events.Subscribe(event.OnLunarReactionAttack, func(args ...any) {
+		atk := args[1].(*info.AttackEvent)
+		if !attacks.AttackTagIsLunar(atk.Info.AttackTag) {
+			return
+		}
+		bonus := min(c.TotalAtk()/100.0*0.007, 0.14)
+
+		atk.Info.BaseDmgBonus += bonus
+	}, lunarBonusKey+"-lunar-atk")
 }
 
 func (c *char) a1Init() {


### PR DESCRIPTION
She's missing the extra OnLunarAttack subscription to enable buffing baseDmgBonus on contributor attacks