### PR TITLE
feat(workers): render Satori preview card to PNG via og-preview route

### DIFF
--- a/ui/packages/components/src/Cards/SatoriPreviewCard/fonts.ts
+++ b/ui/packages/components/src/Cards/SatoriPreviewCard/fonts.ts
@@ -18,31 +18,16 @@ export const FONT_FAMILY = "DejaVu Sans Mono, monospace";
 export const FONT_NAME = "DejaVu Sans Mono";
 
 // Shape of a single Satori font entry (kept local so this package needs no
-// satori dependency).
+// satori dependency). `data` is typed `ArrayBuffer | Uint8Array` (not the Node
+// `Buffer` global) so this module needs no `@types/node`; a Node `Buffer` still
+// satisfies `Uint8Array`.
 export type SatoriFont = {
 	name: string;
-	data: ArrayBuffer | Buffer;
+	data: ArrayBuffer | Uint8Array;
 	weight: 400 | 700;
 	style: "normal";
 };
 
-// URLs of the bundled TTF files, resolved relative to this module.
-export const monoFontUrls = {
-	regular: new URL("./fonts/DejaVuSansMono-Regular.ttf", import.meta.url),
-	bold: new URL("./fonts/DejaVuSansMono-Bold.ttf", import.meta.url),
-};
-
-// Node helper: read the bundled TTFs and return them as Satori font entries.
-// `node:fs` is imported dynamically so this module stays safe to bundle for the
-// browser (Storybook renders the card without calling this).
-export async function loadCardFonts(): Promise<SatoriFont[]> {
-	const { readFile } = await import("node:fs/promises");
-	const [regular, bold] = await Promise.all([
-		readFile(monoFontUrls.regular),
-		readFile(monoFontUrls.bold),
-	]);
-	return [
-		{ name: FONT_NAME, data: regular, weight: 400, style: "normal" },
-		{ name: FONT_NAME, data: bold, weight: 700, style: "normal" },
-	];
-}
+// The Node TTF loader (monoFontUrls / loadCardFonts) lives in ./fontsNode so
+// this module stays free of any `node:*` reference — it is imported by the card
+// tree and must bundle cleanly for the browser and the Cloudflare Worker.

--- a/ui/packages/components/src/Cards/SatoriPreviewCard/fontsNode.ts
+++ b/ui/packages/components/src/Cards/SatoriPreviewCard/fontsNode.ts
@@ -1,0 +1,26 @@
+// Node-only font loading for the Satori preview card. Kept in a separate module
+// from ./fonts (which the card tree imports) so that ./fonts stays free of any
+// `node:*` reference and bundles cleanly for the browser and Cloudflare Workers.
+// On Workers, bundle the TTF bytes at build time instead of calling this (see
+// @gcsim/workers src/preview/cardFonts.ts).
+
+import { FONT_NAME, type SatoriFont } from "./fonts";
+
+// URLs of the bundled TTF files, resolved relative to this module.
+export const monoFontUrls = {
+	regular: new URL("./fonts/DejaVuSansMono-Regular.ttf", import.meta.url),
+	bold: new URL("./fonts/DejaVuSansMono-Bold.ttf", import.meta.url),
+};
+
+// Node helper: read the bundled TTFs and return them as Satori font entries.
+export async function loadCardFonts(): Promise<SatoriFont[]> {
+	const { readFile } = await import("node:fs/promises");
+	const [regular, bold] = await Promise.all([
+		readFile(monoFontUrls.regular),
+		readFile(monoFontUrls.bold),
+	]);
+	return [
+		{ name: FONT_NAME, data: regular, weight: 400, style: "normal" },
+		{ name: FONT_NAME, data: bold, weight: 700, style: "normal" },
+	];
+}

--- a/ui/packages/components/src/Cards/SatoriPreviewCard/index.ts
+++ b/ui/packages/components/src/Cards/SatoriPreviewCard/index.ts
@@ -3,4 +3,5 @@
 // Cards/index.ts, which deliberately omits the Node font loader.)
 
 export * from "./fonts";
