### PR TITLE
refactor(ui): break cyclic workspace dependencies

### DIFF
--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -9,7 +9,6 @@
 		"@gcsim/data": "workspace:^",
 		"@gcsim/localization": "workspace:^",
 		"@gcsim/types": "workspace:^",
-		"@gcsim/ui": "workspace:^",
 		"@radix-ui/react-icons": "^1.3.0",
 		"@radix-ui/react-separator": "^1.0.3",
 		"@radix-ui/react-slot": "^1.0.2",

--- a/ui/packages/components/src/Cards/PreviewCard/Graphs/Histogram.tsx
+++ b/ui/packages/components/src/Cards/PreviewCard/Graphs/Histogram.tsx
@@ -1,8 +1,7 @@
 import type { model } from "@gcsim/types";
-import { NoDataIcon } from "@gcsim/ui/src/Pages/Viewer/Components/Util/NoData";
 import { Group } from "@visx/group";
 import { ParentSize } from "@visx/responsive";
-import { Colors } from "../../../common/gcsim";
+import { Colors, NoDataIcon } from "../../../common/gcsim";
 import { useScales } from "../../DistributionCard/HistogramGraph";
 
 type Props = {

--- a/ui/packages/ui/package.json
+++ b/ui/packages/ui/package.json
@@ -9,7 +9,6 @@
 		"@blueprintjs/select": "^4.8.4",
 		"@fontsource/fira-mono": "^4.5.10",
 		"@gcsim/components": "workspace:^",
-		"@gcsim/db": "workspace:^",
 		"@gcsim/executors": "workspace:^",
 		"@gcsim/localization": "workspace:^",
 		"@gcsim/types": "workspace:^",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       '@gcsim/types':
         specifier: workspace:^
         version: link:../types
-      '@gcsim/ui':
-        specifier: workspace:^
-        version: link:../ui
       '@radix-ui/react-icons':
         specifier: ^1.3.0
         version: 1.3.2(react@18.3.1)
@@ -613,9 +610,6 @@ importers:
       '@gcsim/components':
         specifier: workspace:^
         version: link:../components
-      '@gcsim/db':
-        specifier: workspace:^
-        version: link:../db
       '@gcsim/executors':
         specifier: workspace:^
         version: link:../executors


### PR DESCRIPTION
## What changed

The three UI workspace packages (`@gcsim/components`, `@gcsim/ui`, `@gcsim/db`) formed two dependency cycles. This breaks both, so `pnpm install` and topological pnpm commands no longer report a cyclic workspace graph.

- **`@gcsim/components` ↔ `@gcsim/ui`**: the histogram graph in `components` imported `NoDataIcon` from `@gcsim/ui`, even though `components` ships its own identical copy in `common/gcsim` (already used by the sibling pie and timeline graphs). It now imports from that local module, and `@gcsim/ui` is removed from `components`'s `package.json`.
- **`@gcsim/ui` ↔ `@gcsim/db`**: `ui` declared a dependency on `@gcsim/db` that no source file used. Removed the stale dependency.

The remaining edges (`ui → components`, `db → components`, `db → ui`) are one-directional and correct, and form no cycle.

## What a reviewer can now observe

- No source file in `@gcsim/components` imports from `@gcsim/ui`.
- `@gcsim/components`'s `package.json` no longer lists `@gcsim/ui`; `@gcsim/ui`'s `package.json` no longer lists `@gcsim/db`.
- `pnpm install` completes with no cyclic workspace-dependency warning.
- `pnpm run build:web`, `build:db`, and `build:embed` all pass.
- `pnpm run circular` reports only the pre-existing, out-of-scope `Stores/store.ts ↔ Stores/userSlice.ts` cycle (no new circular dependency).

No behavioral change to the graphs, `NoData`/`NoDataIcon` rendering, or the `Footer`. The two `NoData` implementations are left as-is (consolidation was out of scope).

Closes #2785

🤖 Generated with [Claude Code](https://claude.com/claude-code)
