### PR TITLE
fix(workers): inject head into SPA index via ASSETS binding

### DIFF
--- a/ui/packages/workers/src/preview/handleInjectHead.ts
+++ b/ui/packages/workers/src/preview/handleInjectHead.ts
@@ -1,4 +1,5 @@
 import type { IRequest } from "itty-router";
+import type { Env } from "../bindings";
 
 class ElementHandler {
 	private key;
@@ -64,8 +65,14 @@ class ElementHandler {
 	}
 }
 
-export async function handleInjectHead(request: IRequest): Promise<Response> {
-	const res = await fetch(request);
+export async function handleInjectHead(
+	request: IRequest,
+	env: Env,
+): Promise<Response> {
+	// Fetch the base HTML through the ASSETS binding (not a global fetch): with
+	// `run_worker_first: true` a global fetch(request) re-enters the Worker and
+	// yields a 404, so the head would be injected into the not-found page.
+	const res = await env.ASSETS.fetch(request);
 	const url = new URL(request.url);
 	const segments = url.pathname.split("/");
 	const key = segments.pop() || segments.pop();
@@ -77,8 +84,13 @@ export async function handleInjectHead(request: IRequest): Promise<Response> {
 		.transform(res);
 }
 
-export async function handleInjectHeadDB(request: IRequest): Promise<Response> {
-	const res = await fetch(request);
+export async function handleInjectHeadDB(
+	request: IRequest,
+	env: Env,
+): Promise<Response> {
+	// See handleInjectHead: fetch the base HTML via the ASSETS binding so the
+	// SPA index.html is rewritten, not the Worker's own 404 page.
+	const res = await env.ASSETS.fetch(request);
 	const url = new URL(request.url);
 	const segments = url.pathname.split("/");
 	const key = segments.pop() || segments.pop();


### PR DESCRIPTION
## Changed

- `/sh/:key` and `/db/:key` on the consolidated gateway Worker now serve the SPA `index.html` (with preview head injected) instead of a `404 "Page not found"`.
- The head-inject handlers fetch their base HTML through the `ASSETS` binding (`env.ASSETS.fetch(request)`) rather than a global `fetch(request)`. Under `run_worker_first: true` the global fetch re-entered the Worker and returned its own 404, so `HTMLRewriter` was injecting the og/head into the not-found page.

Injected `og:*` / `twitter:card` meta tags are unchanged — only the base document and status code are fixed.

Closes #2824

**Acceptance not covered here:** the ticket asks to re-run the #2819 staging smoke test afterwards. That requires deploying to `gcsim-gateway-staging` and can't be done from the checkout — please re-run it after this merges/deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
