### PR TITLE
fix(ui): format DBView img to satisfy biome formatter

### DIFF
--- a/ui/packages/db/src/Pages/Database/DBVIew.tsx
+++ b/ui/packages/db/src/Pages/Database/DBVIew.tsx
@@ -25,7 +25,11 @@ export const DBView = (props: Props) => {
 			/>
 			{props.data.length === 0 ? (
 				<div className="6 flex flex-col justify-center items-center h-screen">
-					<img src={eula} alt="" className=" object-contain opacity-50 w-32 h-32" />
+					<img
+						src={eula}
+						alt=""
+						className=" object-contain opacity-50 w-32 h-32"
+					/>
 				</div>
 			) : (
 				<InfiniteScroll


### PR DESCRIPTION
## What

Wrap the empty-state `<img>` attributes in `ui/packages/db/src/Pages/Database/DBVIew.tsx` across multiple lines so the file matches Biome's formatter output.

## Why

The `useAltText` a11y fix (#2806, a child of the #2790 tracker) added `alt=""` to this `<img>`, pushing the tag past Biome's print width. That PR was linted but never `biome format`-ed, so `biome check` started failing with a single lone formatter error — the last thing standing between the #2790 tracker and a clean `biome check`. `biome check` isn't gating CI yet (a documented out-of-scope follow-up on #2790), which is how it slipped through.

## Verification

Before: `biome check` → `Found 1 error. Found 102 warnings. Found 267 infos.`
After: `biome check` → `Found 102 warnings. Found 267 infos.` (0 errors)

The remaining warnings/infos are all out of scope for #2790 (recommended rules at warn/info: `useTemplate`, `useLiteralKeys`, `noExplicitAny`, etc.).

This is the final cleanup for the Biome ruleset tracker; all eight children are already closed.

Closes #2790

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBPRxpNocSiahfCuHCUut2