### PR TITLE
fix(ui): add alt text to all images and enforce a11y/useAltText

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -63,7 +63,6 @@
 			"a11y": {
 				"noSvgWithoutTitle": "off",
 				"noStaticElementInteractions": "off",
-				"useAltText": "off",
 				"useValidAnchor": "off",
 				"useAnchorContent": "off",
 				"useKeyWithClickEvents": "off"

--- a/ui/packages/components/src/Cards/AvatarPortait/AvatarPortrait.tsx
+++ b/ui/packages/components/src/Cards/AvatarPortait/AvatarPortrait.tsx
@@ -83,6 +83,7 @@ export const AvatarPortrait = ({
 				<div className="flex justify-center">
 					<img
 						src={"/api/assets/misc/nahida.png"}
+						alt=""
 						className=" object-contain opacity-50 h-24"
 						onLoad={onImageLoaded}
 					/>
@@ -119,6 +120,7 @@ export const AvatarPortrait = ({
 					<img
 						className="relative object-contain h-24"
 						key={char.name}
+						alt={char.name}
 						src={`/api/assets/avatar/${char.name}.png`}
 						onError={(e) => {
 							(e.target as HTMLImageElement).src =

--- a/ui/packages/components/src/common/gcsim/NoData.tsx
+++ b/ui/packages/components/src/common/gcsim/NoData.tsx
@@ -39,7 +39,7 @@ let availableImages = [...images];
 
 export const NoDataIcon = ({ className }: Props) => {
 	const img = useRef<string | undefined>(image());
-	return <img src={img.current} className={className} />;
+	return <img src={img.current} alt="" className={className} />;
 };
 
 function image(): string {

--- a/ui/packages/components/src/common/gcsim/Warning.tsx
+++ b/ui/packages/components/src/common/gcsim/Warning.tsx
@@ -64,11 +64,11 @@ export function Warning({
 				/>
 			</div>
 			<div className="inline-flex pt-4">
-				<img src={tanuki} className="w-15 h-10 mx-0" />
+				<img src={tanuki} alt="" className="w-15 h-10 mx-0" />
 				<div className="font-semibold px-3 pt-2 text-xl w-50 text-gray-200">
 					{t(headerKey)}
 				</div>
-				<img src={tanuki} className="w-15 h-10 mx-0" />
+				<img src={tanuki} alt="" className="w-15 h-10 mx-0" />
 			</div>
 			<div className="space-y-3 pb-3 text-s leading-5 text-gray-400">
 				<Trans i18nKey={bodyKey} components={bodyComponents}>

--- a/ui/packages/db/src/Pages/Database/DBVIew.tsx
+++ b/ui/packages/db/src/Pages/Database/DBVIew.tsx
@@ -25,7 +25,7 @@ export const DBView = (props: Props) => {
 			/>
 			{props.data.length === 0 ? (
 				<div className="6 flex flex-col justify-center items-center h-screen">
-					<img src={eula} className=" object-contain opacity-50 w-32 h-32" />
+					<img src={eula} alt="" className=" object-contain opacity-50 w-32 h-32" />
 				</div>
 			) : (
 				<InfiniteScroll

--- a/ui/packages/db/src/Sectioning/Nav.tsx
+++ b/ui/packages/db/src/Sectioning/Nav.tsx
@@ -24,6 +24,7 @@ export default function Nav() {
 						<Link href="/" className="flex h-[50px] items-center">
 							<img
 								src={logo}
+								alt=""
 								className="object-scale-down max-h-[75%] m-auto mr-2"
 							/>
 							<span className="font-medium font-mono">simpact</span>

--- a/ui/packages/db/src/SharedComponents/CharacterQuickSelect.tsx
+++ b/ui/packages/db/src/SharedComponents/CharacterQuickSelect.tsx
@@ -34,6 +34,7 @@ export function CharacterQuickSelect() {
 							icon={
 								<img
 									src={`/api/assets/avatar/${charName}.png`}
+									alt=""
 									className="w-6 h-6"
 								/>
 							}
@@ -51,6 +52,7 @@ export function CharacterQuickSelect() {
 					<div className="flex flex-row gap-1" key={charName}>
 						<img
 							className="w-4 h-4"
+							alt=""
 							src={`/api/assets/avatar/${charName}.png`}
 						/>
 						{translateCharName(charName)}

--- a/ui/packages/db/src/SharedComponents/DBEntryViewComponents/DBEntryPortrait.tsx
+++ b/ui/packages/db/src/SharedComponents/DBEntryViewComponents/DBEntryPortrait.tsx
@@ -20,7 +20,7 @@ function DBEntryDesktopPortrait({ name, sets, weapon, cons }: model.Character) {
 	if (!name) {
 		return (
 			<div className="bg-slate-700 p-2 w-20 flex flex-row  h-fit justify-center">
-				<img src={nahida} className=" object-contain opacity-50 " />
+				<img src={nahida} alt="" className=" object-contain opacity-50 " />
 			</div>
 		);
 	}
@@ -52,7 +52,7 @@ function DBEntryMobilePortrait({ name, sets, weapon, cons }: model.Character) {
 	if (!name) {
 		return (
 			<div className="bg-slate-700 p-2  max-h-20 flex flex-row justify-center">
-				<img src={nahida} className=" object-contain opacity-50" />
+				<img src={nahida} alt="" className=" object-contain opacity-50" />
 			</div>
 		);
 	}

--- a/ui/packages/db/src/SharedComponents/FilterComponents/FilterPotrait.tsx
+++ b/ui/packages/db/src/SharedComponents/FilterComponents/FilterPotrait.tsx
@@ -29,7 +29,7 @@ function FilterDesktopPortrait({
 	if (!name) {
 		return (
 			<div className="bg-slate-700 p-2 w-20 flex flex-row  h-fit justify-center">
-				<img src={nahida} className=" object-contain opacity-50 " />
+				<img src={nahida} alt="" className=" object-contain opacity-50 " />
 			</div>
 		);
 	}

--- a/ui/packages/ui/src/Components/Cards/CharacterCard.tsx
+++ b/ui/packages/ui/src/Components/Cards/CharacterCard.tsx
@@ -125,6 +125,7 @@ export function CharacterCard({
 					<img
 						key="key"
 						src={`/api/assets/artifacts/${key}_flower.png`}
+						alt={key}
 						className="w-full h-8"
 						onError={(e) => ((e.target as HTMLImageElement).src = placeholder)}
 					/>

--- a/ui/packages/ui/src/Pages/Viewer/Components/Util/NoData/index.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Util/NoData/index.tsx
@@ -34,7 +34,7 @@ let availableImages = [...images];
 
 export const NoDataIcon = ({ className }: Props) => {
 	const img = useRef<string | undefined>(image());
-	return <img src={img.current} className={className} />;
+	return <img src={img.current} alt="" className={className} />;
 };
 
 function image(): string {

--- a/ui/packages/ui/src/Sectioning/Nav.tsx
+++ b/ui/packages/ui/src/Sectioning/Nav.tsx
@@ -80,6 +80,7 @@ export default () => {
 								<Link to="/" className="flex h-[50px] items-center">
 									<img
 										src={logo}
+										alt=""
 										className="object-scale-down max-h-[75%] m-auto mr-2"
 									/>
 									<span className="font-medium font-mono">gcsim</span>


### PR DESCRIPTION
Every `<img>` in the UI now carries a text alternative, and Biome enforces `a11y/useAltText` at `error` so new images without one fail lint.

Screen-reader users previously hit ~15 unlabeled images across the viewer, database, and shared components. Now:

- Decorative images — placeholders (nahida/eula/tanuki), empty-state and "no data" illustrations, logos sitting beside their brand text, and avatar icons shown next to the character's name — use `alt=""`, so assistive tech skips them instead of announcing a filename.
- Informative images have descriptive text: the character avatar in `AvatarPortrait` uses the character name; the artifact-set image in `CharacterCard` uses the set key.

The `useAltText: "off"` override is removed from `ui/biome.jsonc`, so the recommended rule now runs at `error`; `biome check` reports zero `useAltText` diagnostics and the web app builds.

Reviewer note: the wording of the two *informative* alt values is a judgement call worth a sanity-check — everything else is decorative `alt=""`.

Closes #2797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPm8Q2XfGYz9WgkXhwW7mZ
