### PR TITLE
Add Examples to Docstrings

### DIFF
--- a/pkg/core/event/event.go
+++ b/pkg/core/event/event.go
@@ -115,6 +115,22 @@ func New() *Handler {
 	return h
 }
 
+// Subscribe to an event
+//
+//	core.Events.Subscribe(event.OnEnemyHit, func(args ...any) {
+//		e, ok := args[0].(*enemy.Enemy);
+//		if !ok {
+//			return
+//		}
+//		atk, ok := args[1].(*info.AttackEvent)
+//		if !ok {
+//			return
+//		}
+//		if atk.Info.ActorIndex != char.Index() {
+//			return
+//		}
+//		doSomething(e)
+//	}, "subscription")
 func (h *Handler) Subscribe(e Event, f Hook, key string) {
 	a := h.events[e]
 

--- a/pkg/core/event/event.go
+++ b/pkg/core/event/event.go
@@ -117,7 +117,7 @@ func New() *Handler {
 
 // Subscribe to an event
 //
-//	core.Events.Subscribe(event.OnEnemyHit, func(args ...any) {
+//	core.Events.Subscribe(event.OnEnemyDamage, func(args ...any) {
 //		e, ok := args[0].(*enemy.Enemy);
 //		if !ok {
 //			return

--- a/pkg/core/player/character/mods.go
+++ b/pkg/core/player/character/mods.go
@@ -64,12 +64,39 @@ func (c *CharWrapper) AddStatus(key string, dur int, hitlag bool) {
 	modifier.LogAdd("status", c.Index(), &mod, c.log, overwrote, oldEvt)
 }
 
+// Add an AttackMod.
+//
+// Note: If the AttackMod can affect Lunar reaction damage, an additional subscription
+// to OnLunarReactionAttack should be added to apply the AttackMod to individual contributions
+//
+//	m := make([]float64, attributes.EndStatType)
+//	m[attributes.CR] = 0.12
+//	char.AddAttackMod(character.AttackMod{
+//		Base: modifier.NewBaseWithHitlag("buff", 10*60),
+//		Amount: func(atk *info.AttackEvent, t info.Target) []float64 {
+//			if atk.Info.AttackTag != attacks.AttackTagElementalBurst {
+//				return nil
+//			}
+//			return m
+//		},
+//	})
 func (c *CharWrapper) AddAttackMod(mod AttackMod) {
 	mod.SetExpiry(*c.f)
 	overwrote, oldEvt := modifier.Add[modifier.Mod](&c.mods, &mod, *c.f)
 	modifier.LogAdd("attack", c.Index(), &mod, c.log, overwrote, oldEvt)
 }
 
+// Add a Cooldown Mod
+//
+//	char.AddCooldownMod(character.CooldownMod{
+//		Base: modifier.NewBaseWithHitlag("buff", 10*60),
+//		Amount: func(a action.Action) float64 {
+//			if a == action.ActionSkill {
+//				return -0.15
+//			}
+//			return 0
+//		},
+//	})
 func (c *CharWrapper) AddCooldownMod(mod CooldownMod) {
 	mod.SetExpiry(*c.f)
 	overwrote, oldEvt := modifier.Add[modifier.Mod](&c.mods, &mod, *c.f)
@@ -82,18 +109,50 @@ func (c *CharWrapper) AddDamageReductionMod(mod DamageReductionMod) {
 	modifier.LogAdd("dr", c.Index(), &mod, c.log, overwrote, oldEvt)
 }
 
+// Add a HealBonusMod
+//
+//	char.AddHealBonusMod(character.HealBonusMod{
+//		Base: modifier.NewBaseWithHitlag("buff", 18)60),
+//		Amount: func() float64 {
+//			return 0.3
+//		},
+//	})
 func (c *CharWrapper) AddHealBonusMod(mod HealBonusMod) {
 	mod.SetExpiry(*c.f)
 	overwrote, oldEvt := modifier.Add[modifier.Mod](&c.mods, &mod, *c.f)
 	modifier.LogAdd("heal bonus", c.Index(), &mod, c.log, overwrote, oldEvt)
 }
 
+// Add a ReactBonusMod
+//
+//	char.AddReactBonusMod(character.ReactBonusMod{
+//		Base: modifier.NewBaseWithHitlag("buff", 10*60),
+//		Amount: func(ai info.AttackInfo) float64 {
+//			switch ai.AttackTag {
+//			case attacks.AttackTagOverloadDamage,
+//				attacks.AttackTagBurningDamage,
+//				return 0.5
+//			}
+//			return 0
+//		},
+//	})
 func (c *CharWrapper) AddReactBonusMod(mod ReactBonusMod) {
 	mod.SetExpiry(*c.f)
 	overwrote, oldEvt := modifier.Add[modifier.Mod](&c.mods, &mod, *c.f)
 	modifier.LogAdd("react bonus", c.Index(), &mod, c.log, overwrote, oldEvt)
 }
 
+// Add a StatMod
+//
+//	m := make([]float64, attributes.EndStatType)
+//	m[attributes.EM] = 80
+//	s.char.AddStatMod(character.StatMod{
+//		 Base:		 modifier.NewBaseWithHitlag("buff", 10*60),
+//		 AffectedStat: attributes.EM,
+//		 Amount: func() []float64 {
+//		 	return m
+//		 },
+//	})
 func (c *CharWrapper) AddStatMod(mod StatMod) {
 	mod.SetExpiry(*c.f)
 	overwrote, oldEvt := modifier.Add[modifier.Mod](&c.mods, &mod, *c.f)

--- a/pkg/core/player/character/mods.go
+++ b/pkg/core/player/character/mods.go
@@ -146,7 +146,7 @@ func (c *CharWrapper) AddReactBonusMod(mod ReactBonusMod) {
 //
 //	m := make([]float64, attributes.EndStatType)
 //	m[attributes.EM] = 80
-//	s.char.AddStatMod(character.StatMod{
+//	char.AddStatMod(character.StatMod{
 //		 Base:		 modifier.NewBaseWithHitlag("buff", 10*60),
 //		 AffectedStat: attributes.EM,
 //		 Amount: func() []float64 {

--- a/pkg/enemy/mods.go
+++ b/pkg/enemy/mods.go
@@ -27,12 +27,25 @@ func (e *Enemy) AddStatus(key string, dur int, hitlag bool) {
 	modifier.LogAdd("status", -1, &mod, e.Core.Log, overwrote, oldEvt)
 }
 
+// Add a ResistMod
+//
+//	e.AddResistMod(info.ResistMod{
+//		Base:  modifier.NewBaseWithHitlag("debuff", 10*60),
+//		Ele:   attributes.Cryo,
+//		Value: -0.15,
+//	})
 func (e *Enemy) AddResistMod(mod info.ResistMod) {
 	mod.SetExpiry(e.Core.F)
 	overwrote, oldEvt := modifier.Add[modifier.Mod](&e.mods, &mod, e.Core.F)
 	modifier.LogAdd("enemy", -1, &mod, e.Core.Log, overwrote, oldEvt)
 }
 
+// Add a DefMod
+//
+//	e.AddDefMod(info.DefMod{
+//		Base:  modifier.NewBaseWithHitlag("debuff", 10*60),
+//		Value: -0.3,
+//	})
 func (e *Enemy) AddDefMod(mod info.DefMod) {
 	mod.SetExpiry(e.Core.F)
 	overwrote, oldEvt := modifier.Add[modifier.Mod](&e.mods, &mod, e.Core.F)


### PR DESCRIPTION
Add examples to docstrings for mods and event subscriptions. Allows developers to copy directly from the LSP documentation when writing code, instead of having to CTRL+F to find something similar.

<img width="1329" height="348" alt="image" src="https://github.com/user-attachments/assets/7ab01c35-8cb3-460b-afbe-6df020220c5f" />