### PR TITLE
feat(ci): optimize workflows, bump actions, add dependabot

### DIFF
--- a/.github/actions/go-setup-and-test/action.yml
+++ b/.github/actions/go-setup-and-test/action.yml
@@ -3,9 +3,9 @@ description: "runs setup-go and runs all unit tests in the repo"
 runs:
   using: composite
   steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
-        go-version: "^1.21"
+        go-version: "1.25.0"
     - name: Run Tests
       working-directory: ./
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,6 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: npm
-    directory: /ui
-    schedule:
-      interval: weekly
-    groups:
-      npm:
-        patterns:
-          - "*"
-
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /ui
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directories:
+      - /containers/assets
+      - /containers/embedgenerator
+    schedule:
+      interval: weekly
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -178,7 +178,7 @@ jobs:
           echo "outputs=${outputs}" >> $GITHUB_OUTPUT
 
       - name: Build Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         id: build
         with:
           build-args: |-

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -44,10 +44,10 @@ jobs:
         run: echo "LOWERCASE_REPO_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.x
           cache: pip
@@ -131,7 +131,7 @@ jobs:
 
       # checkout and set up build env
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: go-setup-and-test
         uses: ./.github/actions/go-setup-and-test
       - name: yarn-setup-and-test
@@ -148,10 +148,10 @@ jobs:
           source ${{ matrix.image.build_script }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: "${{ github.actor }}"
@@ -159,7 +159,7 @@ jobs:
 
       - name: Setup Goss
         if: ${{ matrix.image.tests_enabled }}
-        uses: e1himself/goss-installation-action@v1
+        uses: e1himself/goss-installation-action@8c646222c1cb43528392161394b745cb5d28e8f9 # v1
         with:
           version: latest
 
@@ -178,7 +178,7 @@ jobs:
           echo "outputs=${outputs}" >> $GITHUB_OUTPUT
 
       - name: Build Image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build
         with:
           build-args: |-
@@ -229,7 +229,7 @@ jobs:
 
       - name: Upload Digest
         if: ${{ inputs.pushImages }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.image.name }}-${{ matrix.image.target_os }}-${{ matrix.image.target_arch }}
           path: /tmp/${{ matrix.image.name }}/*
@@ -253,7 +253,7 @@ jobs:
         run: echo "LOWERCASE_REPO_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Download Digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: "${{ matrix.image.name }}-{linux,darwin}-{amd64,arm64}"
           merge-multiple: true
@@ -276,10 +276,10 @@ jobs:
           fi
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: "${{ github.actor }}"
@@ -325,7 +325,7 @@ jobs:
           echo "color=0xFF0000" >> $GITHUB_OUTPUT
 
       - name: Send Discord Webhook
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         if: ${{ always() && inputs.sendNotifications == 'true' }}
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get branch names
         id: branch-name
-        uses: tj-actions/branch-names@v7
+        uses: tj-actions/branch-names@v9
 
       # grab latest sha
       - name: Setup Environment (PR)  
@@ -26,7 +26,7 @@ jobs:
           echo "LAST_COMMIT_SHA=${GITHUB_SHA}" >> ${GITHUB_ENV}
 
       # setup + test go and yarn
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: go-setup-and-test
         uses: ./.github/actions/go-setup-and-test
       - name: yarn-setup-and-test
@@ -151,7 +151,7 @@ jobs:
           GCSIM_SHARE_KEY: ${{ secrets.AES_KEY }}
 
       - name: Release Binary
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             LICENSE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get branch names
         id: branch-name
-        uses: tj-actions/branch-names@v9
+        uses: tj-actions/branch-names@5250492686b253f06fa55861556d1027b067aeb5 # v9.0.2
 
       # grab latest sha
       - name: Setup Environment (PR)  
@@ -26,7 +26,7 @@ jobs:
           echo "LAST_COMMIT_SHA=${GITHUB_SHA}" >> ${GITHUB_ENV}
 
       # setup + test go and yarn
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: go-setup-and-test
         uses: ./.github/actions/go-setup-and-test
       - name: yarn-setup-and-test
@@ -120,7 +120,7 @@ jobs:
           ls -la
       # upload artifacts
       - name: upload db artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: backend-artifacts
           path: ./backend/docker
@@ -132,7 +132,7 @@ jobs:
           cp ./backend/docker/hash.txt ./computebin/hash.txt
           cp ./backend/cmd/compute/compute ./computebin/compute
       - name: upload compute artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: compute-artifacts
           path: ./computebin 
@@ -151,7 +151,7 @@ jobs:
           GCSIM_SHARE_KEY: ${{ secrets.AES_KEY }}
 
       - name: Release Binary
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             LICENSE

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,7 +4,13 @@ on:
     branches:
       - master
       - main
+    paths-ignore:
+      - "**.md"
+      - "**.txt"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.txt"
 
 permissions:
   contents: read
@@ -19,10 +25,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "^1.19.3"
+          go-version: "1.22"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,13 +22,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: "1.22"
+          go-version: "1.25.0"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: go-setup-and-test
         uses: ./.github/actions/go-setup-and-test
       - name: deploy-binary

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: go-setup-and-test
         uses: ./.github/actions/go-setup-and-test
       - name: deploy-binary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,25 @@
 name: run tests
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+      - "**.txt"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.txt"
 
 jobs:
   test-go:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: go-setup-and-test
       uses: ./.github/actions/go-setup-and-test
   test-ui:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: yarn-setup-and-test
       uses: ./.github/actions/yarn-setup-and-test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,12 @@ jobs:
   test-go:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: go-setup-and-test
       uses: ./.github/actions/go-setup-and-test
   test-ui:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: yarn-setup-and-test
       uses: ./.github/actions/yarn-setup-and-test


### PR DESCRIPTION
## Summary

Optimize CI workflows and add automated dependency management.

## Changes

### Workflow optimization
- **`tests.yml`** — skip Go/UI test runs when only `.md`/`.txt` files change
- **`golangci-lint.yml`** — skip lint runs on docs-only changes
- Both use `paths-ignore` — zero overhead since it is evaluated server-side before a runner is allocated

### Action security hardening
- All third-party actions pinned by full commit SHA (immutable) instead of mutable version tags
- Version comments kept for readability (e.g., `# v4.4.0`)
- Dependabot fully supports updating SHA-pinned actions and auto-bumps the version comment

### Go version alignment
- **`golangci-lint.yml`** — `go-version: "1.25.0"` (was `"1.22"`)
- **`.github/actions/go-setup-and-test/action.yml`** — `go-version: "1.25.0"` (was `"^1.21"`), upgraded `actions/setup-go` from v3 to v5
- Both now match `go.mod`

### Action version bumps (beyond SHA pinning)
| Workflow | Action | Before | After |
|----------|--------|--------|-------|
| tests.yml | `actions/checkout` | v3 | v4 |
| deploy.yml | `actions/checkout` | v3 | v4 |
| deploy.yml | `tj-actions/branch-names` | v7 | v9 |
| deploy.yml | `softprops/action-gh-release` | v1 | v3 |
| build-images.yaml | `docker/build-push-action` | v5 | v7 |
| nightly.yml | `actions/checkout` | v3 | v4 |
| golangci-lint.yml | `golangci/golangci-lint-action` | v8 | v9 |

### Dependabot
- New `.github/dependabot.yml` covering Go modules, GitHub Actions, and Docker
- All ecosystems on a **weekly** schedule, grouped per ecosystem for one combined PR each

Assisted-by: opencode:deepseek-v4-flash