+export * from "./fontsNode";
 export * from "./SatoriPreviewCard";

--- a/ui/packages/components/src/Cards/index.ts
+++ b/ui/packages/components/src/Cards/index.ts
@@ -4,7 +4,7 @@ export { CardBadge } from "./CardBadge/CardBadge";
 export { DBCard } from "./DBCard/DBCard";
 export { PreviewCard } from "./PreviewCard";
 // Component-only surface (browser-safe). The Node font loader lives in
-// SatoriPreviewCard/fonts and is intentionally not re-exported here.
+// SatoriPreviewCard/fontsNode and is intentionally not re-exported here.
 export {
 	DEFAULT_ASSET_BASE,
 	SatoriPreviewCard,

--- a/ui/packages/workers/package.json
+++ b/ui/packages/workers/package.json
@@ -15,7 +15,11 @@
 	},
 	"dependencies": {
 		"@cfworker/json-schema": "^1.12.5",
+		"@gcsim/components": "workspace:^",
+		"@gcsim/types": "workspace:^",
 		"itty-router": "^5.0.24",
-		"pako": "^2.1.0"
+		"pako": "^2.1.0",
+		"react": "^18.2.0",
+		"workers-og": "^0.0.27"
 	}
 }

--- a/ui/packages/workers/src/index.ts
+++ b/ui/packages/workers/src/index.ts
@@ -2,7 +2,12 @@ import { Router } from "itty-router";
 import { handleAssets } from "./assets";
 import type { Env } from "./bindings";
 import { handleEnka } from "./enka";
-import { handleInjectHead, handleInjectHeadDB, handlePreview } from "./preview";
+import {
+	handleInjectHead,
+	handleInjectHeadDB,
+	handleOgPreview,
+	handlePreview,
+} from "./preview";
 import { proxyRequest } from "./proxy";
 import { handleLegacy, handleShare, handleView } from "./share";
 import { handleWasm } from "./wasm";
@@ -25,6 +30,10 @@ router.get("/api/share/db/:key", handleView);
 router.get("/api/legacy-share/:key", handleLegacy); //TODO: this endpoint should be deleted once we convert over to new
 router.get("/api/preview/:key", handlePreview);
 router.get("/api/preview/db/:key", handlePreview);
+// Satori-rendered preview (manual eyeballing / OG-embed testing); distinct from
+// the live OG path above, which is unchanged. See handleOgPreview.
+router.get("/api/og-preview/:key", handleOgPreview);
+router.get("/api/og-preview/db/:key", handleOgPreview);
 
 //enka
 router.get("/api/enka/:key", handleEnka);

--- a/ui/packages/workers/src/modules.d.ts
+++ b/ui/packages/workers/src/modules.d.ts
@@ -1,0 +1,6 @@
+// TTF files are bundled as raw bytes via the wrangler `Data` module rule
+// (see wrangler.jsonc); the default export is the file's ArrayBuffer.
+declare module "*.ttf" {
+	const data: ArrayBuffer;
+	export default data;
+}

--- a/ui/packages/workers/src/preview/cardFonts.ts
+++ b/ui/packages/workers/src/preview/cardFonts.ts
@@ -1,0 +1,18 @@
+import {
+	FONT_NAME,
+	type SatoriFont,
+} from "@gcsim/components/src/Cards/SatoriPreviewCard/fonts";
+// Bundle the TTF bytes at build time via the wrangler `Data` module rule for
+// `**/*.ttf` (see wrangler.jsonc); each import is the file's raw ArrayBuffer.
+// This is the Worker-side replacement for the components package's Node
+// `loadCardFonts()` (which uses `node:fs` and cannot run on a Worker).
+import boldFont from "@gcsim/components/src/Cards/SatoriPreviewCard/fonts/DejaVuSansMono-Bold.ttf";
+import regularFont from "@gcsim/components/src/Cards/SatoriPreviewCard/fonts/DejaVuSansMono-Regular.ttf";
+
+// Satori font entries for the card, in the `{ name, data, weight, style }`
+// shape the card's FONT_NAME / SatoriFont already define. Reuses FONT_NAME so
+// the family stays in sync with the card tree's `fontFamily`.
+export const cardFonts: SatoriFont[] = [
+	{ name: FONT_NAME, data: regularFont, weight: 400, style: "normal" },
+	{ name: FONT_NAME, data: boldFont, weight: 700, style: "normal" },
+];

