### PR TITLE
Add Traveler's True Moon archon quest stat buffs

### DIFF
--- a/internal/characters/traveler/anemo/aether/config.yml
+++ b/internal/characters/traveler/anemo/aether/config.yml
@@ -22,6 +22,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -29,7 +30,7 @@ abilities:
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Circle
@@ -37,21 +38,21 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 180
         radius: 1.7
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Box
         center: Player
         offset: [0, 0.4]
         box: [1.5, 2.2]
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.6]
         radius: 1.7
-        hitlag: {time: 0.09, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.09, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
@@ -59,7 +60,7 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 240
         radius: 1.75
-        hitlag: {time: 0.12, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.12, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.

--- a/internal/characters/traveler/anemo/lumine/config.yml
+++ b/internal/characters/traveler/anemo/lumine/config.yml
@@ -25,6 +25,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -33,34 +34,34 @@ abilities:
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.1, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.1, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.

--- a/internal/characters/traveler/common/pyro/charge.go
+++ b/internal/characters/traveler/common/pyro/charge.go
@@ -49,6 +49,11 @@ func (c *Traveler) ChargeAttack(p map[string]int) (action.Info, error) {
 		ai.Element = attributes.Pyro
 		ai.IgnoreInfusion = true
 		ai.AdditionalTags = []attacks.AdditionalTag{attacks.AdditionalTagNightsoul}
+
+		// Lumine PMC's C6 CA shares ICD with the enhanced CA
+		if c.gender == 1 {
+			ai.ICDTag = attacks.ICDTagTravelerEnhancedCA
+		}
 	}
 
 	for i, mult := range charge[c.gender] {

--- a/internal/characters/traveler/common/storybuffs.go
+++ b/internal/characters/traveler/common/storybuffs.go
@@ -7,6 +7,8 @@ import (
 	"github.com/genshinsim/gcsim/pkg/modifier"
 )
 
+const TrueMoonParam = "true_moon_story_buff"
+
 func TravelerStoryBuffs(c *character.CharWrapper, p info.CharacterProfile) {
 	// TravelerStoryBuffs applies buffs based on completed story quests
 	//
@@ -16,15 +18,21 @@ func TravelerStoryBuffs(c *character.CharWrapper, p info.CharacterProfile) {
 	// skirk_story_buff
 	// 		buffs from completing Crystallina Chapter: Act I (Skirk's Story Quest)
 	// 		+7 base atk, +15 EM, +50 base HP
-	//
+	// true_moon_buff
+	//		buffs from completing Song of the Welkin Moon: Act VIII - True Moon (Nod Krai Archon Quest)
+	//		we assume traveler has all resonances done
 	// All buffs default to enabled
 	baseAtkBuff, okBaseAtkBuff := p.Params["base_atk_buff"]
 	skirkBuff, okSkirkBuff := p.Params["skirk_story_buff"]
+	trueMoonBuff, okTrueMoonBuff := p.Params[TrueMoonParam]
 	if !okBaseAtkBuff {
 		baseAtkBuff = 1
 	}
 	if !okSkirkBuff {
-		skirkBuff = 1 // default to maximum buffs
+		skirkBuff = 1
+	}
+	if !okTrueMoonBuff {
+		trueMoonBuff = 1
 	}
 
 	m := make([]float64, attributes.EndStatType)
@@ -36,6 +44,17 @@ func TravelerStoryBuffs(c *character.CharWrapper, p info.CharacterProfile) {
 		m[attributes.EM] += 15
 		m[attributes.BaseHP] += 50
 	}
+
+	if trueMoonBuff == 1 {
+		m[attributes.CR] += 0.1
+		m[attributes.DEFP] += 0.2
+		m[attributes.ER] += 0.2
+		m[attributes.EM] += 60
+		m[attributes.HPP] += 0.2
+		m[attributes.ATKP] += 0.2
+		m[attributes.CD] += 0.2
+	}
+
 	c.AddStatMod(character.StatMod{
 		Base: modifier.NewBase("traveler-story-quest-buffs", -1),
 		Amount: func() []float64 {
@@ -43,3 +62,5 @@ func TravelerStoryBuffs(c *character.CharWrapper, p info.CharacterProfile) {
 		},
 	})
 }
+
+// the CA buffs must be added in the specific traveler

--- a/internal/characters/traveler/dendro/aether/config.yml
+++ b/internal/characters/traveler/dendro/aether/config.yml
@@ -22,6 +22,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -29,7 +30,7 @@ abilities:
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Circle
@@ -37,21 +38,21 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 180
         radius: 1.7
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Box
         center: Player
         offset: [0, 0.4]
         box: [1.5, 2.2]
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.6]
         radius: 1.7
-        hitlag: {time: 0.09, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.09, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
@@ -59,7 +60,7 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 240
         radius: 1.75
-        hitlag: {time: 0.12, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.12, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.
@@ -92,7 +93,7 @@ abilities:
         radius: 6.5
 
       - name: Q-Tick
-        note: 'At every tick: Spawn 1 attack on a random enemy in the detection area.'
+        note: "At every tick: Spawn 1 attack on a random enemy in the detection area."
         shape: Circle
         center: GlobalValue
         radius: 2

--- a/internal/characters/traveler/dendro/lumine/config.yml
+++ b/internal/characters/traveler/dendro/lumine/config.yml
@@ -25,6 +25,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -33,34 +34,34 @@ abilities:
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.1, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.1, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.
@@ -93,7 +94,7 @@ abilities:
         radius: 6.5
 
       - name: Q-Tick
-        note: 'At every tick: Spawn 1 attack on a random enemy in the detection area.'
+        note: "At every tick: Spawn 1 attack on a random enemy in the detection area."
         shape: Circle
         center: GlobalValue
         radius: 2

--- a/internal/characters/traveler/electro/aether/config.yml
+++ b/internal/characters/traveler/electro/aether/config.yml
@@ -22,6 +22,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -29,7 +30,7 @@ abilities:
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Circle
@@ -37,21 +38,21 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 180
         radius: 1.7
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Box
         center: Player
         offset: [0, 0.4]
         box: [1.5, 2.2]
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.6]
         radius: 1.7
-        hitlag: {time: 0.09, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.09, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
@@ -59,7 +60,7 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 240
         radius: 1.75
-        hitlag: {time: 0.12, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.12, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.

--- a/internal/characters/traveler/electro/lumine/config.yml
+++ b/internal/characters/traveler/electro/lumine/config.yml
@@ -25,6 +25,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -33,34 +34,34 @@ abilities:
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.1, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.1, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.

--- a/internal/characters/traveler/geo/aether/config.yml
+++ b/internal/characters/traveler/geo/aether/config.yml
@@ -22,6 +22,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -29,7 +30,7 @@ abilities:
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Circle
@@ -37,21 +38,21 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 180
         radius: 1.7
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Box
         center: Player
         offset: [0, 0.4]
         box: [1.5, 2.2]
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.6]
         radius: 1.7
-        hitlag: {time: 0.09, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.09, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
@@ -59,7 +60,7 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 240
         radius: 1.75
-        hitlag: {time: 0.12, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.12, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.
@@ -83,7 +84,8 @@ abilities:
         shape: Circle
         center: PrimaryTarget
         radius: 3
-        hitlag: {time: 0.05, scale: 0.05, defense_halt: true, deployable: true}
+        hitlag:
+          { time: 0.05, scale: 0.05, defense_halt: true, deployable: true }
 
   - name: burst
     params:
@@ -111,7 +113,8 @@ abilities:
         shape: Circle
         center: GlobalValue
         radius: 3
-        hitlag: {time: 0.05, scale: 0.05, defense_halt: true, deployable: true}
+        hitlag:
+          { time: 0.05, scale: 0.05, defense_halt: true, deployable: true }
 
   - name: walk
     note: No action followed by walk has proper frames.

--- a/internal/characters/traveler/geo/lumine/config.yml
+++ b/internal/characters/traveler/geo/lumine/config.yml
@@ -29,6 +29,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -37,34 +38,34 @@ abilities:
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.1, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.1, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.
@@ -88,7 +89,8 @@ abilities:
         shape: Circle
         center: PrimaryTarget
         radius: 3
-        hitlag: {time: 0.05, scale: 0.05, defense_halt: true, deployable: true}
+        hitlag:
+          { time: 0.05, scale: 0.05, defense_halt: true, deployable: true }
 
   - name: burst
     params:
@@ -116,7 +118,8 @@ abilities:
         shape: Circle
         center: GlobalValue
         radius: 3
-        hitlag: {time: 0.05, scale: 0.05, defense_halt: true, deployable: true}
+        hitlag:
+          { time: 0.05, scale: 0.05, defense_halt: true, deployable: true }
 
   - name: walk
     note: No action followed by walk has proper frames.

--- a/internal/characters/traveler/hydro/aether/config.yml
+++ b/internal/characters/traveler/hydro/aether/config.yml
@@ -26,6 +26,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:

--- a/internal/characters/traveler/hydro/lumine/config.yml
+++ b/internal/characters/traveler/hydro/lumine/config.yml
@@ -41,6 +41,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:

--- a/internal/characters/traveler/pyro/aether/config.yml
+++ b/internal/characters/traveler/pyro/aether/config.yml
@@ -22,6 +22,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -29,7 +30,7 @@ abilities:
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Circle
@@ -37,21 +38,21 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 180
         radius: 1.7
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Box
         center: Player
         offset: [0, 0.4]
         box: [1.5, 2.2]
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.6]
         radius: 1.7
-        hitlag: {time: 0.09, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.09, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
@@ -59,7 +60,7 @@ abilities:
         offset: [0, 0.6]
         fan_angle: 240
         radius: 1.75
-        hitlag: {time: 0.12, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.12, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.

--- a/internal/characters/traveler/pyro/lumine/config.yml
+++ b/internal/characters/traveler/pyro/lumine/config.yml
@@ -14,6 +14,7 @@ combat:
     - TravelerScorchingThreshold
     - TravelerBlazingThreshold
     - TravelerHoldDMG
+    - TravelerEnhancedCA
 
 docs:
   frames:
@@ -31,6 +32,7 @@ abilities:
     params:
       base_atk_buff: 0 for no +3 base atk, 1 (default) for +3 base atk. Set via '+params=[base_atk_buff=...]' in the char's line.
       skirk_story_buff: 0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line.
+      true_moon_story_buff: 0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line.
 
   - name: attack
     hitbox:
@@ -39,34 +41,34 @@ abilities:
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N2
         shape: Box
         center: Player
         box: [1.4, 2.2]
-        hitlag: {time: 0.03, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.03, scale: 0.01, defense_halt: true }
 
       - name: N3
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N4
         shape: Circle
         center: Player
         offset: [0, 0.7]
         radius: 1.5
-        hitlag: {time: 0.06, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.06, scale: 0.01, defense_halt: true }
 
       - name: N5
         shape: Circle
         center: Player
         offset: [0, 1]
         radius: 1.6
-        hitlag: {time: 0.1, scale: 0.01, defense_halt: true}
+        hitlag: { time: 0.1, scale: 0.01, defense_halt: true }
 
   - name: charge
     note: Need to use attack right before charge.

--- a/pkg/core/attacks/icd_tags.dm.go
+++ b/pkg/core/attacks/icd_tags.dm.go
@@ -77,6 +77,7 @@ const (
 	ICDTagTartagliaRiptideFlash
 	ICDTagTravelerBlazingThreshold
 	ICDTagTravelerDewdrop
+	ICDTagTravelerEnhancedCA
 	ICDTagTravelerHoldDMG
 	ICDTagTravelerScorchingThreshold
 	ICDTagTravelerWakeOfEarth

--- a/ui/packages/docs/src/components/Params/character.dm.json
+++ b/ui/packages/docs/src/components/Params/character.dm.json
@@ -11,6 +11,11 @@
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
     },
     {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
+    },
+    {
       "ability": "skill",
       "param": "hold",
       "desc": "0 for Tap (default), 1 for Hold."
@@ -31,6 +36,11 @@
       "ability": "-",
       "param": "skirk_story_buff",
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
+    },
+    {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
     }
   ],
   "aetherelectro": [
@@ -43,6 +53,11 @@
       "ability": "-",
       "param": "skirk_story_buff",
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
+    },
+    {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
     },
     {
       "ability": "skill",
@@ -70,6 +85,11 @@
       "ability": "-",
       "param": "skirk_story_buff",
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
+    },
+    {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
     },
     {
       "ability": "skill",
@@ -104,6 +124,11 @@
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
     },
     {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
+    },
+    {
       "ability": "skill",
       "param": "hold",
       "desc": "0 for Tap (default), 1 for Hold."
@@ -134,6 +159,11 @@
       "ability": "-",
       "param": "skirk_story_buff",
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
+    },
+    {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
     },
     {
       "ability": "low_plunge",
@@ -1095,6 +1125,11 @@
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
     },
     {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
+    },
+    {
       "ability": "skill",
       "param": "hold",
       "desc": "0 for Tap (default), 1 for Hold."
@@ -1115,6 +1150,11 @@
       "ability": "-",
       "param": "skirk_story_buff",
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
+    },
+    {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
     }
   ],
   "lumineelectro": [
@@ -1127,6 +1167,11 @@
       "ability": "-",
       "param": "skirk_story_buff",
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
+    },
+    {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
     },
     {
       "ability": "skill",
@@ -1154,6 +1199,11 @@
       "ability": "-",
       "param": "skirk_story_buff",
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
+    },
+    {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
     },
     {
       "ability": "skill",
@@ -1188,6 +1238,11 @@
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
     },
     {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
+    },
+    {
       "ability": "skill",
       "param": "hold",
       "desc": "0 for Tap (default), 1 for Hold."
@@ -1218,6 +1273,11 @@
       "ability": "-",
       "param": "skirk_story_buff",
       "desc": "0 for no buffs, 1 (default) for +7 base atk, +15 EM, +50 base HP. Set via '+params=[skirk_story_buff=...]' in the char's line."
+    },
+    {
+      "ability": "-",
+      "param": "true_moon_story_buff",
+      "desc": "0 for no buffs, 1 (default) for +10% CR, +20% DEF, +20% ER, +60 EM, +20% HP, +20% ATK, +20% CD. Set via '+params=[true_moon_story_buff=...]' in the char's line."
     },
     {
       "ability": "low_plunge",


### PR DESCRIPTION
Adds the stat buffs from the True Moon archon quest, but doesn't add the special CAs which need frame counting for hitmarks.

Also adjusts Lumine PMC's C6 CA to share ICD with the not yet implemented special CA.