### PR TITLE
feat(e2e): local Playwright smoke test for the web app

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -14,6 +14,9 @@
 			"!**/build",
 			"!**/.docusaurus",
 			"!**/storybook-static",
+			"!**/test-results",
+			"!**/playwright-report",
+			"!**/blob-report",
 			"!packages/types/src/generated",
 			"!**/wasm_exec.js",
 			"!**/*.dm.*"

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,7 +30,8 @@
 		"build:taghelper": "pnpm --filter @gcsim/taghelper build",
 		"deploy:workers": "pnpm --filter @gcsim/workers deploy",
 		"start:workers": "pnpm --filter @gcsim/workers start",
-		"storybook": "pnpm --filter @gcsim/storybook storybook"
+		"storybook": "pnpm --filter @gcsim/storybook storybook",
+		"test:e2e": "pnpm --filter @gcsim/e2e test"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.13",

--- a/ui/packages/e2e/.gitignore
+++ b/ui/packages/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+blob-report/
+.playwright/

--- a/ui/packages/e2e/README.md
+++ b/ui/packages/e2e/README.md
@@ -1,0 +1,114 @@
+# @gcsim/e2e
+
+Local, Playwright-driven end-to-end smoke test for the gcsim web app. It boots
+the app, waits for wasm + workers to load, validates and runs a config, and
+asserts the viewer renders — catching regressions where the app *builds* but
+breaks at *runtime*.
+
+Two layers:
+
+- **Harness** (`src/`) — an importable, test-runner-agnostic layer that encodes
+  the app's implicit protocol once (page objects + fixtures). This is the seam a
+  future agent-exploration head can build on.
+- **Specs** (`tests/`) — regression specs that consume the harness and assert
+  the critical path.
+
+## Prerequisites
+
+The suite runs against the **dev server**, not a production build: in a prod
+build the wasm URL points at a remote origin (R2 / `/api/wasm/...`) that isn't
+available locally.
+
+The Playwright `webServer` builds the wasm binary and then starts `vite`. The
+wasm build shells out to `task wasm` (`go build` for `GOOS=js`), so you need:
+
+- **Go** and **[Task](https://taskfile.dev)** (`task`) on your `PATH` — the wasm
+  build step.
+- **pnpm** deps installed: from `ui/`, run `pnpm install`.
+- **Playwright's Chromium** browser: from `ui/`, run
+  `pnpm --filter @gcsim/e2e exec playwright install chromium`.
+
+## Run it
+
+From the `ui/` workspace root:
+
+```sh
+pnpm test:e2e
+```
+
+That builds the wasm binary, boots the dev server on a fixed strict port
+(`5173`), runs the suite headless in Chromium, and tears the server down after.
+A running dev server on `5173` is reused (locally) instead of restarted.
+
+Other entry points (from `ui/packages/e2e`):
+
+- `pnpm --filter @gcsim/e2e test:headed` — watch it drive a real browser.
+- `pnpm --filter @gcsim/e2e report` — open the HTML report from the last run.
+
+## On failure
+
+An HTML report is written to `playwright-report/`, and a Playwright **trace**
+(plus screenshot and video) is retained under `test-results/` for any failing
+test. Open the report with `pnpm --filter @gcsim/e2e report`, or a single trace
+with `pnpm --filter @gcsim/e2e exec playwright show-trace <trace.zip>`.
+
+## What the harness helpers do
+
+The app ships **no data-testids**, so every locator rides an observable
+contract (a DOM id, a Blueprint class, or an accessible name).
+
+### `AppHarness` (`src/app-harness.ts`)
+
+Owns the full boot → run → complete flow and bundles the page objects and the
+console monitor.
+
+- `boot()` — open `/simulator`, then wait for wasm + workers ready.
+- `run(cfg)` — set the config, wait for it to validate, click Run, and wait for
+  the run to complete (`run time: N ms` in the console). The signal is matched
+  against the console monitor's **buffer** rather than a fresh `waitForEvent`,
+  because a one-iteration sim can log it before a post-click listener would
+  attach.
+
+### `SimulatorPage` (`src/pages/simulator-page.ts`) — the `/simulator` route
+
+- `goto()` — navigate and wait for React to mount into `#root`.
+- `waitForReady()` — wait for the **Run** button (Blueprint, accessible name
+  "Run") to leave its loading state (`bp4-loading` spinner). That transition is
+  wasm + workers becoming ready (console: `aggregator loaded okay`,
+  `loading N workers`).
+- `setConfig(cfg)` — replace the Ace editor (`#config_editor`) contents by
+  dispatching a native **paste** on its proxy textarea. Typing key-by-key would
+  trip Ace's auto-indent/bracket-matching and corrupt the config.
+- `waitForConfigValid()` — wait for Run to become enabled with no "Invalid
+  Config" callout (console: `all is good`).
+- `run()` — click Run and wait for the app to navigate to `/web`.
+
+### `ViewerPage` (`src/pages/viewer-page.ts`) — the `/web` route
+
+- `waitForViewer()` — assert the page title `gcsim - viewer` and the
+  **Results / Config / Sample** tab strip.
+- `waitForResults()` — assert the Results tab rendered at least one card
+  (`bp4-card`) and one inline `<svg>` chart. **Structural only** — never asserts
+  DPS or any numeric result.
+
+### `ConsoleMonitor` (`src/console-monitor.ts`)
+
+Watches the page console for its whole lifetime. It collects uncaught
+`console.error` / `pageerror` — `assertNoErrors()` fails the test if any
+un-ignored error was seen across the flow — and buffers every message so
+`waitForLog(re)` can match a signal even if it already fired. A short, justified
+ignore-list filters known dev-mode noise: React StrictMode `Warning:`s (dev-only,
+absent from prod builds — a real crash is a `pageerror` or a non-`Warning:`
+error, which is **not** masked), a pre-existing visx negative-radius chart quirk,
+and a Vite HMR websocket blip on teardown.
+
+### Config fixture
+
+`fixtures/sucrose.txt` is the known-good, minimal Sucrose config
+(`iteration=1`), re-exported as `sucroseConfig` from `src/config.ts`.
+
+## Out of scope
+
+CI integration, the production/preview (R2 wasm) path, server mode, share/db/
+local viewer routes, Enka/GOOD import, engine-correctness or numeric assertions,
+and non-Chromium browsers. See issue #2805.

--- a/ui/packages/e2e/fixtures/sucrose.txt
+++ b/ui/packages/e2e/fixtures/sucrose.txt
@@ -1,0 +1,12 @@
+sucrose char lvl=90/90 cons=6 talent=9,9,9;
+sucrose add weapon="sacfragments" refine=3 lvl=90/90;
+sucrose add set="viridescentvenerer" count=4;
+sucrose add stats hp=4780 atk=311 em=187 em=187 em=187 ; #main
+
+options swap_delay=12 iteration=1;
+
+active sucrose;
+
+target lvl=100 resist=0.1 radius=2 pos=0,2.4 hp=999999999;
+
+sucrose burst, skill, attack;

--- a/ui/packages/e2e/package.json
+++ b/ui/packages/e2e/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@gcsim/e2e",
+	"private": true,
+	"type": "module",
+	"main": "src/index.ts",
+	"scripts": {
+		"test": "playwright test",
+		"test:headed": "playwright test --headed",
+		"report": "playwright show-report"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.63.0",
+		"@types/node": "^20.11.0"
+	}
+}

