### PR TITLE
chore(ci): rewire deploy.yml for the consolidated Worker

### DIFF
--- a/.github/actions/deploy-ui/action.yml
+++ b/.github/actions/deploy-ui/action.yml
@@ -1,15 +1,6 @@
-name: "Deploy UI"
-description: "builds and deploys the gcsim UI to cloudflare. Assumes pnpm setup has already ran"
+name: "Build UI"
+description: "builds the gcsim UI into ui/packages/web/dist for the consolidated Worker to upload as assets. Assumes pnpm setup has already ran"
 inputs:
-  apiToken:
-    required: true
-    description: cloudflare api token
-  accountId:
-    required: true
-    description: cloudflare account id
-  gitHubToken:
-    required: true
-    description: github token
   branch:
     required: true
     description: name of the branch
@@ -28,13 +19,3 @@ runs:
     working-directory: ./ui/packages/web/dist
     shell: bash
     run: ls -lh
-  
-  - name: Publish to Cloudflare Pages
-    uses: cloudflare/pages-action@1
-    with:
-      apiToken: ${{ inputs.apiToken }}
-      accountId: ${{ inputs.accountId }}
-      gitHubToken: ${{ inputs.gitHubToken }}
-      projectName: gcsim
-      branch: ${{ inputs.branch }}
-      directory: ./ui/packages/web/dist

--- a/.github/actions/deploy-workers/action.yml
+++ b/.github/actions/deploy-workers/action.yml
@@ -11,8 +11,8 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Publish to Cloudflare Pages
-    uses: cloudflare/wrangler-action@v3
+  - name: Deploy to Cloudflare Workers
+    uses: cloudflare/wrangler-action@v4
     with:
       apiToken: ${{ inputs.apiToken }}
       accountId: ${{ inputs.accountId }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,7 @@ jobs:
         uses: ./.github/actions/deploy-workers
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
 
       - name: deploy-db
         uses: ./.github/actions/deploy-db

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,10 +33,6 @@ jobs:
         uses: ./.github/actions/yarn-setup-and-test
 
       # deploy
-      - name: deploy-workers
-        uses: ./.github/actions/deploy-workers
-        with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
 
       # wasm first because it takes the longest
       - name: deploy-wasm
@@ -46,14 +42,18 @@ jobs:
           branch: ${{ steps.branch-name.outputs.base_ref_branch }}
           shareKey: ${{ secrets.AES_KEY }}
 
+      # build the UI before deploying the Worker: the consolidated Worker
+      # uploads ui/packages/web/dist as its static assets
       - name: deploy-ui
         uses: ./.github/actions/deploy-ui
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           # name needs to be "main" if on mainline
           branch: ${{ steps.branch-name.outputs.base_ref_branch == 'mainline' && 'main' || steps.branch-name.outputs.base_ref_branch }}
+
+      - name: deploy-workers
+        uses: ./.github/actions/deploy-workers
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
 
       - name: deploy-db
         uses: ./.github/actions/deploy-db


### PR DESCRIPTION
Rewire the `v*`-tag release pipeline (`deploy.yml`) to publish the UI through the consolidated `gcsim-gateway` Worker instead of the old Pages project.

## Changed
- The UI now builds **before** the Worker deploys, so `ui/packages/web/dist` exists for the Worker to upload as its static assets (wrangler reads `main`/`assets`/`r2_buckets` from `wrangler.jsonc` itself).
- `deploy-ui` no longer publishes to Cloudflare Pages — it only builds the UI. The now-unused `apiToken`/`accountId`/`gitHubToken` inputs are gone; only `branch` remains.
- `deploy-workers` uses `cloudflare/wrangler-action@v4` (was `@v3`) and its step is named accurately ("Deploy to Cloudflare Workers").
- The `deploy-workers` step now passes `accountId: secrets.CF_ACCOUNT_ID`. `wrangler deploy` needs an account id, and neither `wrangler.jsonc` nor the step supplied one — it would fail with "No account id found". Now matches the other deploy steps.

## Removed
- The `cloudflare/pages-action@1` publish step.

## Not done / notes
- **Acceptance criterion "reviewed against the release pipeline (dry-run / `workflow_dispatch`)":** left for a human — the workflow only runs on `v*` tags (or `workflow_dispatch`) and needs the Cloudflare release secrets, so it can't be exercised from this PR. Please dry-run before merge.
- `deploy-wasm` and all backend/binary release steps are untouched.

Closes #2820

🤖 Generated with [Claude Code](https://claude.com/claude-code)
