### PR TITLE
feat(workers): serve SPA via Static Assets binding + env.staging

### DIFF
--- a/ui/packages/web/public/.assetsignore
+++ b/ui/packages/web/public/.assetsignore
@@ -1,0 +1,1 @@
+main.wasm

--- a/ui/packages/workers/src/bindings.d.ts
+++ b/ui/packages/workers/src/bindings.d.ts
@@ -1,5 +1,6 @@
 export interface Env {
 	API_ENDPOINT: string;
 	ASSETS_ENDPOINT: string;
+	ASSETS: Fetcher; //static-assets binding serving the SPA (../web/dist)
 	GCSIM_WASM: R2Bucket; //bucket
 }

--- a/ui/packages/workers/src/index.ts
+++ b/ui/packages/workers/src/index.ts
@@ -36,6 +36,11 @@ router.get("/db/:key", handleInjectHeadDB);
 router.get("/api/assets/*", handleAssets);
 router.get("/api/wasm/*", handleWasm);
 
+// SPA fallthrough: anything not matched above is served from the static-assets
+// binding. `not_found_handling: "single-page-application"` makes deep links
+// resolve to index.html. Kept explicit so the routing intent lives in code too.
+router.all("*", (request: Request, env: Env) => env.ASSETS.fetch(request));
+
 export default {
 	async fetch(
 		request: Request,

--- a/ui/packages/workers/wrangler.jsonc
+++ b/ui/packages/workers/wrangler.jsonc
@@ -2,6 +2,12 @@
 	"name": "gcsim-gateway",
 	"main": "src/index.ts",
 	"compatibility_date": "2026-09-12",
+	"assets": {
+		"directory": "../web/dist",
+		"binding": "ASSETS",
+		"run_worker_first": true,
+		"not_found_handling": "single-page-application"
+	},
 	"r2_buckets": [
 		{
 			"binding": "GCSIM_WASM",

--- a/ui/packages/workers/wrangler.jsonc
+++ b/ui/packages/workers/wrangler.jsonc
@@ -13,5 +13,24 @@
 			"binding": "GCSIM_WASM",
 			"bucket_name": "wasm"
 		}
-	]
+	],
+	"env": {
+		"staging": {
+			"workers_dev": true,
+			// Bindings are not inherited across wrangler environments, so the
+			// assets binding and r2 buckets must be redeclared here verbatim.
+			"assets": {
+				"directory": "../web/dist",
+				"binding": "ASSETS",
+				"run_worker_first": true,
+				"not_found_handling": "single-page-application"
+			},
+			"r2_buckets": [
+				{
+					"binding": "GCSIM_WASM",
+					"bucket_name": "wasm"
+				}
+			]
+		}
+	}
 }


### PR DESCRIPTION
Absorbs the static site into the consolidated Worker: it now serves the SPA via a Static Assets binding, so the Pages project is no longer needed to serve HTML/JS/CSS. Adds a committed `env.staging` target for throwaway `*.workers.dev` testing. No production change.

## New

- SPA served by the consolidated Worker via a Static Assets binding (`ASSETS`, `../web/dist`, `run_worker_first`, `not_found_handling: "single-page-application"`); deep links resolve to `index.html`.
- Terminal `router.all('*', (req, env) => env.ASSETS.fetch(req))` fallthrough, so SPA routing intent is visible in code as well as config.
- Committed `env.staging` environment (`workers_dev: true`) with `assets` and `r2_buckets` redeclared (bindings are non-inheritable across wrangler environments).
- `web/public/.assetsignore` excluding the dev-only 57 MiB `main.wasm`, so a local `build:wasm` doesn't push it past the 25 MiB static-asset limit. Not in the acceptance criteria, but the criteria's own R2/25 MiB rationale requires wasm to stay off static assets; without this a developer's local `wrangler deploy`/`dev` fails with "Asset too large".

## Verification (no CF account)

- `pnpm build:web` then `wrangler deploy --dry-run -e staging` bundles SPA + router clean.
- `wrangler dev -e staging`: deep link `/viewer/abc` → 200 `index.html`; `/api/wasm/...` → 404 from the worker (local R2 miss, route resolves); gateway routes reach their handlers (`/sh`, `/api/*` block only on the unset per-env endpoint secrets, as expected locally).
- Typecheck and Biome pass.

Endpoint config (`API_ENDPOINT`, `ASSETS_ENDPOINT`) stays as per-environment `wrangler secret`s, not committed `vars` — set manually with `-e staging`.

## Not done

- The acceptance criteria asked for domain docs (a `CONTEXT.md` glossary entry and an ADR). Both intentionally omitted at maintainer request — the terminology isn't settled yet.

Closes #2818

🤖 Generated with [Claude Code](https://claude.com/claude-code)