--- a/ui/packages/e2e/playwright.config.ts
+++ b/ui/packages/e2e/playwright.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 5173;
+const HOST = `http://localhost:${PORT}`;
+
+/**
+ * Chromium-only e2e config. Runs against the *dev server* (build wasm, then
+ * `vite`), because a production build points the wasm URL at a remote origin
+ * (R2 / `/api/wasm/...`) that is not available locally.
+ *
+ * The `webServer` builds the wasm binary first (needs Go + `task` on PATH — see
+ * README) and then serves the app on a fixed, strict port so the harness knows
+ * where to connect.
+ */
+export default defineConfig({
+	testDir: "./tests",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: 1,
+	// wasm boot + a sim run comfortably exceed Playwright's 30s default.
+	timeout: 120_000,
+	expect: { timeout: 15_000 },
+	reporter: [["html", { open: "never" }], ["list"]],
+	use: {
+		baseURL: HOST,
+		trace: "retain-on-failure",
+		screenshot: "only-on-failure",
+		video: "retain-on-failure",
+	},
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+	webServer: {
+		command:
+			"pnpm --filter @gcsim/executors build:wasm:web && pnpm --filter @gcsim/web dev -- --port 5173 --strictPort",
+		url: HOST,
+		reuseExistingServer: !process.env.CI,
+		// wasm build (go build) plus the dev server's first compile can be slow.
+		timeout: 240_000,
+		stdout: "pipe",
+		stderr: "pipe",
+	},
+});

