### PR TITLE
Fix citlali skull and c4 hitmark

### DIFF
--- a/internal/characters/citlali/burst.go
+++ b/internal/characters/citlali/burst.go
@@ -12,11 +12,12 @@ import (
 const (
 	iceStormHitmark = 118
 
-	// the logic is cast -> 1s delay -> nyxadd+initial hit
-	// -> 0.95s + random [0.5,1.0] delay -> 2nd nyxadd+burst hit
+	// after Q hitmark, random [0.5,1.0] delay -> skull summon
+	// After field tick (c4) -> immediate skull summon
+	// Skull summon -> 0.95s delay -> NS point restore + skull hitmark
 	// From testing, the random delay is uniform
 	// const is relative to skull summoning- burst hitmark on q, field hitmark for c4
-	spiritVesselSkullHitmarkBase = 87
+	spiritVesselSkullHitmark = 57
 
 	iceStormAbil = "Ice Storm DMG"
 )
@@ -24,7 +25,7 @@ const (
 var burstFrames []int
 
 func (c *char) spiritVesselSkullRandHitmark() int {
-	return spiritVesselSkullHitmarkBase + c.Core.Rand.Intn(31)
+	return spiritVesselSkullHitmark + 30 + c.Core.Rand.Intn(31)
 }
 
 func init() {

--- a/internal/characters/citlali/burst.go
+++ b/internal/characters/citlali/burst.go
@@ -10,13 +10,22 @@ import (
 )
 
 const (
-	iceStormHitmark          = 118
-	spiritVesselSkullHitmark = 210
+	iceStormHitmark = 118
+
+	// the logic is cast -> 1s delay -> nyxadd+initial hit
+	// -> 0.95s + random [0.5,1.0] delay -> 2nd nyxadd+burst hit
+	// From testing, the random delay is uniform
+	// const is relative to skull summoning- burst hitmark on q, field hitmark for c4
+	spiritVesselSkullHitmarkBase = 87
 
 	iceStormAbil = "Ice Storm DMG"
 )
 
 var burstFrames []int
+
+func (c *char) spiritVesselSkullRandHitmark() int {
+	return spiritVesselSkullHitmarkBase + c.Core.Rand.Intn(31)
+}
 
 func init() {
 	burstFrames = frames.InitAbilSlice(113) // Q -> Jump
@@ -66,18 +75,16 @@ func (c *char) Burst(_ map[string]int) (action.Info, error) {
 	c.Core.QueueAttack(aiIceStorm, combat.NewCircleHitOnTarget(c.Core.Combat.PrimaryTarget(), nil, 6.5), iceStormHitmark, iceStormHitmark)
 
 	// skull hits
-	c.QueueCharTask(func() {
-		enemies := c.Core.Combat.EnemiesWithinArea(combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 7), nil)
-		points := 0.0
-		for i, enemy := range enemies {
-			if i > 2 {
-				break
-			}
-			points += 3.0
-			c.Core.QueueAttack(aiSpiritVesselSkull, combat.NewCircleHitOnTarget(enemy.Pos(), nil, 3.5), 0, 0)
+	enemies := c.Core.Combat.EnemiesWithinArea(combat.NewCircleHitOnTarget(c.Core.Combat.Player(), nil, 7), nil)
+	for i, enemy := range enemies {
+		if i > 2 {
+			break
 		}
-		c.generateNightsoulPoints(points)
-	}, spiritVesselSkullHitmark)
+		c.QueueCharTask(func() {
+			c.generateNightsoulPoints(3.0)
+			c.Core.QueueAttack(aiSpiritVesselSkull, combat.NewCircleHitOnTarget(enemy.Pos(), nil, 3.5), 0, 0)
+		}, iceStormHitmark+c.spiritVesselSkullRandHitmark())
+	}
 
 	return action.Info{
 		Frames:          frames.NewAbilFunc(burstFrames),

--- a/internal/characters/citlali/cons.go
+++ b/internal/characters/citlali/cons.go
@@ -121,8 +121,8 @@ func (c *char) c4SkullCB(a info.AttackCB) {
 		Durability:     25,
 		FlatDmg:        18 * c.Stat(attributes.EM),
 	}
-	// TODO: the actual hitmark
-	hitmark := c.spiritVesselSkullRandHitmark()
+
+	hitmark := spiritVesselSkullHitmark
 	c.Core.QueueAttack(
 		aiSpiritVesselSkull,
 		combat.NewCircleHitOnTarget(c.Core.Combat.PrimaryTarget(), nil, 3.5),

--- a/internal/characters/citlali/cons.go
+++ b/internal/characters/citlali/cons.go
@@ -122,7 +122,7 @@ func (c *char) c4SkullCB(a info.AttackCB) {
 		FlatDmg:        18 * c.Stat(attributes.EM),
 	}
 	// TODO: the actual hitmark
-	hitmark := spiritVesselSkullHitmark - iceStormHitmark
+	hitmark := c.spiritVesselSkullRandHitmark()
 	c.Core.QueueAttack(
 		aiSpiritVesselSkull,
 		combat.NewCircleHitOnTarget(c.Core.Combat.PrimaryTarget(), nil, 3.5),


### PR DESCRIPTION
Assume random delays round to nearest frame, not floor frame or ceil frame. Hence [30, 60] interval of possible frame delays, instead of (30, 60] or [30, 60).