--- a/ui/packages/workers/src/preview/handleOgPreview.tsx
+++ b/ui/packages/workers/src/preview/handleOgPreview.tsx
@@ -1,0 +1,72 @@
+import type { SatoriFont } from "@gcsim/components/src/Cards/SatoriPreviewCard/fonts";
+// Deep import (not the package root) so bundling pulls only the card subtree,
+// not the whole component library (which imports .png/.css assets).
+import { SatoriPreviewCard } from "@gcsim/components/src/Cards/SatoriPreviewCard/SatoriPreviewCard";
+import type { model } from "@gcsim/types";
+import type { IRequest } from "itty-router";
+import { ImageResponse } from "workers-og";
+import type { Env } from "../bindings";
+import { cardFonts } from "./cardFonts";
+
+// workers-og 0.0.27 derives its option type from @vercel/og, which it does not
+// depend on; the resulting `ImageResponseOptions` drops the `fonts` field satori
+// supports at runtime. Reconstruct a usable shape from the constructor and add
+// `fonts` back so the render is fully typed.
+type ImageResponseOptions = NonNullable<
+	ConstructorParameters<typeof ImageResponse>[1]
+> & { fonts?: SatoriFont[] };
+
+// Card geometry, matching SatoriPreviewCard's fixed layout and the live OG
+// dimensions (og:image:width/height in handleInjectHead).
+const CARD_W = 540;
+const CARD_H = 250;
+
+// Renders SatoriPreviewCard to PNG (or SVG for debugging) from a share/db key,
+// as a manual preview aid. Distinct from the live OG path (handlePreview /
+// /api/preview/*), which is left unchanged; cutting live OG over to this
+// renderer is a separate follow-up.
+export async function handleOgPreview(
+	request: IRequest,
+	env: Env,
+): Promise<Response> {
+	const { params } = request;
+	const key = params?.key;
+	if (!key) {
+		return new Response("missing key", { status: 400 });
+	}
+
+	// Match handleView's db-variant detection: /api/og-preview/db/:key resolves
+	// against the backend's /api/share/db/ path.
+	const dbStr = request.url.includes("/db/") ? "db/" : "";
+
+	// PNG is the default and only OG-valid output; ?format=svg is a browser-only
+	// debug aid (unfurlers ignore SVG).
+	const format =
+		new URL(request.url).searchParams.get("format") === "svg" ? "svg" : "png";
+
+	// Same data source as the live preview/share path: the backend share JSON.
+	const resp = await fetch(
+		new Request(env.API_ENDPOINT + "/api/share/" + dbStr + key),
+	);
+	if (!resp.ok) {
+		// Unknown/invalid key must be a 4xx, not a 500. Pass through the backend's
+		// 4xx (e.g. 404 not found); collapse any 5xx to 502 Bad Gateway.
+		const status = resp.status >= 400 && resp.status < 500 ? resp.status : 502;
+		return new Response("could not load share " + key, { status });
+	}
+
+	let result: model.SimulationResult;
+	try {
+		result = (await resp.json()) as model.SimulationResult;
+	} catch {
+		return new Response("invalid share data for " + key, { status: 400 });
+	}
+
+	const options: ImageResponseOptions = {
+		width: CARD_W,
+		height: CARD_H,
+		format,
+		fonts: cardFonts,
+	};
+	return new ImageResponse(<SatoriPreviewCard data={result} />, options);
+}

--- a/ui/packages/workers/src/preview/index.ts
+++ b/ui/packages/workers/src/preview/index.ts
@@ -1,2 +1,3 @@
 export * from "./handleInjectHead";