--- a/ui/packages/e2e/src/app-harness.ts
+++ b/ui/packages/e2e/src/app-harness.ts
@@ -1,0 +1,47 @@
+import type { Page } from "@playwright/test";
+import { ConsoleMonitor } from "./console-monitor";
+import { SimulatorPage } from "./pages/simulator-page";
+import { ViewerPage } from "./pages/viewer-page";
+
+/**
+ * The reusable browser-driving harness for the gcsim web app.
+ *
+ * It encodes the app's implicit protocol once — boot, wait for wasm+workers,
+ * load a config, run a sim, open the viewer — as a standalone importable layer.
+ * The regression specs consume it; a future agent-exploration head can too.
+ */
+export class AppHarness {
+	readonly page: Page;
+	readonly simulator: SimulatorPage;
+	readonly viewer: ViewerPage;
+	readonly console: ConsoleMonitor;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.simulator = new SimulatorPage(page);
+		this.viewer = new ViewerPage(page);
+		this.console = new ConsoleMonitor(page);
+	}
+
+	/** Open the simulator and wait for wasm + workers to be ready. */
+	async boot(): Promise<void> {
+		await this.simulator.goto();
+		await this.simulator.waitForReady();
+	}
+
+	/**
+	 * Run `cfg` and wait for the run to complete.
+	 *
+	 * Completion is the `run time: N ms` console signal. It is matched against
+	 * the {@link ConsoleMonitor} buffer rather than a fresh `waitForEvent`,
+	 * because a one-iteration sim can log it before a post-click listener would
+	 * attach.
+	 */
+	async run(cfg: string): Promise<void> {
+		await this.simulator.setConfig(cfg);
+		await this.simulator.waitForConfigValid();
+		await this.simulator.run();
+		// Anchored so a cancel ("cancelled with run time: N ms") can't satisfy it.
+		await this.console.waitForLog(/^run time: \d+(\.\d+)? ms$/);
+	}
+}

--- a/ui/packages/e2e/src/config.ts
+++ b/ui/packages/e2e/src/config.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The known-good, minimal Sucrose config used by the smoke spec.
+ *
+ * It is committed as a plain-text fixture (fixtures/sucrose.txt) so it reads
+ * exactly like a config a user would paste. `iteration=1` keeps the run fast —
+ * the spec asserts structure, never specific numbers.
+ */
+export const sucroseConfig: string = readFileSync(
+	fileURLToPath(new URL("../fixtures/sucrose.txt", import.meta.url)),
+	"utf8",
+);

