### PR TITLE
Fix Aino C6 on Off Field characters

### DIFF
--- a/internal/characters/aino/cons.go
+++ b/internal/characters/aino/cons.go
@@ -137,6 +137,11 @@ func (c *char) c6Init() {
 				if !c.StatusIsActive(c6Key) {
 					return 0
 				}
+
+				if c.Core.Player.Active() != char.Index() {
+					return 0
+				}
+
 				buff := 0.15
 				if c.Core.Player.GetMoonsignLevel() >= 2 {
 					buff += 0.2


### PR DESCRIPTION
It's supposed to only buff on field characters.