+export * from "./handleOgPreview";
 export * from "./handlePreview";

--- a/ui/packages/workers/wrangler.jsonc
+++ b/ui/packages/workers/wrangler.jsonc
@@ -2,6 +2,8 @@
 	"name": "gcsim-gateway",
 	"main": "src/index.ts",
 	"compatibility_date": "2026-09-12",
+	// Bundle the card's TTF bytes as raw ArrayBuffers (see preview/cardFonts.ts).
+	"rules": [{ "type": "Data", "globs": ["**/*.ttf"], "fallthrough": true }],
 	"assets": {
 		"directory": "../web/dist",
 		"binding": "ASSETS",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -341,7 +341,7 @@ importers:
         version: 6.0.0
       styled-components:
         specifier: ^6.0.2
-        version: 6.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwindcss:
         specifier: ^3.3.2
         version: 3.4.19
@@ -845,12 +845,24 @@ importers:
       '@cfworker/json-schema':
         specifier: ^1.12.5
         version: 1.12.8
+      '@gcsim/components':
+        specifier: workspace:^
+        version: link:../components
+      '@gcsim/types':
+        specifier: workspace:^
+        version: link:../types
       itty-router:
         specifier: ^5.0.24
         version: 5.0.24
       pako:
         specifier: ^2.1.0
         version: 2.2.0
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      workers-og:
+        specifier: ^0.0.27
+        version: 0.0.27
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250310.0
@@ -3800,6 +3812,10 @@ packages:
     resolution: {integrity: sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==}
     engines: {node: '>=14.0.0'}
 
+  '@resvg/resvg-wasm@2.4.0':
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -3949,6 +3965,11 @@ packages:
     resolution: {integrity: sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==}
     cpu: [x64]
     os: [win32]
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -4944,6 +4965,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -5068,6 +5093,9 @@ packages:
   camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
+
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -5384,17 +5412,31 @@ packages:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
     engines: {node: '>=12'}
 
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
   css-blank-pseudo@7.0.1:
     resolution: {integrity: sha512-jf+twWGDf6LDoXDUode+nc7ZlrqfaNphrBIBrcmeP3D8yw1uPaix1gCC8LUQUGQ6CycuK2opkbFFWFuq/a94ag==}
     engines: {node: '>=18'}
     peerDependencies:
       postcss: ^8.4
 
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
   css-declaration-sorter@7.4.0:
     resolution: {integrity: sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
+
+  css-gradient-parser@0.0.16:
+    resolution: {integrity: sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==}
+    engines: {node: '>=16'}
 
   css-has-pseudo@7.0.3:
     resolution: {integrity: sha512-oG+vKuGyqe/xvEMoxAQrhi7uY16deJR3i7wwhBerVrGQKSqUC5GiOVxTpM9F9B9hw0J+eKeOWLH7E9gZ1Dr5rA==}
@@ -5450,6 +5492,9 @@ packages:
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -5860,6 +5905,10 @@ packages:
   electron-to-chromium@1.5.426:
     resolution: {integrity: sha512-2Gcq6inCQs/AqfHP3f5ftCzk+pqeW2VlA1LgmPqEj2hfBO8HiZRspNYkD4HzFBe4u6lGqca4BspFr6Ix4Q400g==}
 
+  emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -6125,6 +6174,9 @@ packages:
   feed@4.2.2:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
     engines: {node: '>=0.4.0'}
+
+  fflate@0.7.5:
+    resolution: {integrity: sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g==}
 
   file-loader@6.2.0:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
@@ -6426,6 +6478,10 @@ packages:
 
   header-case@2.0.4:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
 
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
@@ -6859,6 +6915,9 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  just-camel-case@6.2.0:
+    resolution: {integrity: sha512-ICenRLXwkQYLk3UyvLQZ+uKuwFVJ3JHFYFn7F2782G2Mv2hW8WPePqgdhpnjGaqkYtSVWnyCESZhGXUmY3/bEg==}
+
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
@@ -6895,6 +6954,9 @@ packages:
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
+
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -7613,6 +7675,9 @@ packages:
     resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
     engines: {node: '>=14.16'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   pako@2.2.0:
     resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
 
@@ -7625,6 +7690,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -8789,6 +8857,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  satori@0.15.2:
+    resolution: {integrity: sha512-vu/49vdc8MzV5jUchs3TIRDCOkOvMc1iJ11MrZvhg9tE4ziKIEIBjBZvies6a9sfM2vQ2gc3dXeu6rCK7AztHA==}
+    engines: {node: '>=16'}
+
   sax@1.6.1:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
@@ -9049,6 +9121,9 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -9254,6 +9329,9 @@ packages:
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -9455,6 +9533,9 @@ packages:
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -9771,6 +9852,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workers-og@0.0.27:
+    resolution: {integrity: sha512-QvwptQ0twmouQHiITUi3kYxEPCLdueC/U4msQ2xMz2iktd+iseSs7zlREw3T1dAsPxPw73FQlw8cXFsfANZPlw==}
+
   wouter@2.12.1:
     resolution: {integrity: sha512-G7a6JMSLSNcu6o8gdOfIzqxuo8Qx1qs+9rpVnlurH69angsSFPZP5gESNuVNeJct/MGpQg191pDo4HUjTx7IIQ==}
     peerDependencies:
@@ -9877,6 +9961,9 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  yoga-wasm-web@0.3.3:
+    resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
 
   youch@3.2.3:
     resolution: {integrity: sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==}
@@ -13498,6 +13585,8 @@ snapshots:
 
   '@remix-run/router@1.23.4': {}
 
+  '@resvg/resvg-wasm@2.4.0': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/pluginutils@5.4.0(rollup@4.63.1)':
@@ -13582,6 +13671,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.63.1':
     optional: true
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.5
+      string.prototype.codepointat: 0.2.1
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -14749,6 +14843,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@0.0.8: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.11.22: {}
@@ -14898,6 +14994,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   camelcase@7.0.1: {}
+
+  camelize@1.0.1: {}
 
   caniuse-api@3.0.0:
     dependencies:
@@ -15220,14 +15318,22 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
+  css-background-parser@0.1.0: {}
+
   css-blank-pseudo@7.0.1(postcss@8.5.28):
     dependencies:
       postcss: 8.5.28
       postcss-selector-parser: 7.1.6
 
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
   css-declaration-sorter@7.4.0(postcss@8.5.28):
     dependencies:
       postcss: 8.5.28
+
+  css-gradient-parser@0.0.16: {}
 
   css-has-pseudo@7.0.3(postcss@8.5.28):
     dependencies:
@@ -15280,6 +15386,12 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   css-tree@2.2.1:
     dependencies:
@@ -15720,6 +15832,8 @@ snapshots:
 
   electron-to-chromium@1.5.426: {}
 
+  emoji-regex-xs@2.0.1: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -16088,6 +16202,8 @@ snapshots:
   feed@4.2.2:
     dependencies:
       xml-js: 1.6.11
+
+  fflate@0.7.5: {}
 
   file-loader@6.2.0(webpack@5.110.3(postcss@8.5.28)):
     dependencies:
@@ -16506,6 +16622,8 @@ snapshots:
       capital-case: 1.0.4
       tslib: 2.5.3
 
+  hex-rgb@4.3.0: {}
+
   hey-listen@1.0.8: {}
 
   history@4.10.1:
@@ -16920,6 +17038,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  just-camel-case@6.2.0: {}
+
   katex@0.16.47:
     dependencies:
       commander: 8.3.0
@@ -16953,6 +17073,11 @@ snapshots:
       type-check: 0.3.2
 
   lilconfig@3.1.3: {}
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lines-and-columns@1.2.4: {}
 
@@ -17979,6 +18104,8 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.8.5
 
+  pako@0.2.9: {}
+
   pako@2.2.0: {}
 
   papaparse@5.7.0: {}
@@ -17991,6 +18118,11 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
 
   parse-entities@4.0.2:
     dependencies:
@@ -19357,6 +19489,20 @@ snapshots:
     dependencies:
       commander: 2.20.3
 
+  satori@0.15.2:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.16
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-wasm-web: 0.3.3
+
   sax@1.6.1: {}
 
   scheduler@0.23.2:
@@ -19713,6 +19859,8 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string.prototype.codepointat@0.2.1: {}
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -19766,13 +19914,14 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-components@6.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@emotion/is-prop-valid': 1.4.0
       csstype: 3.2.3
       react: 18.3.1
       stylis: 4.3.6
     optionalDependencies:
+      css-to-react-native: 3.2.0
       react-dom: 18.3.1(react@18.3.1)
 
   stylehacks@6.1.1(postcss@8.5.28):
@@ -19906,6 +20055,8 @@ snapshots:
   throttle-debounce@2.3.0: {}
 
   thunky@1.1.0: {}
+
+  tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -20066,6 +20217,11 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unified@11.0.5:
     dependencies:
@@ -20434,6 +20590,13 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20250310.0
       '@cloudflare/workerd-windows-64': 1.20250310.0
 
+  workers-og@0.0.27:
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      just-camel-case: 6.2.0
+      satori: 0.15.2
+      yoga-wasm-web: 0.3.3
+
   wouter@2.12.1(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -20521,6 +20684,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@1.2.2: {}
+
+  yoga-wasm-web@0.3.3: {}
 
   youch@3.2.3:
     dependencies:


### PR DESCRIPTION
## New

- `GET /api/og-preview/:key` and `GET /api/og-preview/db/:key` — render the `SatoriPreviewCard` to a **540×250 PNG** from a share or db key, for manual preview / OG-embed eyeballing. Fetches the same backend share JSON the live preview path uses, renders `<SatoriPreviewCard data={result} />` through `workers-og`'s `ImageResponse`, and returns `image/png`.
  - `?format=svg` returns `image/svg+xml` as a browser-only debug aid; absent or any other value yields PNG.
  - Unknown/invalid key returns the backend's `4xx` (e.g. `404`), never a `500`.
  - Fonts render from DejaVu Sans Mono TTF bytes bundled into the Worker via a wrangler `Data` module rule — `node:fs` / `loadCardFonts()` is never invoked at Worker runtime.

## Changed

- Split the card's Node TTF loader (`monoFontUrls`, `loadCardFonts`) out of `SatoriPreviewCard/fonts.ts` into a new `fontsNode.ts`, so `fonts.ts` (imported by the card tree) carries no `node:*` reference and bundles cleanly for the browser and the Worker. `SatoriFont.data` is now typed `ArrayBuffer | Uint8Array` (no Node `Buffer` global). Public export surface is unchanged.

## Verified

Under `wrangler dev` against the live backend: valid share key → `200 image/png` (540×250 RGBA), db variant → `200 image/png`, invalid key → `404`, `?format=svg` → `200 image/svg+xml`. The rendered PNG matches the Storybook `SatoriPreviewCard` (portraits, metadata row, four charts).

## Notes

- The live OG path (`handlePreview` / `/api/preview/*`) and the injected `og:image` meta tag are untouched — `index.ts` only adds the two new routes. Cutting live OG over to this renderer is a separate follow-up, as the issue scopes it.
- `SatoriPreviewCard` is deep-imported from its source path (not the `@gcsim/components` root) so bundling pulls only the card subtree, not the whole component library (which imports `.png`/`.css` assets). The payload is typed directly as `model.SimulationResult`; `SatoriPreviewCardProps` (which the issue named) is not imported since the handler builds the props inline.
- The `/db/`-prefix + share-fetch snippet now appears in three handlers (`handleView`, `handlePreview`, `handleOgPreview`). Left un-deduplicated on purpose: unifying it would require editing the live-path handlers, which this issue requires to stay unchanged.

Closes #2827

🤖 Generated with [Claude Code](https://claude.com/claude-code)
