### PR TITLE
fix(ui): resolve missing useExhaustiveDependencies deps, raise rule to error

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -35,13 +35,7 @@
 					"level": "warn",
 					"options": { "ignoreRestSiblings": true }
 				},
-				// Preserve the old severity: eslint-plugin-react-hooks'
-				// `recommended` config ran `react-hooks/exhaustive-deps` at
-				// "warn", not error. Keep the Biome equivalent at "warn" so the
-				// migration is behaviour-preserving rather than auto-rewriting
-				// hook dependency arrays (which can change effect timing).
-				// Raising it back to error is tracked in issue #2790.
-				"useExhaustiveDependencies": "warn"
+				"useExhaustiveDependencies": "error"
 			},
 			"suspicious": {
 				"noTsIgnore": "off",

--- a/ui/packages/db/src/Pages/Database/Database.tsx
+++ b/ui/packages/db/src/Pages/Database/Database.tsx
@@ -2,7 +2,7 @@ import { craftQuery, type DbQuery } from "SharedHooks/databaseQuery";
 import { Spinner } from "@blueprintjs/core";
 import type { db } from "@gcsim/types";
 import axios from "axios";
-import { useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import {
 	initialFilter as defaultFilter,
 	FilterContext,
@@ -24,51 +24,54 @@ export const Database = ({ initialFilter = defaultFilter }: Props) => {
 	const [page, setPage] = useState<number>(1);
 	const abortController = useRef(new AbortController());
 
-	const appendData = (next: db.Entry[]) => {
+	const appendData = useCallback((next: db.Entry[]) => {
 		// let d = [ ...data,...next.filter(e => {
 		//   return false
 		// })]
-		setData([...data, ...next]);
-	};
+		setData((prev) => [...prev, ...next]);
+	}, []);
 
-	const querydb = (query: DbQuery, nextPage: number, append: boolean) => {
-		axios(`/api/db?q=${encodeURIComponent(JSON.stringify(query))}`, {
-			signal: abortController.current.signal,
-		})
-			.then((resp: { data: db.Entries }) => {
-				if (resp.data && resp.data.data) {
-					setPage(nextPage);
-					setHasMore(true);
-					if (append) {
-						appendData(resp.data.data);
-					} else {
-						setData(resp.data.data);
-					}
-					//check count; if we got less than limit then there's no more data...
-					//TODO: this is bugged if there are exactly limit number of entries...
-					//TODO: really server should tell us if there's more data
-					if (resp.data.data.length < query.limit) {
-						setHasMore(false);
-					}
-				} else {
-					setHasMore(false);
-					if (!append) {
-						setData([]);
-					}
-				}
-				setIsLoading(false);
+	const querydb = useCallback(
+		(query: DbQuery, nextPage: number, append: boolean) => {
+			axios(`/api/db?q=${encodeURIComponent(JSON.stringify(query))}`, {
+				signal: abortController.current.signal,
 			})
-			.catch((err) => {
-				console.log("error: ", err);
-			});
-	};
+				.then((resp: { data: db.Entries }) => {
+					if (resp.data && resp.data.data) {
+						setPage(nextPage);
+						setHasMore(true);
+						if (append) {
+							appendData(resp.data.data);
+						} else {
+							setData(resp.data.data);
+						}
+						//check count; if we got less than limit then there's no more data...
+						//TODO: this is bugged if there are exactly limit number of entries...
+						//TODO: really server should tell us if there's more data
+						if (resp.data.data.length < query.limit) {
+							setHasMore(false);
+						}
+					} else {
+						setHasMore(false);
+						if (!append) {
+							setData([]);
+						}
+					}
+					setIsLoading(false);
+				})
+				.catch((err) => {
+					console.log("error: ", err);
+				});
+		},
+		[appendData],
+	);
 
 	useEffect(() => {
 		abortController.current.abort();
 		abortController.current = new AbortController();
 		const query = craftQuery(filter, 1, 25);
 		querydb(query, 1, false);
-	}, [filter]);
+	}, [filter, querydb]);
 
 	const fetchData = () => {
 		const nextPage = page + 1;

--- a/ui/packages/db/src/Pages/Database/Database.tsx
+++ b/ui/packages/db/src/Pages/Database/Database.tsx
@@ -24,6 +24,9 @@ export const Database = ({ initialFilter = defaultFilter }: Props) => {
 	const [page, setPage] = useState<number>(1);
 	const abortController = useRef(new AbortController());
 
+	// TODO(react19): drop this useCallback (inline the function) once the React
+	// Compiler is enabled — it auto-memoizes. Keep the functional setData
+	// updater regardless: it fixes a stale-closure bug, independent of memoization.
 	const appendData = useCallback((next: db.Entry[]) => {
 		// let d = [ ...data,...next.filter(e => {
 		//   return false
@@ -31,6 +34,10 @@ export const Database = ({ initialFilter = defaultFilter }: Props) => {
 		setData((prev) => [...prev, ...next]);
 	}, []);
 
+	// TODO(react19): drop this useCallback (inline the function) once the React
+	// Compiler is enabled — it auto-memoizes. Don't remove it before then:
+	// querydb must stay referentially stable or the effect below refetch-loops,
+	// and useExhaustiveDependencies is now an error.
 	const querydb = useCallback(
 		(query: DbQuery, nextPage: number, append: boolean) => {
 			axios(`/api/db?q=${encodeURIComponent(JSON.stringify(query))}`, {

--- a/ui/packages/embed/src/App.tsx
+++ b/ui/packages/embed/src/App.tsx
@@ -23,6 +23,7 @@ const App = ({ id, src }: { id: string; src: string }) => {
 	);
 	const [loaded, setLoaded] = React.useState(0);
 	const [completed, setCompleted] = React.useState(false);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: mount-only fetch. The embed app is single-use — the Go embed generator opens a fresh headless page, navigates once to a single /db/:id or /sh/:id URL, and discards it; id/src never change on a mounted App, so refetching on them would be dead code.
 	React.useEffect(() => {
 		//https://gcsim.app/api/share/db/nFLhjtD9dfFN
 		const url = `/api/share/` + (src === "db" ? "db/" : "") + id;
@@ -44,7 +45,7 @@ const App = ({ id, src }: { id: string; src: string }) => {
 		if (loaded >= (data?.character_details?.length ?? 0)) {
 			setCompleted(true);
 		}
-	}, [loaded]);
+	}, [loaded, data?.character_details?.length]);
 
 	const handleOnImageLoaded = () => {
 		setLoaded(loaded + 1);

--- a/ui/packages/ui/src/Pages/Viewer/Components/LoadingToast.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/LoadingToast.tsx
@@ -91,7 +91,7 @@ export default ({ running, src, error, current, total, cancel }: Props) => {
 			},
 			key.current,
 		);
-	}, [current, total, src, error, running, cancel]);
+	}, [current, total, src, error, running, cancel, t]);
 
 	return (
 		<Toaster ref={loadingToast} position={Position.TOP} className="z-50" />

--- a/ui/packages/ui/src/Pages/Viewer/Tabs/Config.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Tabs/Config.tsx
@@ -101,6 +101,9 @@ export function useConfig(
 	const [err, setErr] = useState("");
 	const [modified, setModified] = useState<boolean>(false);
 
+	// TODO(react19): drop this useCallback and inline the function once the
+	// React Compiler is enabled — it auto-memoizes. Don't remove it before
+	// then: useExhaustiveDependencies is now an error and would fail the build.
 	const updateCfg = useCallback((newCfg: string) => {
 		setCfg(newCfg);
 		setModified(true);

--- a/ui/packages/ui/src/Pages/Viewer/Tabs/Config.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Tabs/Config.tsx
@@ -9,7 +9,7 @@ import {
 import type { Executor, ExecutorSupplier } from "@gcsim/executors";
 import type { SimResults } from "@gcsim/types";
 import { ConfigEditor } from "@ui/Components";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router";
 import ExecutorSettingsButton from "../../../Components/Buttons/ExecutorSettingsButton";
@@ -101,10 +101,10 @@ export function useConfig(
 	const [err, setErr] = useState("");
 	const [modified, setModified] = useState<boolean>(false);
 
-	const updateCfg = (newCfg: string) => {
+	const updateCfg = useCallback((newCfg: string) => {
 		setCfg(newCfg);
 		setModified(true);
-	};
+	}, []);
 
 	// reset config file every time it changes from results
 	useEffect(() => {
@@ -140,7 +140,7 @@ export function useConfig(
 			exec: exec,
 			setCfg: updateCfg,
 		};
-	}, [cfg, err, exec, isReady, modified, validated]);
+	}, [cfg, err, exec, isReady, modified, validated, updateCfg]);
 }
 
 export default React.memo(ConfigUI);

--- a/ui/packages/ui/src/Pages/Viewer/Tabs/Sample.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Tabs/Sample.tsx
@@ -234,6 +234,9 @@ export function useSample(
 		return DefaultSampleOptions;
 	});
 
+	// TODO(react19): drop this useCallback and inline the function once the
+	// React Compiler is enabled — it auto-memoizes. Don't remove it before
+	// then: useExhaustiveDependencies is now an error and would fail the build.
 	const setAndStore = useCallback((val: string[]) => {
 		setSelected(val);
 		localStorage.setItem(SAVED_SAMPLE_KEY, JSON.stringify(val));

--- a/ui/packages/ui/src/Pages/Viewer/Tabs/Sample.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Tabs/Sample.tsx
@@ -10,7 +10,7 @@ import {
 } from "@blueprintjs/core";
 import type { Sample, SimResults } from "@gcsim/types";
 import queryString from "query-string";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	DefaultSampleOptions,
@@ -234,10 +234,10 @@ export function useSample(
 		return DefaultSampleOptions;
 	});
 
-	const setAndStore = (val: string[]) => {
+	const setAndStore = useCallback((val: string[]) => {
 		setSelected(val);
 		localStorage.setItem(SAVED_SAMPLE_KEY, JSON.stringify(val));
-	};
+	}, []);
 
 	const [sample, SetSample] = useState<Sample | undefined>(undefined);
 	const [generating, setGenerating] = useState(false);
@@ -327,5 +327,5 @@ export function useSample(
 			setSettings: setAndStore,
 			setSeed: setSeed,
 		};
-	}, [generating, parsed, sample, searchable, seed, selected]);
+	}, [generating, parsed, sample, searchable, seed, selected, setAndStore]);
 }


### PR DESCRIPTION
## What this changes

The `useExhaustiveDependencies` lint rule in the `ui/` workspace now runs at **error**, and `biome check` reports **zero** missing-dependency warnings where it previously reported five. A reviewer can now rely on hook dependency arrays being complete in `ui/`, and any future missing dep fails the check rather than being silently tolerated.

Each of the five hooks was fixed at the source rather than silenced:

- **`Config` `updateCfg` and `Sample` `setAndStore`** — wrapped in `useCallback` (empty deps; they only call stable state setters and `localStorage`) and added to their `useMemo` deps. The returned hook-API objects stay referentially stable across renders.
- **`Database` `querydb`** — wrapped in `useCallback` and added to the page-1 refetch effect's deps. To keep `querydb` stable, `appendData` now uses the functional `setData` updater (dropping its `data` closure) and is itself memoized, so `querydb` depends only on the stable `appendData`. The effect still refetches page 1 only on a real `filter` change — no refetch loop. This also fixes a latent stale-closure bug where paginated appends could drop entries.
- **`embed` `App` first effect** — left as an intentional mount-only fetch, documented with a justified `biome-ignore`. The embed app is single-use (the Go embed generator opens a fresh headless page, navigates once, and discards it), so `id`/`src` never change on a mounted `App`; adding them would be dead re-fetch handling.
- **`embed` `App` second effect** — added the missing `data?.character_details?.length` dep.
- **`LoadingToast`** — added `t` from `useTranslation` to the toast effect deps.

## Verification

- `pnpm exec biome check` in `ui/`: zero `useExhaustiveDependencies` diagnostics.
- `pnpm run build:db` and `pnpm run build:embed` succeed.
- `tsc --noEmit` on the `ui` package introduces no new type errors vs. baseline (the pre-existing i18next `t<string>()` typing errors are unrelated and out of scope).

## Not done / notes

- The `appendData` refactor in `Database.tsx` goes slightly beyond the literally-named `querydb`, but it is required to stabilize `querydb` without a refetch loop.
- Pre-existing lint/type issues unrelated to this rule (e.g. `noUnusedFunctionParameters`, i18next typings) are left untouched, per the ticket's out-of-scope list.

Closes #2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2v17psJR8YdFKb8icGT1i
