### PR TITLE
Extend ttds icd by 1s when the holder is on-field

### DIFF
--- a/internal/weapons/catalyst/thrilling/thrilling.go
+++ b/internal/weapons/catalyst/thrilling/thrilling.go
@@ -6,10 +6,14 @@ import (
 	"github.com/genshinsim/gcsim/pkg/core"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/event"
-	"github.com/genshinsim/gcsim/pkg/core/glog"
 	"github.com/genshinsim/gcsim/pkg/core/info"
 	"github.com/genshinsim/gcsim/pkg/core/player/character"
 	"github.com/genshinsim/gcsim/pkg/modifier"
+)
+
+const (
+	icdKey = "ttds-icd"
+	icdDur = 20 * 60
 )
 
 type Weapon struct {
@@ -20,52 +24,36 @@ func (w *Weapon) SetIndex(idx int) { w.Index = idx }
 func (w *Weapon) Init() error      { return nil }
 
 func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) (info.Weapon, error) {
-	// When switching characters, the new character taking the field has their
-	// ATK increased by 24% for 10s. This effect can only occur once every 20s.
 	w := &Weapon{}
 	r := p.Refine
-
-	const icdKey = "ttds-icd"
-	icd := 1200 // 20s * 60
-	isActive := false
-	key := fmt.Sprintf("ttds-%v", char.Base.Key.String())
-
-	c.Events.Subscribe(event.OnInitialize, func(args ...any) {
-		isActive = c.Player.Active() == char.Index()
-	}, key)
 
 	m := make([]float64, attributes.EndStatType)
 	m[attributes.ATKP] = .18 + float64(r)*0.06
 
 	c.Events.Subscribe(event.OnCharacterSwap, func(args ...any) {
-		if !isActive && c.Player.Active() == char.Index() {
-			isActive = true
+		prev := args[0].(int)
+		if prev != char.Index() {
 			return
 		}
 
-		if isActive && c.Player.Active() != char.Index() {
-			isActive = false
-			if char.StatusIsActive(icdKey) {
-				return
-			}
-			char.AddStatus(icdKey, icd, true)
-			active := c.Player.ActiveChar()
-			// When TTDS mod is active, don't reapply
-			if active.StatModIsActive("ttds") {
-				return
-			}
-			active.AddStatMod(character.StatMod{
-				Base:         modifier.NewBaseWithHitlag("ttds", 600),
-				AffectedStat: attributes.NoStat,
-				Amount: func() []float64 {
-					return m
-				},
-			})
-
-			c.Log.NewEvent("ttds activated", glog.LogWeaponEvent, c.Player.Active()).
-				Write("expiry (without hitlag)", c.F+600)
+		if char.StatusIsActive(icdKey) {
+			return
 		}
-	}, key)
+		char.AddStatus(icdKey, icdDur, true)
+
+		active := c.Player.ActiveChar()
+		// When TTDS mod is active, don't reapply
+		if active.StatModIsActive("ttds") {
+			return
+		}
+		active.AddStatMod(character.StatMod{
+			Base:         modifier.NewBaseWithHitlag("ttds", 600),
+			AffectedStat: attributes.ATKP,
+			Amount: func() []float64 {
+				return m
+			},
+		})
+	}, fmt.Sprintf("ttds-swap-%v", char.Base.Key.String()))
 
 	return w, nil
 }

--- a/internal/weapons/catalyst/thrilling/thrilling.go
+++ b/internal/weapons/catalyst/thrilling/thrilling.go
@@ -14,6 +14,7 @@ import (
 const (
 	icdKey = "ttds-icd"
 	icdDur = 20 * 60
+	icdExt = 1 * 60
 )
 
 type Weapon struct {
@@ -32,6 +33,10 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 
 	c.Events.Subscribe(event.OnCharacterSwap, func(args ...any) {
 		prev := args[0].(int)
+		next := args[1].(int)
+		if next == char.Index() && char.StatusDuration(icdKey) < icdExt {
+			char.DeleteStatus(icdKey)
+		}
 		if prev != char.Index() {
 			return
 		}
@@ -39,7 +44,7 @@ func NewWeapon(c *core.Core, char *character.CharWrapper, p info.WeaponProfile) 
 		if char.StatusIsActive(icdKey) {
 			return
 		}
-		char.AddStatus(icdKey, icdDur, true)
+		char.AddStatus(icdKey, icdDur+icdExt, true)
 
 		active := c.Player.ActiveChar()
 		// When TTDS mod is active, don't reapply


### PR DESCRIPTION

https://github.com/user-attachments/assets/839c67c4-f8d7-408b-8bb8-792e67bf43e9
First swap to Columbina at f86, second swap to Columbina at f1343, which is f1257 (20.95s ) duration between swaps, and TTDS didn't activate.


https://github.com/user-attachments/assets/5a1d9030-b8e2-46b1-85b7-daf8a231ab59
First swap to Columbina at f87, second swap to Columbina at f1347, which is f1260 (21s) duration between swaps, and TTDS does activate


