### PR TITLE
fix(ui): datum-derived React keys, enforce noArrayIndexKey (#2800)

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -45,12 +45,7 @@
 			},
 			"suspicious": {
 				"noTsIgnore": "off",
-				"noEmptyBlockStatements": "off",
-				// New signal the old ESLint config never checked (~39 hits).
-				// Deferred to a follow-up tightening pass so this tooling swap
-				// lands clean. Fixing needs stable React keys, not a mechanical
-				// change. See the Biome-tightening follow-up (issue #2790).
-				"noArrayIndexKey": "off"
+				"noEmptyBlockStatements": "off"
 			},
 			// The old ESLint setup had no jsx-a11y plugin, so Biome's
 			// recommended a11y group surfaced ~104 pre-existing violations.

--- a/ui/packages/components/src/Cards/AvatarCard/AvatarCard.tsx
+++ b/ui/packages/components/src/Cards/AvatarCard/AvatarCard.tsx
@@ -32,7 +32,7 @@ export const AvatarCard = ({
 				}
 				return (
 					<AvatarPortrait
-						key={"char-" + i}
+						key={c?.name ?? "empty-" + i}
 						i={i}
 						char={c}
 						className="min-[420px]:max-w-[96px] min-[420px]:basis-1/4 basis-[45%]"

--- a/ui/packages/components/src/Cards/DistributionCard/HistogramGraph.tsx
+++ b/ui/packages/components/src/Cards/DistributionCard/HistogramGraph.tsx
@@ -169,6 +169,7 @@ const Graph = ({
 
 						return (
 							<rect
+								// biome-ignore lint/suspicious/noArrayIndexKey: number[] histogram bins, positional
 								key={"bin-" + i}
 								fill={fill}
 								x={barX}

--- a/ui/packages/components/src/Cards/PreviewCard/Graphs/Histogram.tsx
+++ b/ui/packages/components/src/Cards/PreviewCard/Graphs/Histogram.tsx
@@ -81,6 +81,7 @@ export const Graph = ({
 
 						return (
 							<rect
+								// biome-ignore lint/suspicious/noArrayIndexKey: number[] histogram bins, positional
 								key={"bin-" + i}
 								fill={fill}
 								x={barX}

--- a/ui/packages/components/src/Cards/PreviewCard/PreviewCard.tsx
+++ b/ui/packages/components/src/Cards/PreviewCard/PreviewCard.tsx
@@ -23,7 +23,7 @@ export const PreviewCard = ({
 					{data.character_details?.map((c, i) => {
 						return (
 							<AvatarPortrait
-								key={"char-" + i}
+								key={c.name ?? "empty-" + i}
 								i={i}
 								char={c}
 								invalid={

--- a/ui/packages/components/src/common/gcsim/GraphComponents/OuterLabelPie/OuterLabels.tsx
+++ b/ui/packages/components/src/common/gcsim/GraphComponents/OuterLabelPie/OuterLabels.tsx
@@ -66,9 +66,8 @@ export const OuterLabels = <Datum,>({
 			{arcs.map((arc, index) => {
 				const left = midAngle(arc) > Math.PI;
 				return (
-					<Group key={"g-" + index}>
+					<Group key={labelText(arc.data)}>
 						<Group
-							key={"label-" + index}
 							left={labelPositions.get(index)?.x}
 							top={labelPositions.get(index)?.y}
 							onMouseMove={(e) => mouseHover(e, index, arc.data)}
@@ -86,7 +85,6 @@ export const OuterLabels = <Datum,>({
 							</text>
 						</Group>
 						<LinePath<Point>
-							key={"line-" + index}
 							curve={curveBasis}
 							data={linePoints.get(index)}
 							stroke={labelColor(arc.data)}

--- a/ui/packages/components/src/common/gcsim/GraphComponents/OuterLabelPie/index.tsx
+++ b/ui/packages/components/src/common/gcsim/GraphComponents/OuterLabelPie/index.tsx
@@ -91,7 +91,7 @@ export default <Datum,>({
 
 								return (
 									<path
-										key={"hover-arc-" + index}
+										key={labelText?.(arc.data) ?? index}
 										d={pie.path(arc) ?? ""}
 										fill={color(arc.data)}
 										opacity={0.5}
@@ -108,7 +108,7 @@ export default <Datum,>({
 								return (
 									// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 									<path
-										key={"arc-" + index}
+										key={labelText?.(arc.data) ?? index}
 										d={pie.path(arc) ?? ""}
 										fill={color(arc.data)}
 										stroke={outline}

--- a/ui/packages/db/src/SharedComponents/ListView.tsx
+++ b/ui/packages/db/src/SharedComponents/ListView.tsx
@@ -31,11 +31,11 @@ export function ListView({ data }: { data: db.Entry[] }) {
 	return (
 		<>
 			<div className="flex flex-col gap-2 justify-center align-middle items-center ">
-				{data.map((entry, index) => {
+				{data.map((entry) => {
 					return (
 						<DBCard
 							entry={entry}
-							key={index}
+							key={entry._id}
 							className="min-[1300px]:w-[1100px] border-0"
 							footer={
 								<div className="flex flex-row flex-wrap place-content-end mr-2 gap-4">

--- a/ui/packages/docs/src/components/Frames/FramesTable.js
+++ b/ui/packages/docs/src/components/Frames/FramesTable.js
@@ -28,6 +28,7 @@ function Vid({ vid }) {
 function MultiVids({ vids }) {
 	const tabs = vids.map((e, i) => {
 		return (
+			// biome-ignore lint/suspicious/noArrayIndexKey: build-time static JSON
 			<TabItem value={i} label={`Video #${i + 1}`} key={i}>
 				<Vid vid={e} />
 			</TabItem>

--- a/ui/packages/docs/src/components/HomepageFeatures.js
+++ b/ui/packages/docs/src/components/HomepageFeatures.js
@@ -54,8 +54,8 @@ export default function HomepageFeatures() {
 		<section className={styles.features}>
 			<div className="container">
 				<div className="row">
-					{FeatureList.map((props, idx) => (
-						<Feature key={idx} {...props} />
+					{FeatureList.map((props) => (
+						<Feature key={props.title} {...props} />
 					))}
 				</div>
 			</div>

--- a/ui/packages/docs/src/components/Issues/IssuesTable.js
+++ b/ui/packages/docs/src/components/Issues/IssuesTable.js
@@ -20,6 +20,7 @@ export default function IssuesTable({ item_key, data_src }) {
 		return <div>Does not have any known issues</div>;
 	}
 	const rows = data[item_key].map((e, i) => {
+		// biome-ignore lint/suspicious/noArrayIndexKey: build-time static JSON, opaque strings
 		return <li key={i}>{e}</li>;
 	});
 	return (

--- a/ui/packages/docs/src/components/Names/NamesList.js
+++ b/ui/packages/docs/src/components/Names/NamesList.js
@@ -27,6 +27,7 @@ export default function NamesList({ item_key, data_src }) {
 		);
 	}
 	const rows = [item_key, ...data[item_key]].map((e, i) => {
+		// biome-ignore lint/suspicious/noArrayIndexKey: build-time static JSON alias strings
 		return <li key={i}>{e}</li>;
 	});
 	return (

--- a/ui/packages/taghelper/src/App.tsx
+++ b/ui/packages/taghelper/src/App.tsx
@@ -104,11 +104,11 @@ function App({ id }: { id: string }) {
 
 	const rows = data
 		.filter((e) => e["_id"] !== id)
-		.map((e, i) => {
+		.map((e) => {
 			return (
 				<DBCard
 					className="border-0"
-					key={"entry-" + i}
+					key={e._id}
 					entry={e}
 					skipTags={-1}
 					footer={

--- a/ui/packages/ui/src/Components/Cards/CharacterCard.tsx
+++ b/ui/packages/ui/src/Components/Cards/CharacterCard.tsx
@@ -144,7 +144,7 @@ export function CharacterCard({
 		stats = snapshot;
 		statsHeader = <Trans>character.total_stats</Trans>;
 	}
-	stats.forEach((s, i) => {
+	stats.forEach((s) => {
 		const val: JSX.Element[] = [];
 		if (s.flat === 0 && s.percent === 0) {
 			return;
@@ -155,28 +155,28 @@ export function CharacterCard({
 		switch (s.t) {
 			case "both":
 				val.push(
-					<td key={"flat-" + i} className="text-right text-xs">
+					<td key={"flat-" + s.key} className="text-right text-xs">
 						{s.flat.toFixed(0)}
 					</td>,
 				);
 				val.push(
-					<td key={"per-" + i} className="text-right text-xs">
+					<td key={"per-" + s.key} className="text-right text-xs">
 						{(s.percent * 100).toFixed(2) + "%"}
 					</td>,
 				);
 				break;
 			case "f":
 				val.push(
-					<td key={"flat-" + i} className="text-right text-xs">
+					<td key={"flat-" + s.key} className="text-right text-xs">
 						{s.flat.toFixed(0)}
 					</td>,
 				);
-				val.push(<td key={"per-" + i}></td>);
+				val.push(<td key={"per-" + s.key}></td>);
 				break;
 			case "%":
-				val.push(<td key={"flat-" + i}></td>);
+				val.push(<td key={"flat-" + s.key}></td>);
 				val.push(
-					<td key={"per-" + i} className="text-right text-xs">
+					<td key={"per-" + s.key} className="text-right text-xs">
 						{(s.percent * 100).toFixed(2) + "%"}
 					</td>,
 				);

--- a/ui/packages/ui/src/Pages/Dash/Dash.tsx
+++ b/ui/packages/ui/src/Pages/Dash/Dash.tsx
@@ -56,10 +56,10 @@ export function Dash() {
 					</h1>
 					<div>
 						{dataIsLoaded
-							? data.map((e, i) => (
+							? data.map((e) => (
 									<DBCard
 										className="border-0"
-										key={"entry-" + i}
+										key={e._id}
 										entry={e}
 										skipTags={-1}
 										footer={

--- a/ui/packages/ui/src/Pages/Sample/Components/Options.tsx
+++ b/ui/packages/ui/src/Pages/Sample/Components/Options.tsx
@@ -17,9 +17,9 @@ export interface OptionsProp {
 export function Options(props: OptionsProp) {
 	const { t } = useTranslation();
 
-	const cols = props.options.map((o, index) => {
+	const cols = props.options.map((o) => {
 		return (
-			<div className="flex flex-row gap-1 p-1 items-center" key={index}>
+			<div className="flex flex-row gap-1 p-1 items-center" key={o}>
 				<label className="cursor-pointer">
 					<input
 						type="checkbox"

--- a/ui/packages/ui/src/Pages/Sample/Components/SampleView.tsx
+++ b/ui/packages/ui/src/Pages/Sample/Components/SampleView.tsx
@@ -43,12 +43,14 @@ const Row = ({
 	const cols = row.slots.map((slot, ci) => {
 		const events = slot.map((e, ei) => {
 			return (
+				// biome-ignore lint/suspicious/noArrayIndexKey: parsed sample row cells, static once parsed, no unique field
 				<SampleItemView item={e} key={ei} showBuffDuration={showBuffDuration} />
 			);
 		});
 
 		return (
 			<div
+				// biome-ignore lint/suspicious/noArrayIndexKey: fixed positional team slot (0–4)
 				key={ci}
 				className={
 					row.active === ci

--- a/ui/packages/ui/src/Pages/Simulator/Components/Enka/ImportFromEnkaDialog.tsx
+++ b/ui/packages/ui/src/Pages/Simulator/Components/Enka/ImportFromEnkaDialog.tsx
@@ -110,7 +110,11 @@ export function ImportFromEnkaDialog(props: Props) {
 									<CustDiv i18nIsDynamicList>
 										{characters.map((e, i) => {
 											return (
-												<div key={i} className="ml-2">
+												<div
+													// biome-ignore lint/suspicious/noArrayIndexKey: character names may duplicate so index completes the composite; list is set wholesale after import, never reordered
+													key={e.name + "-" + i}
+													className="ml-2"
+												>
 													{e.name}{" "}
 													{e.enka_build_name
 														? "(" + e.enka_build_name + ")"
@@ -127,6 +131,7 @@ export function ImportFromEnkaDialog(props: Props) {
 								Encountered the following issue(s) importing data:
 								{errors.map((e, i) => {
 									return (
+										// biome-ignore lint/suspicious/noArrayIndexKey: string[] error messages, may duplicate, append-only
 										<div key={i} className="ml-2">
 											{e}
 										</div>

--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/CumulativeDamageCard/CumulativeDamage.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/CumulativeDamageCard/CumulativeDamage.tsx
@@ -47,8 +47,8 @@ export const CumulativeLegend = ({ names, glyphs }: LegendProps) => {
 		>
 			{(labels) => (
 				<div className="flex flex-row">
-					{labels.map((label, i) => (
-						<LegendItem key={"legend-" + i}>
+					{labels.map((label) => (
+						<LegendItem key={label.datum}>
 							<div className="my-[2px] mr-[4px]">
 								<svg width={glpyhSize} height={glpyhSize} aria-hidden="true">
 									<rect

--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/CumulativeContribution.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/CumulativeContribution.tsx
@@ -50,8 +50,8 @@ export const CumulativeLegend = ({ names }: LegendProps) => {
 		>
 			{(labels) => (
 				<div className="flex flex-row">
-					{labels.map((label, i) => (
-						<LegendItem key={"legend-" + i}>
+					{labels.map((label) => (
+						<LegendItem key={label.datum}>
 							<div className="my-[2px] mr-[4px]">
 								<svg width={glpyhSize} height={glpyhSize} aria-hidden="true">
 									<rect
@@ -208,6 +208,7 @@ export const CumulativeGraph = ({
 					/>
 					<HoverLine
 						data={data}
+						names={names}
 						xScale={xScale}
 						yScale={yScale}
 						yMax={yMax}

--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/CumulativeTooltip.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/CumulativeTooltip.tsx
@@ -73,6 +73,7 @@ export function useTooltipHandles(
 
 type HoverLineProps = {
 	data: CumulativePoint[];
+	names: string[];
 	xScale: ScaleLinear<number, number>;
 	yScale: ScaleLinear<number, number>;
 	yMax: number;
@@ -95,7 +96,7 @@ export const HoverLine = (props: HoverLineProps) => {
 		total += val.mean ?? 0;
 		const y = props.yScale(total);
 		return (
-			<g key={"circle-" + char}>
+			<g key={props.names[char]}>
 				<circle
 					cx={x}
 					cy={y + 1}

--- a/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/DamageOverTime.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Damage/DamageTimelineCard/DamageOverTime.tsx
@@ -49,8 +49,8 @@ export const DamageOverTimeLegend = ({ names, glyphs }: LegendProps) => {
 		>
 			{(labels) => (
 				<div className="flex flex-row">
-					{labels.map((label, i) => (
-						<LegendItem key={"legend-" + i}>
+					{labels.map((label) => (
+						<LegendItem key={label.datum}>
 							<div className="my-[2px] mr-[4px]">
 								<svg width={glpyhSize} height={glpyhSize} aria-hidden="true">
 									<rect

--- a/ui/packages/ui/src/Pages/Viewer/Components/Overview/DistributionCard/HistogramGraph.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Overview/DistributionCard/HistogramGraph.tsx
@@ -169,6 +169,7 @@ const Graph = ({
 
 						return (
 							<rect
+								// biome-ignore lint/suspicious/noArrayIndexKey: number[] histogram bins, positional
 								key={"bin-" + i}
 								fill={fill}
 								x={barX}

--- a/ui/packages/ui/src/Pages/Viewer/Components/Overview/TargetInfo/PositionGraph.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Overview/TargetInfo/PositionGraph.tsx
@@ -121,7 +121,8 @@ export const PositionGraph = ({
 								: 0.25;
 						return (
 							<Circle
-								key={`enemy-${i}`}
+								// biome-ignore lint/suspicious/noArrayIndexKey: name may be absent/duplicated so index completes the composite; enemy order is stable (built once in Go, never reordered)
+								key={`enemy-${e.name}-${i}`}
 								cx={xScale(e.x)}
 								cy={yScale(e.y)}
 								r={sizeScale(e.r)}
@@ -181,6 +182,7 @@ type Position = {
 	x: number;
 	y: number;
 	r: number;
+	name?: string;
 };
 
 type PositionData = {
@@ -206,7 +208,7 @@ function useData(enemies?: Enemy[], player?: Coord): PositionData {
 			const r = e.position?.r ?? 1;
 			const dist = Math.sqrt((playerX - x) ** 2 + (playerY - y) ** 2);
 			max = Math.max(max, dist + r);
-			return { x: x, y: y, r: r };
+			return { x: x, y: y, r: r, name: e.name };
 		});
 
 		return {

--- a/ui/packages/ui/src/Pages/Viewer/Components/Overview/TargetInfo/index.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Overview/TargetInfo/index.tsx
@@ -34,7 +34,8 @@ const CardData = ({ enemies, player }: Props) => {
 		<div className="flex flex-col-reverse lg:flex-row gap-2 pt-2 h-64">
 			<div className="flex flex-col gap-2 grow basis-2/3 overflow-y-scroll h-full min-w-[250px]">
 				{enemies.map((enemy, i) => (
-					<EnemyCard key={`enemy-${i}`} id={i} enemy={enemy} />
+					// biome-ignore lint/suspicious/noArrayIndexKey: name may be absent/duplicated so index completes the composite; enemy order is stable (built once in Go, never reordered)
+					<EnemyCard key={`enemy-${enemy.name}-${i}`} id={i} enemy={enemy} />
 				))}
 			</div>
 			<div className="flex flex-col grow w-[236px] min-h-[100px] lg:self-auto self-center">

--- a/ui/packages/ui/src/Pages/Viewer/Components/Util/OuterLabelPie/OuterLabels.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Util/OuterLabelPie/OuterLabels.tsx
@@ -66,9 +66,8 @@ export const OuterLabels = <Datum,>({
 			{arcs.map((arc, index) => {
 				const left = midAngle(arc) > Math.PI;
 				return (
-					<Group key={"g-" + index}>
+					<Group key={labelText(arc.data)}>
 						<Group
-							key={"label-" + index}
 							left={labelPositions.get(index)?.x}
 							top={labelPositions.get(index)?.y}
 							onMouseMove={(e) => mouseHover(e, index, arc.data)}
@@ -86,7 +85,6 @@ export const OuterLabels = <Datum,>({
 							</text>
 						</Group>
 						<LinePath<Point>
-							key={"line-" + index}
 							curve={curveBasis}
 							data={linePoints.get(index)}
 							stroke={labelColor(arc.data)}

--- a/ui/packages/ui/src/Pages/Viewer/Components/Util/OuterLabelPie/index.tsx
+++ b/ui/packages/ui/src/Pages/Viewer/Components/Util/OuterLabelPie/index.tsx
@@ -91,7 +91,7 @@ export default <Datum,>({
 
 								return (
 									<path
-										key={"hover-arc-" + index}
+										key={labelText?.(arc.data) ?? index}
 										d={pie.path(arc) ?? ""}
 										fill={color(arc.data)}
 										opacity={0.5}
@@ -108,7 +108,7 @@ export default <Datum,>({
 								return (
 									// biome-ignore lint/a11y/noStaticElementInteractions: mouse-only chart tooltip hover region, no interactive semantics
 									<path
-										key={"arc-" + index}
+										key={labelText?.(arc.data) ?? index}
 										d={pie.path(arc) ?? ""}
 										fill={color(arc.data)}
 										stroke={outline}


### PR DESCRIPTION
## What changed

`biome`'s `suspicious/noArrayIndexKey` was disabled in `ui/biome.jsonc`, and ~39 lists across 26 files keyed React elements by their array index. This gives each flagged list a stable, datum-derived key (or a justified per-line ignore where the index genuinely *is* the identity) and turns the rule back on at its recommended `error` level.

## What a reviewer can now observe

- `pnpm --filter . exec biome lint --only=suspicious/noArrayIndexKey .` reports **zero diagnostics** (was 39 errors with the rule forced on).
- The `noArrayIndexKey: off` override is gone, so any new array-index key now fails `biome check` — regressions are caught going forward.
- Lists that are reconciled by real identity now key by it: entity lists by `_id`/name, chart legends by their label datum, pie labels/arcs by the label-text accessor, character stat rows by the stat key.
- The web / db / taghelper / docs bundles all still build.

## Keys applied

All Section-A keys from the issue are present as specified (`entry._id`, `e._id`, `s.key`, `o`, `props.title`, `label.datum`, `labelText(arc.data)`, `c?.name`/`c.name` fallbacks, enemy/character composites). Section-B lists (positional histogram bins, fixed team slots, build-time static JSON, append-only error strings) each carry a one-line `biome-ignore` reason.

## Deviations from the issue's key list (all necessary to satisfy the rule at `error`)

- **OuterLabelPie `index.tsx` arcs** use `labelText?.(arc.data) ?? index` rather than a bare `labelText(arc.data)`. `labelText` is an *optional* prop and `PreviewCard`'s pie (`CharacterDPSPie`/`ElementDPSPie`) renders the arcs **without** it, so a bare call would throw at runtime. The arc maps are outside the `labelText != null` guard, so the `?? index` fallback is live for that path, not dead code.
- **Enemy / imported-character composite keys** (`` `enemy-${enemy.name}-${i}` ``, `e.name + "-" + i`) were listed under Section A, but the rule flags *any* key that embeds the index — even inside a composite. Because the datum can be absent or duplicated (enemy names repeat), the index is needed to complete the key, so these carry a per-line `biome-ignore` with that rationale. Enemy order is verified stable in the Go backend, so no runtime reorder can regress this.
- **`OuterLabels.tsx`**: only the outer `<Group>` is an array child, so the two static inner elements no longer carry a redundant key (they were index-keyed before and would otherwise all share the same key).
- **`CumulativeTooltip` / `PositionGraph`**: to key by enemy/character identity, a `names` prop is threaded into the local `HoverLine` and a `name?` field through `PositionGraph`'s `useData` — minimal, local wiring, not the OuterLabelPie key-accessor prop the issue put out of scope.

## Not done (out of scope, per the issue)

- a11y rules and `useExhaustiveDependencies` (separate children of #2790).
- No data models were restructured to add ids, and no new key-accessor prop was added to OuterLabelPie.

## Notes

- No unit-test suite exists in the `ui` workspace; verification is `biome` + the package builds above.
- `biome check .` still reports one **pre-existing** formatter error in `packages/db/src/Pages/Database/DBVIew.tsx`, a file not touched here and already failing on `main`.

Closes #2800

🤖 Generated with [Claude Code](https://claude.com/claude-code)
