### PR TITLE
refactor(ui): split biome a11y group toggle into per-rule overrides

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -55,10 +55,20 @@
 			// The old ESLint setup had no jsx-a11y plugin, so Biome's
 			// recommended a11y group surfaces ~104 pre-existing violations
 			// (missing SVG titles, button types, alt text, keyboard handlers,
-			// valid anchors). Disabled here so the ESLint->Biome swap stays a
-			// clean tooling change; enabling a11y and fixing the violations is
-			// its own follow-up (issue #2790).
-			"a11y": "off"
+			// valid anchors). Each rule is disabled individually rather than
+			// switching off the whole group, so a follow-up child of #2790 can
+			// re-enable one rule at a time by deleting its "off" line. Keep the
+			// ESLint->Biome swap a clean tooling change; fixing the violations
+			// is tracked per rule under #2790.
+			"a11y": {
+				"noSvgWithoutTitle": "off",
+				"noStaticElementInteractions": "off",
+				"useAltText": "off",
+				"useButtonType": "off",
+				"useValidAnchor": "off",
+				"useAnchorContent": "off",
+				"useKeyWithClickEvents": "off"
+			}
 		}
 	},
 	"assist": {


### PR DESCRIPTION
Splits the single `"a11y": "off"` group toggle in `ui/biome.jsonc` into
seven explicit per-rule `off` overrides.

Before this, no individual a11y rule could be enforced without turning the
whole group back on and surfacing ~104 pre-existing violations at once. Now
each of the seven rules #2790 tracks is disabled on its own line, so a
follow-up child issue can re-enable one rule at a time by simply deleting its
`off` line:

- `noSvgWithoutTitle`
- `noStaticElementInteractions`
- `useAltText`
- `useButtonType`
- `useValidAnchor`
- `useAnchorContent`
- `useKeyWithClickEvents`

The explanatory comment is updated to describe the per-rule structure.

Behaviour-preserving: `biome check` reports the same diagnostics as before —
114 warnings, 282 infos, with an identical per-rule breakdown and no a11y
diagnostics. The config file itself remains valid JSONC and passes the
formatter.

Out of scope (each its own child of #2790): fixing any a11y violation, and the
pre-existing `recommended`-field deprecation info that `biome check` already
reported on the config before this change.

Closes #2794

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPm8Q2XfGYz9WgkXhwW7mZ