--- a/ui/packages/e2e/src/console-monitor.ts
+++ b/ui/packages/e2e/src/console-monitor.ts
@@ -1,0 +1,111 @@
+import { expect, type Page } from "@playwright/test";
+
+// Messages that are environmental noise rather than real app faults. Keep this
+// list short and justified — every entry weakens the "zero console errors"
+// guarantee. Match against the full console/error text.
+const IGNORED: RegExp[] = [
+	// Vite dev server injects a websocket HMR client; a transient connection
+	// blip during teardown is not an app fault.
+	/\[vite\] failed to connect to websocket/i,
+	// React routes its dev-only warnings through console.error, prefixed
+	// "Warning:". Under StrictMode the app + its third-party libs (react-helmet,
+	// react-transition-group, blueprint) emit a fixed set — legacy lifecycles,
+	// findDOMNode, the language <select>'s `selected` option. These are
+	// pre-existing and dev-only (absent from a production build); a real crash
+	// surfaces as a `pageerror` or a non-"Warning:" console.error, which this
+	// does NOT mask.
+	/^Warning: /,
+	// visx draws a couple of markers with a computed negative radius on this
+	// fixture (e.g. a zero-variance distribution), so the browser rejects
+	// `<circle r="-2">`. Pre-existing chart quirk, unrelated to the boot/run/
+	// render path this smoke test guards.
+	/<circle> attribute r: A negative value/,
+];
+
+function isIgnored(text: string): boolean {
+	return IGNORED.some((re) => re.test(text));
+}
+
+type Waiter = (text: string) => void;
+
+/**
+ * Watches a page's console for the lifetime of the page.
+ *
+ * Two jobs:
+ *  - collect uncaught `console.error` / `pageerror` so the smoke spec can assert
+ *    the critical path ran clean;
+ *  - buffer every console message so {@link waitForLog} can match a signal even
+ *    if it already fired. A one-iteration sim finishes in well under a second,
+ *    so a post-hoc `page.waitForEvent` would race the message it waits for.
+ */
+export class ConsoleMonitor {
+	readonly errors: string[] = [];
+	private readonly logs: string[] = [];
+	private readonly waiters = new Set<Waiter>();
+
+	constructor(page: Page) {
+		page.on("console", (msg) => {
+			const text = msg.text();
+			this.record(text);
+			if (msg.type() === "error" && !isIgnored(text)) {
+				this.errors.push(`console.error: ${text}`);
+			}
+		});
+		page.on("pageerror", (err) => {
+			const text = err.stack ?? err.message;
+			this.record(text);
+			if (!isIgnored(text)) {
+				this.errors.push(`pageerror: ${text}`);
+			}
+		});
+	}
+
+	private record(text: string): void {
+		this.logs.push(text);
+		for (const waiter of this.waiters) {
+			waiter(text);
+		}
+	}
+
+	/**
+	 * Resolve once a console message matching `re` has been seen — checking the
+	 * buffer first, so an already-fired message counts. Rejects on timeout with
+	 * the recent buffer attached for diagnosis.
+	 */
+	waitForLog(re: RegExp, timeout = 60_000): Promise<string> {
+		const existing = this.logs.find((text) => re.test(text));
+		if (existing !== undefined) {
+			return Promise.resolve(existing);
+		}
+		return new Promise((resolve, reject) => {
+			const waiter: Waiter = (text) => {
+				if (re.test(text)) {
+					cleanup();
+					resolve(text);
+				}
+			};
+			const timer = setTimeout(() => {
+				cleanup();
+				const tail = this.logs.slice(-20).join("\n");
+				reject(
+					new Error(
+						`timed out after ${timeout}ms waiting for console log matching ${re}.\nrecent console:\n${tail}`,
+					),
+				);
+			}, timeout);
+			const cleanup = () => {
+				clearTimeout(timer);
+				this.waiters.delete(waiter);
+			};
+			this.waiters.add(waiter);
+		});
+	}
+
+	/** Fails the test if any un-ignored console/page error was seen so far. */
+	assertNoErrors(): void {
+		expect(
+			this.errors,
+			`expected no uncaught console errors, saw:\n${this.errors.join("\n")}`,
+		).toEqual([]);
+	}
+}

--- a/ui/packages/e2e/src/fixtures.ts
+++ b/ui/packages/e2e/src/fixtures.ts
@@ -1,0 +1,15 @@
+import { test as base } from "@playwright/test";
+import { AppHarness } from "./app-harness";
+
+/**
+ * Playwright test extended with an `app` fixture — a fresh {@link AppHarness}
+ * bound to the test's page. Specs use `test`/`expect` from here instead of
+ * `@playwright/test` directly.
+ */
+export const test = base.extend<{ app: AppHarness }>({
+	app: async ({ page }, use) => {
+		await use(new AppHarness(page));
+	},
+});
+
+export { expect } from "@playwright/test";

--- a/ui/packages/e2e/src/index.ts
+++ b/ui/packages/e2e/src/index.ts
@@ -1,0 +1,6 @@
+export { AppHarness } from "./app-harness";
+export { sucroseConfig } from "./config";
+export { ConsoleMonitor } from "./console-monitor";
+export { expect, test } from "./fixtures";
+export { SimulatorPage } from "./pages/simulator-page";
+export { ViewerPage } from "./pages/viewer-page";

