### PR TITLE
fix(ui): add explicit button type and enforce useButtonType

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -64,7 +64,6 @@
 				"noSvgWithoutTitle": "off",
 				"noStaticElementInteractions": "off",
 				"useAltText": "off",
-				"useButtonType": "off",
 				"useValidAnchor": "off",
 				"useAnchorContent": "off",
 				"useKeyWithClickEvents": "off"

--- a/ui/packages/db/src/SharedComponents/DBEntryViewComponents/DBEntryActions.tsx
+++ b/ui/packages/db/src/SharedComponents/DBEntryViewComponents/DBEntryActions.tsx
@@ -91,6 +91,7 @@ function ApproveDBEntryButton({
 	return (
 		<>
 			<button
+				type="button"
 				className="bp4-button bp4-intent-success w-full"
 				disabled={dbEntryId === undefined || dbEntryId === null}
 				onClick={() => {

--- a/ui/packages/db/src/SharedComponents/Filter.tsx
+++ b/ui/packages/db/src/SharedComponents/Filter.tsx
@@ -46,6 +46,7 @@ export function Filter() {
 	return (
 		<div>
 			<button
+				type="button"
 				className="flex flex-row gap-2 bp4-button justify-center items-center p-3 bp4-intent-primary h-12 w-12"
 				onClick={() => setIsOpen(!isOpen)}
 			>
@@ -96,6 +97,7 @@ function ClearFilterButton() {
 	const dispatch = useContext(FilterDispatchContext);
 	return (
 		<button
+			type="button"
 			className="bp4-button bp4-intent-danger bp4-small  "
 			onClick={() => dispatch({ type: "clearFilter" })}
 		>
@@ -122,6 +124,7 @@ function TagFilter() {
 	return (
 		<div className="w-full  overflow-x-hidden no-scrollbar">
 			<button
+				type="button"
 				className=" bp4-button bp4-intent-primary w-full flex-row flex justify-between items-center "
 				onClick={() => setTagIsOpen(!tagIsOpen)}
 			>
@@ -191,6 +194,7 @@ function CharacterFilter() {
 	return (
 		<div className="w-full  overflow-x-hidden no-scrollbar">
 			<button
+				type="button"
 				className=" bp4-button bp4-intent-primary w-full flex-row flex justify-between items-center "
 				onClick={() => setCharIsOpen(!charIsOpen)}
 			>
@@ -248,6 +252,7 @@ function CharFilterButton({ charName }: { charName: string }) {
 		case ItemFilterState.include:
 			return (
 				<button
+					type="button"
 					className={"bp4-button bp4-intent-success block"}
 					onClick={handleClick}
 				>
@@ -257,6 +262,7 @@ function CharFilterButton({ charName }: { charName: string }) {
 		case ItemFilterState.exclude:
 			return (
 				<button
+					type="button"
 					className={"bp4-button bp4-intent-danger block"}
 					onClick={handleClick}
 				>
@@ -266,7 +272,11 @@ function CharFilterButton({ charName }: { charName: string }) {
 		case ItemFilterState.none:
 		default:
 			return (
-				<button className={"bp4-button block "} onClick={handleClick}>
+				<button
+					type="button"
+					className={"bp4-button block "}
+					onClick={handleClick}
+				>
 					<CharFilterButtonChild charName={charName} />
 				</button>
 			);
@@ -308,6 +318,7 @@ function SortBy() {
 	return (
 		<div className="w-full  overflow-x-hidden no-scrollbar">
 			<button
+				type="button"
 				className=" bp4-button bp4-intent-primary w-full flex-row flex justify-between items-center "
 				onClick={() => setSortIsOpen(!sortIsOpen)}
 			>

--- a/ui/packages/db/src/SharedComponents/FilterComponents/FilterPotrait.tsx
+++ b/ui/packages/db/src/SharedComponents/FilterComponents/FilterPotrait.tsx
@@ -88,7 +88,7 @@ function FilterDesktopPortrait({
 
 function PortraitWeaponComponent({ weapon }: { weapon?: string }) {
 	return (
-		<button className={"bp4-button"}>
+		<button type="button" className={"bp4-button"}>
 			{weapon ? (
 				<img
 					src={"https://gcsim.app/api/assets/weapons/" + weapon + ".png"}

--- a/ui/packages/ui/.gitignore
+++ b/ui/packages/ui/.gitignore
@@ -1,0 +1,2 @@
+dist/
+*.tsbuildinfo

--- a/ui/packages/ui/src/Components/NumberInput.tsx
+++ b/ui/packages/ui/src/Components/NumberInput.tsx
@@ -58,6 +58,7 @@ export function NumberInput({
 				/>
 				<div className="rounded-r-md flex flex-col">
 					<button
+						type="button"
 						className="bg-gray-800 w-12 rounded-tr-md focus:outline-none hover:bg-gray-900"
 						disabled={value === max}
 						onClick={() => {
@@ -83,6 +84,7 @@ export function NumberInput({
 						</span>
 					</button>
 					<button
+						type="button"
 						className="bg-gray-800 w-12 rounded-br-md focus:outline-none hover:bg-gray-900"
 						disabled={value === min}
 						onClick={() => {


### PR DESCRIPTION
Fixes all `a11y/useButtonType` violations in `ui/` and enforces the rule at `error`.

## What changed

Twelve `<button>` elements across four files omitted an explicit `type` attribute, so they defaulted to `type="submit"` — a latent bug that would submit an enclosing `<form>` on click. Each is a JS-handler button (drawer/collapse toggles, filter dispatches, the DB approve/deny axios posts, and the NumberInput steppers), none of which submits a form, so all twelve now carry `type="button"`.

The `useButtonType` `off` override is removed from `ui/biome.jsonc`, so the rule now runs at its `recommended` `error` level and will block any future untyped button.

## Verification

- `biome check --only=a11y/useButtonType` reports zero diagnostics.
- `useButtonType` no longer appears as an override in `ui/biome.jsonc`.
- `@gcsim/db` builds; `NumberInput.tsx` typechecks clean (pre-existing unrelated i18next typing errors in `Nav.tsx` are untouched).
- No `<button>` that submits a form was changed — none of the four touched files contains a `<form>`.

No test suite exists in the `ui/` workspace, so "existing tests pass" is vacuous here.

Closes #2795

🤖 Generated with [Claude Code](https://claude.com/claude-code)
