### PR TITLE
fix(a11y): resolve interaction/anchor rule cluster and enforce at error

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -53,19 +53,11 @@
 				"noArrayIndexKey": "off"
 			},
 			// The old ESLint setup had no jsx-a11y plugin, so Biome's
-			// recommended a11y group surfaces ~104 pre-existing violations
-			// (missing SVG titles, button types, alt text, keyboard handlers,
-			// valid anchors). Each rule is disabled individually rather than
-			// switching off the whole group, so a follow-up child of #2790 can
-			// re-enable one rule at a time by deleting its "off" line. Keep the
-			// ESLint->Biome swap a clean tooling change; fixing the violations
-			// is tracked per rule under #2790.
-			"a11y": {
-				"noStaticElementInteractions": "off",
-				"useValidAnchor": "off",
-				"useAnchorContent": "off",
-				"useKeyWithClickEvents": "off"
-			}
+			// recommended a11y group surfaced ~104 pre-existing violations.
+			// They are being fixed and re-enabled one rule at a time under
+			// #2790; the interaction/anchor cluster (#2799) is done and now
+			// runs at the recommended "error". No a11y overrides remain.
+			"a11y": {}
 		}
 	},
 	"assist": {

--- a/ui/packages/components/src/Cards/DistributionCard/Tooltip.tsx
+++ b/ui/packages/components/src/Cards/DistributionCard/Tooltip.tsx
@@ -111,6 +111,7 @@ export const RenderTooltip = (props: Props) => {
 	const tooltipTop = props.yScale(count) - 10;
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/components/src/common/gcsim/GraphComponents/OuterLabelPie/Tooltip.tsx
+++ b/ui/packages/components/src/common/gcsim/GraphComponents/OuterLabelPie/Tooltip.tsx
@@ -67,6 +67,7 @@ export const RenderTooltip = <Datum,>(props: Props<Datum>) => {
 	}
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/components/src/common/gcsim/GraphComponents/OuterLabelPie/index.tsx
+++ b/ui/packages/components/src/common/gcsim/GraphComponents/OuterLabelPie/index.tsx
@@ -106,6 +106,7 @@ export default <Datum,>({
 						{(pie) => {
 							return pie.arcs.map((arc, index) => {
 								return (
+									// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 									<path
 										key={"arc-" + index}
 										d={pie.path(arc) ?? ""}

--- a/ui/packages/components/src/common/gcsim/Warning.tsx
+++ b/ui/packages/components/src/common/gcsim/Warning.tsx
@@ -90,6 +90,7 @@ export const RiskWarning = () => (
 			b: <b />,
 			p: <p className="text-gray-200" />,
 			discordlink: (
+				// biome-ignore lint/a11y/useAnchorContent: text injected at runtime by <Trans>
 				<a
 					href="https://discord.com/invite/m7jvjdxx7q"
 					target="_blank"
@@ -97,6 +98,7 @@ export const RiskWarning = () => (
 				/>
 			),
 			githublink: (
+				// biome-ignore lint/a11y/useAnchorContent: text injected at runtime by <Trans>
 				<a
 					href="https://github.com/genshinsim/gcsim"
 					target="_blank"
@@ -104,6 +106,7 @@ export const RiskWarning = () => (
 				/>
 			),
 			issueslink: (
+				// biome-ignore lint/a11y/useAnchorContent: text injected at runtime by <Trans>
 				<a
 					href="https://github.com/genshinsim/gcsim/issues"
 					target="_blank"

--- a/ui/packages/db/src/SharedComponents/DBEntryViewComponents/DBEntryTags.tsx
+++ b/ui/packages/db/src/SharedComponents/DBEntryViewComponents/DBEntryTags.tsx
@@ -1,6 +1,6 @@
 import tagData from "@gcsim/data/src/tags.json";
 import type { model } from "@gcsim/types";
-import { useLocation } from "wouter";
+import { Link } from "wouter";
 
 export default function DBEntryTags({
 	tags,
@@ -10,23 +10,18 @@ export default function DBEntryTags({
 	// const { t: translate } = useTranslation();
 	// const t = (key: string) => translate(key) as string; // idk why this is needed
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const [_, setLocation] = useLocation();
-
 	return (
 		<div className={"flex flex-row overflow-hidden"}>
 			{tags
 				?.filter((tag) => tag !== 1)
 				.map((tag) => (
-					<div
+					<Link
 						className="hover:opacity-50 cursor-pointer bg-slate-500 text-xs font-semibold rounded-full px-2 py-1 mr-2 mt-1 whitespace-nowrap "
 						key={tag}
-						onClick={() => {
-							setLocation(`/tag/${tag}`);
-						}}
+						href={`/tag/${tag}`}
 					>
 						{tagData[tag].display_name}
-					</div>
+					</Link>
 				))}
 		</div>
 	);

--- a/ui/packages/storybook/src/stories/Cards/DBCard.stories.tsx
+++ b/ui/packages/storybook/src/stories/Cards/DBCard.stories.tsx
@@ -27,9 +27,7 @@ export const Primary: Story = {
 	args: {
 		entry: dbEntries.data[0],
 		footer: (
-			<a href="#">
-				<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
-			</a>
+			<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
 		),
 	},
 };
@@ -38,9 +36,7 @@ export const PrimaryTablet: Story = {
 	args: {
 		entry: dbEntries.data[0],
 		footer: (
-			<a href="#">
-				<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
-			</a>
+			<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
 		),
 	},
 	parameters: {
@@ -54,9 +50,7 @@ export const PrimaryMobile: Story = {
 	args: {
 		entry: dbEntries.data[0],
 		footer: (
-			<a href="#">
-				<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
-			</a>
+			<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
 		),
 	},
 	parameters: {
@@ -71,9 +65,7 @@ export const BGOverride: Story = {
 		className: "bg-orange-600",
 		entry: dbEntries.data[0],
 		footer: (
-			<a href="#">
-				<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
-			</a>
+			<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
 		),
 	},
 };
@@ -94,9 +86,7 @@ export const LongDesc: Story = {
 	args: {
 		entry: longDesc,
 		footer: (
-			<a href="#">
-				<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
-			</a>
+			<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
 		),
 	},
 };
@@ -105,9 +95,7 @@ export const LongDescTablet: Story = {
 	args: {
 		entry: longDesc,
 		footer: (
-			<a href="#">
-				<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
-			</a>
+			<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
 		),
 	},
 	parameters: {
@@ -121,9 +109,7 @@ export const LongDescMobile: Story = {
 	args: {
 		entry: longDesc,
 		footer: (
-			<a href="#">
-				<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
-			</a>
+			<Button className="bg-blue-700 opacity-90">Show Results Page</Button>
 		),
 	},
 	parameters: {

--- a/ui/packages/ui/src/Pages/Sample/Components/SampleItemView.tsx
+++ b/ui/packages/ui/src/Pages/Sample/Components/SampleItemView.tsx
@@ -18,15 +18,20 @@ export function SampleItemView({
 			className="flex flex-row gap-2 items-center pl-1 pr-1 pt-px pb-px rounded-md m-1 "
 			style={{ backgroundColor: item.color }}
 		>
-			<span
+			<button
+				type="button"
 				className="material-icons text-sm cursor-pointer"
 				onClick={() => showBuffDuration(item)}
 			>
 				{item.icon}
-			</span>
-			<div className="flex-grow cursor-pointer" onClick={handleClick}>
+			</button>
+			<button
+				type="button"
+				className="flex-grow cursor-pointer text-left"
+				onClick={handleClick}
+			>
 				{item.msg}
-			</div>
+			</button>
 			<div>{item.target}</div>
 			<Dialog
 				canEscapeKeyClose

--- a/ui/packages/ui/src/Pages/Simulator/Components/Enka/ImportFromEnkaDialog.tsx
+++ b/ui/packages/ui/src/Pages/Simulator/Components/Enka/ImportFromEnkaDialog.tsx
@@ -86,6 +86,7 @@ export function ImportFromEnkaDialog(props: Props) {
 			<div className={Classes.DIALOG_BODY}>
 				<p className="!pb-2">
 					<Trans i18nKey="simple.tools_import_pre_enka">
+						{/* biome-ignore lint/a11y/useAnchorContent: text injected at runtime by <Trans> */}
 						<a href="https://enka.network/" target="_blank" rel="noreferrer" />
 					</Trans>
 				</p>

--- a/ui/packages/ui/src/Pages/Simulator/Components/GOOD/ImportFromGOODDialog.tsx
+++ b/ui/packages/ui/src/Pages/Simulator/Components/GOOD/ImportFromGOODDialog.tsx
@@ -61,6 +61,7 @@ export function ImportFromGOODDialog(props: Props) {
 			<div className={Classes.DIALOG_BODY}>
 				<p className="!pb-2">
 					<Trans i18nKey="simple.tools_import_pre_go">
+						{/* biome-ignore lint/a11y/useAnchorContent: text injected at runtime by <Trans> */}
 						<a
 							href="https://frzyc.github.io/genshin-optimizer/#/setting"
 							target="_blank"

--- a/ui/packages/ui/src/Pages/Simulator/Components/TeamBuilder/Builder.tsx
+++ b/ui/packages/ui/src/Pages/Simulator/Components/TeamBuilder/Builder.tsx
@@ -50,12 +50,13 @@ export const Builder = (props: Props) => {
 			className="basis-full sm:basis-1/2 hd:basis-1/4 pr-2 pb-2 pt-2"
 			key="_blank"
 		>
-			<div
-				className="bg-gray-600 shadow rounded-md hover:bg-gray-500 flex items-center justify-center min-h-[226px] h-full"
+			<button
+				type="button"
+				className="bg-gray-600 shadow rounded-md hover:bg-gray-500 flex items-center justify-center min-h-[226px] h-full w-full"
 				onClick={props.handleAdd}
 			>
 				<Icon icon="plus" size={30} color="white" />
-			</div>
+			</button>
 		</div>
 	);
 

--- a/ui/packages/ui/src/Pages/Simulator/Tooltips.tsx
+++ b/ui/packages/ui/src/Pages/Simulator/Tooltips.tsx
@@ -78,9 +78,9 @@ export const TeamBuilderTooltip = () => {
 			<Callout intent={Intent.PRIMARY} className="flex flex-col">
 				<span>
 					<Trans>simple.video_pre</Trans>
-					<a onClick={() => setOpenAddCharHelp(true)}>
+					<button type="button" onClick={() => setOpenAddCharHelp(true)}>
 						<Trans>simple.video</Trans>
-					</a>
+					</button>
 					<Trans>simple.video_post</Trans>
 				</span>
 				<div className="ml-auto">

--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/CumulativeDamageCard/CumulativeDamageTooltip.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/CumulativeDamageCard/CumulativeDamageTooltip.tsx
@@ -250,6 +250,7 @@ export const RenderTooltip = (props: TooltipProps) => {
 	const point = props.data[props.tooltipData.index];
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/CumulativeTooltip.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/CumulativeTooltip.tsx
@@ -164,6 +164,7 @@ export const RenderTooltip = (props: TooltipProps) => {
 	const point = props.data[props.tooltipData.index];
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/DamageOverTimeTooltip.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/DamageOverTimeTooltip.tsx
@@ -232,6 +232,7 @@ export const RenderTooltip = (props: TooltipProps) => {
 	const point = props.data[props.tooltipData.index];
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/ui/src/Pages/Viewer/Components/Overview/DistributionCard/Tooltip.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Overview/DistributionCard/Tooltip.tsx
@@ -111,6 +111,7 @@ export const RenderTooltip = (props: Props) => {
 	const tooltipTop = props.yScale(count) - 10;
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/ui/src/Pages/Viewer/Components/Overview/TargetInfo/PositionGraphTooltip.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Overview/TargetInfo/PositionGraphTooltip.tsx
@@ -81,6 +81,7 @@ export const RenderTooltip = (props: Props) => {
 		: DataColorsConst.qualitative5(data.index);
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/ui/src/Pages/Viewer/Components/Util/HorizontalBarStack/Tooltip.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Util/HorizontalBarStack/Tooltip.tsx
@@ -71,6 +71,7 @@ export const RenderTooltip = <Datum, Key>(props: Props<Datum, Key>) => {
 	}
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/ui/src/Pages/Viewer/Components/Util/HorizontalBarStack/index.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Util/HorizontalBarStack/index.tsx
@@ -135,6 +135,7 @@ export default <Datum, Key extends StackKey>({
 											top={bar.y}
 											left={bar.x}
 										>
+											{/* biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics */}
 											<rect
 												width={bar.width}
 												height={bar.height}

--- a/ui/packages/ui/src/Pages/Viewer/Components/Util/OuterLabelPie/Tooltip.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Util/OuterLabelPie/Tooltip.tsx
@@ -67,6 +67,7 @@ export const RenderTooltip = <Datum,>(props: Props<Datum>) => {
 	}
 
 	const content = (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 		<div
 			onMouseMove={() => {
 				props.handles.clearTimeout();

--- a/ui/packages/ui/src/Pages/Viewer/Components/Util/OuterLabelPie/index.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Util/OuterLabelPie/index.tsx
@@ -106,6 +106,7 @@ export default <Datum,>({
 						{(pie) => {
 							return pie.arcs.map((arc, index) => {
 								return (
+									// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 									<path
 										key={"arc-" + index}
 										d={pie.path(arc) ?? ""}

--- a/ui/packages/ui/src/Pages/Viewer/Components/ViewerNav.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/ViewerNav.tsx
@@ -27,16 +27,19 @@ export default ({ tabState, data, hash, running }: NavProps) => {
 	return (
 		<Tabs selectedTabId={tabId} onChange={(s) => setTabId(s as string)}>
 			<Tab id="results" className="focus:outline-none">
+				{/* biome-ignore lint/a11y/useValidAnchor: intentional nav anchor — href drives URL-hash tab deep-linking (reload/bookmark/share to a tab) and native ctrl/cmd-click open-in-new-tab; a <button> would lose both */}
 				<a href="#" onClick={ignoreCtrlClick}>
 					{t<string>("viewer.results")}
 				</a>
 			</Tab>
 			<Tab id="config" className="focus:outline-none">
+				{/* biome-ignore lint/a11y/useValidAnchor: intentional nav anchor — href drives URL-hash tab deep-linking (reload/bookmark/share to a tab) and native ctrl/cmd-click open-in-new-tab; a <button> would lose both */}
 				<a href="#tab=config" onClick={ignoreCtrlClick}>
 					{t<string>("viewer.config")}
 				</a>
 			</Tab>
 			<Tab id="sample" className="focus:outline-none">
+				{/* biome-ignore lint/a11y/useValidAnchor: intentional nav anchor — href drives URL-hash tab deep-linking (reload/bookmark/share to a tab) and native ctrl/cmd-click open-in-new-tab; a <button> would lose both */}
 				<a href="#tab=sample" onClick={ignoreCtrlClick}>
 					{t<string>("viewer.sample")}
 				</a>

--- a/ui/packages/ui/src/Pages/Viewer/Components/Warnings.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Warnings.tsx
@@ -44,6 +44,7 @@ const IncompleteCharWarning = ({ data }: WarningProps) => {
 		>
 			<p>
 				<Trans i18nKey="warnings.incomplete_char_body">
+					{/* biome-ignore lint/a11y/useAnchorContent: text injected at runtime by <Trans> */}
 					<a
 						href="https://discord.gg/m7jvjdxx7q"
 						target="_blank"


### PR DESCRIPTION
## What this changes

The `ui/` Biome config had four a11y rules disabled with per-rule `off`
entries — `noStaticElementInteractions`, `useValidAnchor`,
`useAnchorContent` and `useKeyWithClickEvents` (~39 diagnostics). This
resolves every diagnostic and enforces all four at the recommended
`error`. A reviewer can now run `biome lint` in `ui/` and see the
interaction/anchor cluster pass with no overrides remaining in
`biome.jsonc`.

Each flagged element was resolved by the triage decision table, in two
ways:

**Converted to native, keyboard-operable controls** (no
`role`+`tabIndex`+`onKeyDown` fallbacks):

- `<div>`/`<span>` acting as buttons (open dialog, toggle, add team
  member) → `<button type="button">`, existing classes preserved
- the "video" help `<a onClick>` with no href → `<button type="button">`
- the DB tag chip that navigated via wouter `setLocation` → wouter
  `<Link href>` (matches the existing pattern in
  `db/Sectioning/Nav.tsx`; keeps SPA navigation), dropping the now-unused
  `useLocation` and its `eslint-disable`

**Documented with `biome-ignore` + rationale** where the element is
correct as-is:

- chart/tooltip hover regions (SVG `rect`/`path` and `div` wrappers) that
  carry only `onMouseMove`/`onMouseLeave` to position a visx tooltip
- `<a href>` placeholders passed to react-i18next `<Trans>`, whose
  visible text is injected at runtime
- the viewer results/config/sample tab anchors — their hrefs drive
  URL-hash tab deep-linking (reload/bookmark/share-to-tab) and native
  ctrl/cmd-click open-in-new-tab; a `<button>` would lose both (behaviour
  was manually verified during triage)

Storybook `DBCard` fixtures dropped their dead `<a href="#">` wrappers;
the `<Button>` alone carries each story.

## Verification

- `biome lint --only=a11y/<rule>` reports **zero** diagnostics for all
  four rules; no a11y overrides remain in `ui/biome.jsonc`.
- `pnpm --filter @gcsim/web build` and `pnpm --filter @gcsim/storybook
  build-storybook` both succeed.
- Tailwind preflight is active, so converted `<button>`s render with
  transparent background, no border and inherited font/colour — no
  visual chrome regression versus the original elements.
- No UI test runner/tests exist for these packages, so there are none to
  run.

## Not done / follow-up

- The two icon-only converts (the TeamBuilder "add" button and the
  Sample icon button) have no accessible name yet. That is not flagged by
  any of the four rules in scope and belongs with the remaining a11y
  rollout under #2790, so it is intentionally left out to keep this PR
  scoped.
- Out of scope per the brief and untouched: `noSvgWithoutTitle`,
  `useAltText`, `useButtonType`, `noArrayIndexKey`, and wiring Biome into
  CI as a blocking check.

Closes #2799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2v17psJR8YdFKb8icGT1i