--- a/ui/packages/e2e/src/pages/simulator-page.ts
+++ b/ui/packages/e2e/src/pages/simulator-page.ts
@@ -1,0 +1,84 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Drives the `/simulator` route: the config editor and the Run button.
+ *
+ * This encodes the app's implicit boot protocol once. The app ships no
+ * data-testids, so every locator here rides an observable contract (a DOM id,
+ * a Blueprint class, or the button's accessible name) documented in the README.
+ */
+export class SimulatorPage {
+	readonly page: Page;
+	/** Blueprint button, accessible name "Run". */
+	readonly runButton: Locator;
+	/** Ace editor container (`#config_editor`) holding the config text. */
+	readonly editor: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.runButton = page.getByRole("button", { name: "Run" });
+		this.editor = page.locator("#config_editor");
+	}
+
+	/** Navigate to the simulator and wait for React to mount into `#root`. */
+	async goto(): Promise<void> {
+		await this.page.goto("/simulator");
+		await expect(this.page.locator("#root")).not.toBeEmpty();
+		await expect(this.editor).toBeVisible();
+	}
+
+	/**
+	 * Wait for wasm + workers to finish loading. While loading, the Blueprint
+	 * Run button carries `bp4-loading` (a spinner); readiness is that class
+	 * leaving. Console emits "aggregator loaded okay" / "loading N workers"
+	 * during this window.
+	 */
+	async waitForReady(): Promise<void> {
+		await expect(this.runButton).not.toHaveClass(/bp4-loading/, {
+			timeout: 60_000,
+		});
+	}
+
+	/**
+	 * Replace the editor contents with `cfg`. Dispatches a native paste event on
+	 * Ace's proxy textarea rather than typing key-by-key — typing would trip
+	 * Ace's auto-indent and bracket matching and corrupt the config.
+	 */
+	async setConfig(cfg: string): Promise<void> {
+		const textarea = this.editor.locator("textarea.ace_text-input");
+		await textarea.focus();
+		await this.page.evaluate((text) => {
+			const ta = document.querySelector<HTMLTextAreaElement>(
+				"#config_editor textarea.ace_text-input",
+			);
+			if (ta == null) {
+				throw new Error("config editor textarea not found");
+			}
+			ta.focus();
+			const data = new DataTransfer();
+			data.setData("text/plain", text);
+			ta.dispatchEvent(
+				new ClipboardEvent("paste", {
+					clipboardData: data,
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+		}, cfg);
+	}
+
+	/**
+	 * Wait for the config to validate: the Run button becomes enabled and no
+	 * "Invalid Config" error callout is present. Validation logs "all is good".
+	 */
+	async waitForConfigValid(): Promise<void> {
+		await expect(this.runButton).toBeEnabled({ timeout: 30_000 });
+		await expect(this.page.getByText("Invalid Config")).toHaveCount(0);
+	}
+
+	/** Click Run. Navigates the app to `/web`. */
+	async run(): Promise<void> {
+		await this.runButton.click();
+		await this.page.waitForURL(/\/web$/);
+	}
+}

--- a/ui/packages/e2e/src/pages/viewer-page.ts
+++ b/ui/packages/e2e/src/pages/viewer-page.ts
@@ -1,0 +1,44 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Drives the `/web` viewer route: the tab strip and the Results tab content.
+ *
+ * Locators ride observable contracts (page title, tab accessible names,
+ * Blueprint `bp4-card`, inline `<svg>`) since the app ships no data-testids.
+ */
+export class ViewerPage {
+	readonly page: Page;
+	readonly resultsTab: Locator;
+	readonly configTab: Locator;
+	readonly sampleTab: Locator;
+	/** Blueprint cards on the Results tab. */
+	readonly cards: Locator;
+	/** Inline visx charts on the Results tab. */
+	readonly charts: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.resultsTab = page.getByRole("tab", { name: "Results" });
+		this.configTab = page.getByRole("tab", { name: "Config" });
+		this.sampleTab = page.getByRole("tab", { name: "Sample" });
+		this.cards = page.locator(".bp4-card");
+		this.charts = page.locator(".bp4-card svg");
+	}
+
+	/** Assert the viewer chrome rendered: title and the three-tab strip. */
+	async waitForViewer(): Promise<void> {
+		await expect(this.page).toHaveTitle("gcsim - viewer");
+		await expect(this.resultsTab).toBeVisible();
+		await expect(this.configTab).toBeVisible();
+		await expect(this.sampleTab).toBeVisible();
+	}
+
+	/**
+	 * Assert the Results tab rendered the sim output: at least one card and at
+	 * least one inline chart. Structural only — never asserts result numbers.
+	 */
+	async waitForResults(): Promise<void> {
+		await expect(this.cards.first()).toBeVisible({ timeout: 30_000 });
+		await expect(this.charts.first()).toBeVisible({ timeout: 30_000 });
+	}
+}

--- a/ui/packages/e2e/tests/smoke.spec.ts
+++ b/ui/packages/e2e/tests/smoke.spec.ts
@@ -1,0 +1,20 @@
+import { sucroseConfig, test } from "../src";
+
+test.describe("smoke", () => {
+	test("boots, runs a sim, and renders the viewer", async ({ app }) => {
+		// App mounts and wasm + workers become ready (Run leaves its spinner).
+		await app.boot();
+
+		// The provided config validates (Run enables) and the sim runs to
+		// completion, navigating to the viewer.
+		await app.run(sucroseConfig);
+
+		// The viewer renders: title, tab strip, and the Results tab's cards +
+		// inline charts. Structural only — no numeric result assertions.
+		await app.viewer.waitForViewer();
+		await app.viewer.waitForResults();
+
+		// Nothing threw or logged an error across the whole path.
+		app.console.assertNoErrors();
+	});
+});

--- a/ui/packages/e2e/tsconfig.json
+++ b/ui/packages/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"types": ["node"],
+		"composite": false,
+		"declaration": false,
+		"incremental": false,
+		"noEmit": true
+	},
+	"include": ["src", "tests", "playwright.config.ts"]
+}

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -350,6 +350,15 @@ importers:
         specifier: ^5.4.1
         version: 5.7.0
 
+  packages/e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.63.0
+        version: 1.63.0
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.43
+
   packages/embed:
     dependencies:
       '@gcsim/components':
@@ -3473,6 +3482,11 @@ packages:
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
     engines: {node: '>=20.0.0'}
 
+  '@playwright/test@1.63.0':
+    resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
@@ -4393,6 +4407,9 @@ packages:
 
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@22.20.2':
     resolution: {integrity: sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==}
@@ -7689,6 +7706,16 @@ packages:
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
+
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -13185,6 +13212,10 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
+  '@playwright/test@1.63.0':
+    dependencies:
+      playwright: 1.63.0
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -14012,6 +14043,10 @@ snapshots:
 
   '@types/node@17.0.45': {}
 
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.20.2':
     dependencies:
       undici-types: 6.21.0
@@ -14078,7 +14113,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.20.2
 
   '@types/send@0.17.6':
     dependencies:
@@ -18023,6 +18058,12 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.2.0
       tslib: 2.8.1
+
+  playwright-core@1.63.0: {}
+
+  playwright@1.63.0:
+    dependencies:
+      playwright-core: 1.63.0
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
A locally-runnable Playwright smoke test that fails when the app is genuinely broken at runtime (wasm not loading, workers not initializing, a sim not completing, the viewer not rendering) — the class of regression nothing in the repo currently catches.

## New

- **`ui/packages/e2e` workspace package**, split into a reusable harness (`src/`) and regression specs (`tests/`).
- **`pnpm test:e2e`** (root command): builds the wasm binary, boots the dev server (`vite --host`) on a fixed strict port, runs the suite headless in Chromium, and tears the server down after.
- **Smoke spec** asserting the full critical path through the harness:
  - app mounts into `#root`;
  - the Run button leaves its loading state (wasm + workers ready);
  - the provided config validates and enables Run;
  - clicking Run navigates to `/web` and the run completes (`run time: N ms`);
  - the Results tab renders cards and inline `<svg>` charts;
  - **zero uncaught console errors** across the flow (structural assertions only — no DPS/numeric checks).
- **Harness** (importable, test-runner-agnostic — the seam a future agent-exploration head can build on): `AppHarness`, `SimulatorPage`, `ViewerPage`, and a `ConsoleMonitor` that both collects errors and buffers logs so a sub-second completion signal isn't raced.
- **Config fixture** `fixtures/sucrose.txt` (known-good, `iteration=1`).
- **Failure artifacts**: HTML report plus trace/screenshot/video retained on failure.
- **README** documenting how to run it locally and what each harness helper does.

## Changed

- Root `biome.jsonc` ignores Playwright output dirs (`test-results`, `playwright-report`, `blob-report`).

## Notes on acceptance criteria

- **wasm build**: wired into the Playwright `webServer` command, and also documented as a prerequisite in the package README (needs Go + `task` on `PATH`) — CI integration is explicitly out of scope.
- **"Zero uncaught console errors"** is enforced against a short, narrowly-scoped ignore list of pre-existing dev-mode noise the app emits on this path regardless of any change: React StrictMode `Warning:`s (dev-only, from react-helmet/blueprint/react-transition-group) and a visx negative-radius `<circle>` quirk on this fixture. A real crash surfaces as a `pageerror` or a non-`Warning:` error and is **not** masked. Each entry is justified in `console-monitor.ts` and the README.

Closes #2805

🤖 Generated with [Claude Code](https://claude.com/claude-code)
